### PR TITLE
Use Qt auto-connected tab change slot in UpdateDialog

### DIFF
--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -121,9 +121,6 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	setWindowTitle(tr("VCMI Updates Center"));
 	ui->title->setText(tr("VCMI Updates Center"));
 
-	connect(ui->tabWidget, &QTabWidget::currentChanged, this, [this](int) {
-		updateAvailabilityNotice();
-	});
 
 	// Testing build info
 	if(ui->testingBuilds->isChecked())
@@ -145,6 +142,12 @@ void UpdateDialog::showUpdateDialog(bool isManually)
 {
 	auto * dialog = new UpdateDialog(isManually, Helper::getMainWindow());
 	dialog->setAttribute(Qt::WA_DeleteOnClose);
+}
+
+void UpdateDialog::on_tabWidget_currentChanged(int index)
+{
+	Q_UNUSED(index);
+	updateAvailabilityNotice();
 }
 
 void UpdateDialog::on_checkOnStartup_stateChanged(int state)

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -152,12 +152,14 @@ void UpdateDialog::on_tabWidget_currentChanged(int index)
 
 void UpdateDialog::on_checkOnStartup_stateChanged(int state)
 {
+	Q_UNUSED(state);
 	Settings node = settings.write["launcher"]["updateOnStartup"];
 	node->Bool() = ui->checkOnStartup->isChecked();
 }
 
 void UpdateDialog::on_testingBuilds_stateChanged(int state)
 {
+	Q_UNUSED(state);
 	bool testing = ui->testingBuilds->isChecked();
 
 	Settings node = settings.write["launcher"]["testingBuilds"];
@@ -460,8 +462,9 @@ void UpdateDialog::loadFromJson(const JsonNode& node, bool testing, const QStrin
 
 	if(testing)
 	{
-		TestingBuildState &targetState = normalizeChannel(channel) == "beta" ? betaState : developState;
-		targetState.channel = normalizeChannel(channel);
+		const QString normalizedChannel = normalizeChannel(channel);
+		TestingBuildState &targetState = normalizedChannel == "beta" ? betaState : developState;
+		targetState.channel = normalizedChannel;
 		targetState.version = QString::fromStdString(newVersion);
 		targetState.commit = QString::fromStdString(newCommit);
 		targetState.buildDate = QString::fromStdString(buildDate);
@@ -647,7 +650,7 @@ void UpdateDialog::startDownloadToCacheAndRun(const QUrl& url, const QString& ta
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     QNetworkReply* rep = networkManager.get(request);
 
-    QProgressBar* progress = this->findChild<QProgressBar*>("progressBar");
+    QProgressBar* progress = ui->progressBar;
     if(progress)
 	{
         progress->setVisible(true);

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -43,6 +43,7 @@ private slots:
     void on_testingBuilds_stateChanged(int state);
 
 	void on_buildChannel_currentIndexChanged(int index);
+	void on_tabWidget_currentChanged(int index);
 
 	void on_installButton_clicked();
 	void on_closeButton_clicked();


### PR DESCRIPTION
### Motivation
- Reduce explicit signal/slot boilerplate by replacing a manual `connect` lambda for `ui->tabWidget` with Qt's auto-connection naming convention while preserving existing behavior.

### Description
- Removed the explicit `connect(ui->tabWidget, &QTabWidget::currentChanged, ...)` from `UpdateDialog` constructor and added a `void on_tabWidget_currentChanged(int index)` slot declaration in `launcher/updatedialog_moc.h` and its implementation in `launcher/updatedialog_moc.cpp` that calls `updateAvailabilityNotice()`.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699434a3be80832d9a646c8a4c60c7df)