### PR TITLE
Android: open Google Play from updater when app was Play-installed

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/util/FileUtil.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/util/FileUtil.java
@@ -3,8 +3,10 @@ package eu.vcmi.vcmi.util;
 import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.OpenableColumns;
 import android.provider.DocumentsContract;
@@ -160,6 +162,37 @@ public class FileUtil
 		}
 
 		return fileName;
+	}
+
+	@Keep
+	@SuppressWarnings(Const.JNI_METHOD_SUPPRESS)
+	public static boolean isInstalledFromGooglePlay(Context context)
+	{
+		if (context == null)
+			return false;
+
+		try
+		{
+			final PackageManager packageManager = context.getPackageManager();
+			final String packageName = context.getPackageName();
+			String installer = null;
+
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+			{
+				installer = packageManager.getInstallSourceInfo(packageName).getInstallingPackageName();
+			}
+			else
+			{
+				installer = packageManager.getInstallerPackageName(packageName);
+			}
+
+			return "com.android.vending".equals(installer);
+		}
+		catch (Exception e)
+		{
+			Log.e("FileUtil", "isInstalledFromGooglePlay failed", e);
+			return false;
+		}
 	}
 
 

--- a/launcher/helper.cpp
+++ b/launcher/helper.cpp
@@ -373,4 +373,22 @@ void sendFileToApp(QString path)
 #endif
 }
 
+bool isInstalledFromGooglePlay()
+{
+#if defined(VCMI_ANDROID)
+	if(!QtAndroid::androidContext().isValid())
+		return false;
+
+	const jboolean installedFromGooglePlay = QAndroidJniObject::callStaticMethod<jboolean>(
+		"eu/vcmi/vcmi/util/FileUtil",
+		"isInstalledFromGooglePlay",
+		"(Landroid/content/Context;)Z",
+		QtAndroid::androidContext().object()
+	);
+	return installedFromGooglePlay;
+#else
+	return false;
+#endif
+}
+
 }

--- a/launcher/helper.h
+++ b/launcher/helper.h
@@ -28,4 +28,5 @@ namespace Helper
 	void nativeFolderPicker(QWidget *parent, std::function<void(QString)>&& cb);
 	QStringList findFilesForCopy(const QString &treeUri);
 	void sendFileToApp(QString path);
+	bool isInstalledFromGooglePlay();
 }

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -390,6 +390,18 @@ void UpdateDialog::on_installButton_clicked()
 	    return;
 	}
 
+	#if defined(VCMI_ANDROID)
+	if(Helper::isInstalledFromGooglePlay())
+	{
+		const QUrl playStoreUrl(QStringLiteral("market://details?id=is.xyz.vcmi"));
+		if(!QDesktopServices::openUrl(playStoreUrl))
+		{
+			QDesktopServices::openUrl(QUrl(QStringLiteral("https://play.google.com/store/apps/details?id=is.xyz.vcmi")));
+		}
+		return;
+	}
+	#endif
+
 	#if defined(VCMI_MOBILE)
 	    // Always ask user where to save on mobile
 	    Helper::nativeFolderPicker(this, [this, url](QString picked){


### PR DESCRIPTION
### Motivation
- Ensure the updater prefers the Play Store when the app was installed via Google Play so users get Play-managed updates instead of a manual download.
- Keep the existing download/install flow unchanged for non-Play installs to preserve current behavior.

### Description
- Added `FileUtil.isInstalledFromGooglePlay(Context)` in `android/vcmi-app/src/main/java/eu/vcmi/vcmi/util/FileUtil.java` which checks the installer package using `PackageManager.getInstallSourceInfo(...).getInstallingPackageName()` on newer Android and `getInstallerPackageName(...)` on older versions and returns `true` for `com.android.vending`.
- Exposed the check to C++ via `Helper::isInstalledFromGooglePlay()` (declared in `launcher/helper.h` and implemented in `launcher/helper.cpp`) which calls the new Java method through JNI.
- Updated `UpdateDialog::on_installButton_clicked()` in `launcher/updatedialog_moc.cpp` to, on Android, open the Play Store page (`market://details?id=is.xyz.vcmi`) with a fallback to the HTTPS URL (`https://play.google.com/store/apps/details?id=is.xyz.vcmi`) when `Helper::isInstalledFromGooglePlay()` returns `true`.

### Testing
- Ran `rg` searches to verify new symbols and Play Store URLs were referenced (`isInstalledFromGooglePlay`, `market://details?id=is.xyz.vcmi`, and the HTTPS fallback) and found the updated usages successfully.
- Ran `git diff --check` to verify there are no whitespace/style issues and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937b9f97b4832d9991b1de95112325)