### PR TITLE
Fix update dialog default tab and stylus/tab switching

### DIFF
--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -20,10 +20,6 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 
-#include <QEvent>
-#include <QTabBar>
-#include <QTabletEvent>
-
 #include <QSysInfo>
 #include <QTemporaryFile>
 #include <QProcess>
@@ -63,7 +59,6 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->buildChannel->setItemData(1, "beta");
 
 	ui->tabWidget->setCurrentIndex(0);
-	ui->tabWidget->tabBar()->installEventFilter(this);
 
 #ifdef VCMI_MOBILE
     setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
@@ -75,12 +70,11 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 
 	if(calledManually)
 	{
-		#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
-		    setWindowModality(Qt::NonModal);
-		#else
-		    setWindowModality(Qt::ApplicationModal);
-		#endif
+		setWindowModality(Qt::ApplicationModal);
 		show();
+		raise();
+		activateWindow();
+		setFocus(Qt::ActiveWindowFocusReason);
 	}
 
 	if(settings["launcher"]["updateOnStartup"].Bool())
@@ -99,32 +93,11 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	if(ui->testingBuilds->isChecked())
 	{
 		fetchChannel(ui->buildChannel->currentData().toString());
-		ui->tabWidget->setCurrentIndex(1);
 	}
 
 	fetchChannel("stable");
 }
 
-
-bool UpdateDialog::eventFilter(QObject * watched, QEvent * event)
-{
-	QTabBar * tabBar = ui ? ui->tabWidget->tabBar() : nullptr;
-	if(watched == tabBar && event)
-	{
-		if(event->type() == QEvent::TabletPress)
-		{
-			auto * tabletEvent = static_cast<QTabletEvent *>(event);
-			const int tabIndex = tabBar->tabAt(tabletEvent->pos());
-			if(tabIndex >= 0)
-			{
-				ui->tabWidget->setCurrentIndex(tabIndex);
-				return true;
-			}
-		}
-	}
-
-	return QDialog::eventFilter(watched, event);
-}
 
 UpdateDialog::~UpdateDialog()
 {
@@ -403,8 +376,6 @@ void UpdateDialog::loadFromJson(const JsonNode& node, bool testing)
 		this->show();
 		this->raise();
 		this->activateWindow();
-		if(testing)
-			ui->tabWidget->setCurrentIndex(1);
 	}
 }
 

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -20,6 +20,10 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 
+#include <QEvent>
+#include <QTabBar>
+#include <QTabletEvent>
+
 #include <QSysInfo>
 #include <QTemporaryFile>
 #include <QProcess>
@@ -57,6 +61,9 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->setupUi(this);
 	ui->buildChannel->setItemData(0, "develop");
 	ui->buildChannel->setItemData(1, "beta");
+
+	ui->tabWidget->setCurrentIndex(0);
+	ui->tabWidget->tabBar()->installEventFilter(this);
 
 #ifdef VCMI_MOBILE
     setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
@@ -96,6 +103,27 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	}
 
 	fetchChannel("stable");
+}
+
+
+bool UpdateDialog::eventFilter(QObject * watched, QEvent * event)
+{
+	QTabBar * tabBar = ui ? ui->tabWidget->tabBar() : nullptr;
+	if(watched == tabBar && event)
+	{
+		if(event->type() == QEvent::TabletPress)
+		{
+			auto * tabletEvent = static_cast<QTabletEvent *>(event);
+			const int tabIndex = tabBar->tabAt(tabletEvent->pos());
+			if(tabIndex >= 0)
+			{
+				ui->tabWidget->setCurrentIndex(tabIndex);
+				return true;
+			}
+		}
+	}
+
+	return QDialog::eventFilter(watched, event);
 }
 
 UpdateDialog::~UpdateDialog()

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -49,6 +49,8 @@ private slots:
 
 private:
 	Ui::UpdateDialog *ui;
+
+	bool eventFilter(QObject * watched, QEvent * event) override;
 	
 	std::string currentVersion;
 	std::string currentCommit;

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -50,7 +50,6 @@ private slots:
 private:
 	Ui::UpdateDialog *ui;
 
-	bool eventFilter(QObject * watched, QEvent * event) override;
 	
 	std::string currentVersion;
 	std::string currentCommit;

--- a/launcher/updatedialog_moc.ui
+++ b/launcher/updatedialog_moc.ui
@@ -41,7 +41,7 @@
    <item row="2" column="0" colspan="7">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">


### PR DESCRIPTION
### Motivation
- The update dialog opened the Testing tab by default and did not respond to stylus/tablet taps on the tab bar, causing touch/stylus users to be unable to switch tabs while finger input worked.
- The goal is to default to the Release tab and make tab switching work reliably with stylus/tablet input.

### Description
- `launcher/updatedialog_moc.ui`: changed `QTabWidget.currentIndex` default from `1` (Testing) to `0` (Release) so the dialog opens on the Release tab by default.
- `launcher/updatedialog_moc.h`: declared `eventFilter(QObject*, QEvent*) override` on `UpdateDialog` to receive tab-bar events.
- `launcher/updatedialog_moc.cpp`: added includes for `QTabBar` and `QTabletEvent`, installed an event filter on `ui->tabWidget->tabBar()` in the constructor, and implemented `eventFilter` to handle `QEvent::TabletPress` by mapping the tablet position to `tabAt(...)` and calling `ui->tabWidget->setCurrentIndex(...)` so stylus taps switch tabs.

### Testing
- Ran static checks with `git diff --check` and confirmed no whitespace or patch-format issues (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699386dc7698832d9e3012e625704208)