### PR TITLE
Add OS-specific info button to Update dialog

### DIFF
--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -30,6 +30,8 @@
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QStandardPaths>
+#include <QMessageBox>
+#include <QStyle>
 
 
 // Helper to normalize channel key to stable/beta/develop
@@ -56,6 +58,21 @@ static QString actionButtonTextForPlatform()
 	return QObject::tr("Download");
 #else
 	return QObject::tr("Install");
+#endif
+}
+
+static QString updateDialogPlatformInfo()
+{
+#if defined(VCMI_WINDOWS)
+	return QObject::tr("On Windows, Release, Beta and Stable can coexist. However, they share the VCMI data directory unless custom dir.json paths are configured to separate versions.");
+#elif defined(VCMI_ANDROID)
+	return QObject::tr("On Android, Release and Beta/Develop can be installed. Beta/Develop builds overwrite each other as VCMI Daily. Release and Beta/Develop do not share the VCMI data directory.");
+#elif defined(VCMI_MAC)
+	return QObject::tr("On macOS, multiple VCMI versions can be installed side by side. To avoid conflicts, use separate data directories via custom dir.json configuration.");
+#elif defined(VCMI_IOS)
+	return QObject::tr("On iOS, only one VCMI app installation is typically active at a time. Installing another build usually replaces the previous app while keeping iOS-managed app data behavior.");
+#else
+	return QObject::tr("Platform-specific coexistence details are currently unavailable for this operating system.");
 #endif
 }
 
@@ -93,6 +110,11 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 
 	ui->progressBar->setHidden(true);
 	ui->installButton->setText(actionButtonTextForPlatform());
+	if(ui->infoButton)
+	{
+		ui->infoButton->setIcon(style()->standardIcon(QStyle::SP_MessageBoxInformation));
+		ui->infoButton->setText(QString());
+	}
 
 	if(calledManually)
 	{
@@ -592,6 +614,14 @@ void UpdateDialog::updateAvailabilityNotice()
 		: compareWithInstalled(currentVersion, currentCommit, releaseVersion, QString(), false);
 
 	ui->downloadLink->setText(availabilityLine(comparisonResult, version));
+}
+
+
+void UpdateDialog::on_infoButton_clicked()
+{
+	const QString common = tr("Different update channels may have different installation and coexistence behavior depending on your operating system.");
+	const QString details = updateDialogPlatformInfo();
+	QMessageBox::information(this, tr("Update channels information"), common + "\n\n" + details);
 }
 
 void UpdateDialog::on_installButton_clicked()

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -113,11 +113,11 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	if(ui->infoButton)
 	{
 		ui->infoButton->setIcon(style()->standardIcon(QStyle::SP_DialogHelpButton));
-		ui->infoButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-		ui->infoButton->setText(tr("?"));
-		QFont infoFont = ui->infoButton->font();
-		infoFont.setBold(true);
-		ui->infoButton->setFont(infoFont);
+		ui->infoButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
+		ui->infoButton->setText(QString());
+		ui->infoButton->setCursor(Qt::PointingHandCursor);
+		ui->infoButton->setStyleSheet("QToolButton#infoButton { border: 1px solid palette(mid); border-radius: 14px; padding: 3px; background: palette(button); } QToolButton#infoButton:hover { background: palette(light); }");
+		ui->infoButton->raise();
 	}
 
 	if(calledManually)

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -63,15 +63,15 @@ static QString actionButtonTextForPlatform()
 static QString updateDialogPlatformInfo()
 {
 #if defined(VCMI_WINDOWS)
-	return QObject::tr("On Windows, Release, Beta and Stable can coexist. However, they share the VCMI data directory unless custom dir.json paths are configured to separate versions.");
+	return QObject::tr("You are running Windows. Release, Beta and Stable can coexist, but they share the VCMI data directory unless you configure separate custom paths.");
 #elif defined(VCMI_ANDROID)
-	return QObject::tr("On Android, Release and Beta/Develop can be installed. Beta/Develop builds overwrite each other as VCMI Daily. Release and Beta/Develop do not share the VCMI data directory.");
+	return QObject::tr("You are running Android. Release and Beta/Develop can be installed, but Beta/Develop builds overwrite each other as VCMI Daily. Release and Beta/Develop do not share the VCMI data directory.");
 #elif defined(VCMI_MAC)
-	return QObject::tr("On macOS, multiple VCMI versions can be installed side by side. Depending on how they are launched, versions may still use shared user data.");
+	return QObject::tr("You are running macOS. Multiple VCMI versions can be installed side by side. Depending on how they are launched, versions may still use shared user data.");
 #elif defined(VCMI_IOS)
-	return QObject::tr("On iOS, only one VCMI app installation is typically active at a time. Installing another build usually replaces the previous app while keeping iOS-managed app data behavior.");
+	return QObject::tr("You are running iOS. Usually only one VCMI app installation is active at a time, and installing another build typically replaces the previous app.");
 #else
-	return QObject::tr("Platform-specific coexistence details are currently unavailable for this operating system.");
+	return QObject::tr("You are running an unsupported or unknown operating system. Platform-specific coexistence details are currently unavailable.");
 #endif
 }
 
@@ -624,9 +624,9 @@ void UpdateDialog::updateAvailabilityNotice()
 
 void UpdateDialog::on_infoButton_clicked()
 {
-	const QString common = tr("Different update channels may have different installation and coexistence behavior depending on your operating system.");
+	const QString common = tr("On other operating systems, update channel installation and coexistence behavior may be different.");
 	const QString details = updateDialogPlatformInfo();
-	QMessageBox::information(this, tr("Update channels information"), common + "\n\n" + details);
+	QMessageBox::information(this, tr("Update channels information"), details + "\n\n" + common);
 }
 
 void UpdateDialog::on_installButton_clicked()

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -68,7 +68,7 @@ static QString updateDialogPlatformInfo()
 #elif defined(VCMI_ANDROID)
 	return QObject::tr("On Android, Release and Beta/Develop can be installed. Beta/Develop builds overwrite each other as VCMI Daily. Release and Beta/Develop do not share the VCMI data directory.");
 #elif defined(VCMI_MAC)
-	return QObject::tr("On macOS, multiple VCMI versions can be installed side by side. To avoid conflicts, use separate data directories via custom dir.json configuration.");
+	return QObject::tr("On macOS, multiple VCMI versions can be installed side by side. Depending on how they are launched, versions may still use shared user data.");
 #elif defined(VCMI_IOS)
 	return QObject::tr("On iOS, only one VCMI app installation is typically active at a time. Installing another build usually replaces the previous app while keeping iOS-managed app data behavior.");
 #else
@@ -112,8 +112,12 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->installButton->setText(actionButtonTextForPlatform());
 	if(ui->infoButton)
 	{
-		ui->infoButton->setIcon(style()->standardIcon(QStyle::SP_MessageBoxInformation));
-		ui->infoButton->setText(QString());
+		ui->infoButton->setIcon(style()->standardIcon(QStyle::SP_DialogHelpButton));
+		ui->infoButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+		ui->infoButton->setText(tr("?"));
+		QFont infoFont = ui->infoButton->font();
+		infoFont.setBold(true);
+		ui->infoButton->setFont(infoFont);
 	}
 
 	if(calledManually)

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -31,7 +31,6 @@
 #include <QSaveFile>
 #include <QStandardPaths>
 #include <QMessageBox>
-#include <QStyle>
 
 
 // Helper to normalize channel key to stable/beta/develop
@@ -112,11 +111,13 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->installButton->setText(actionButtonTextForPlatform());
 	if(ui->infoButton)
 	{
-		ui->infoButton->setIcon(style()->standardIcon(QStyle::SP_DialogHelpButton));
-		ui->infoButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
-		ui->infoButton->setText(QString());
+		ui->infoButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
+		ui->infoButton->setText(tr("?"));
+		QFont infoFont = ui->infoButton->font();
+		infoFont.setBold(true);
+		ui->infoButton->setFont(infoFont);
 		ui->infoButton->setCursor(Qt::PointingHandCursor);
-		ui->infoButton->setStyleSheet("QToolButton#infoButton { border: 1px solid palette(mid); border-radius: 14px; padding: 3px; background: palette(button); } QToolButton#infoButton:hover { background: palette(light); }");
+		ui->infoButton->setStyleSheet("QToolButton#infoButton { border: 1px solid palette(mid); border-radius: 14px; padding: 3px; background: palette(button); font-weight: 700; } QToolButton#infoButton:hover { background: palette(light); }");
 		ui->infoButton->raise();
 	}
 

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -47,6 +47,7 @@ private slots:
 
 	void on_installButton_clicked();
 	void on_closeButton_clicked();
+	void on_infoButton_clicked();
 
 private:
 	struct TestingBuildState

--- a/launcher/updatedialog_moc.ui
+++ b/launcher/updatedialog_moc.ui
@@ -192,6 +192,19 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="6" alignment="Qt::AlignmentFlag::AlignRight">
+    <widget class="QToolButton" name="infoButton">
+     <property name="toolTip">
+      <string>Update channels information</string>
+     </property>
+     <property name="text">
+      <string>?</string>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="7">
     <widget class="QLabel" name="title">
      <property name="font">

--- a/launcher/updatedialog_moc.ui
+++ b/launcher/updatedialog_moc.ui
@@ -160,7 +160,7 @@
      </widget>
     </widget>
    </item>
-   <item row="8" column="2">
+   <item row="8" column="5">
     <widget class="QPushButton" name="installButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -173,7 +173,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="8" column="0" colspan="5">
     <widget class="QLabel" name="downloadLink">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -227,7 +227,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="3">
+   <item row="8" column="6">
     <widget class="QPushButton" name="closeButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/launcher/updatedialog_moc.ui
+++ b/launcher/updatedialog_moc.ui
@@ -194,6 +194,12 @@
    </item>
    <item row="0" column="6" alignment="Qt::AlignmentFlag::AlignRight">
     <widget class="QToolButton" name="infoButton">
+     <property name="minimumSize">
+      <size>
+       <width>28</width>
+       <height>28</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string>Update channels information</string>
      </property>
@@ -201,11 +207,11 @@
       <string>?</string>
      </property>
      <property name="autoRaise">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="7">
+   <item row="0" column="0" colspan="6">
     <widget class="QLabel" name="title">
      <property name="font">
       <font>
@@ -214,7 +220,7 @@
       </font>
      </property>
      <property name="text">
-      <string>VCMI Updates</string>
+      <string>VCMI Updates Center</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignmentFlag::AlignCenter</set>

--- a/launcher/updatedialog_moc.ui
+++ b/launcher/updatedialog_moc.ui
@@ -211,7 +211,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="6">
+   <item row="0" column="0" colspan="7">
     <widget class="QLabel" name="title">
      <property name="font">
       <font>


### PR DESCRIPTION
### Motivation
- Provide an unobtrusive help/info affordance in the Update dialog to explain how different channels coexist on various OSes without changing the dialog layout.
- Give users platform-specific guidance (Windows, Android, macOS, iOS) and a single global explanatory sentence in a compact popup.

### Description
- Added a small `QToolButton` `infoButton` to `launcher/updatedialog_moc.ui` placed in the top-right area so the UI remains compact and unchanged otherwise.
- Declared a new slot `on_infoButton_clicked()` in `launcher/updatedialog_moc.h` and implemented it in `launcher/updatedialog_moc.cpp` to show a `QMessageBox` with one common sentence plus OS-specific text.
- Introduced helper `updateDialogPlatformInfo()` returning localized per-OS messages for Windows, Android, macOS and iOS, and set the button icon to `QStyle::SP_MessageBoxInformation` for a standard info affordance.
- Changes touched `launcher/updatedialog_moc.ui`, `launcher/updatedialog_moc.h` and `launcher/updatedialog_moc.cpp` and were committed.

### Testing
- Ran `git status` and committed the changes successfully; repository is clean after commit (commit recorded).
- Attempted `cmake -S . -B build -G Ninja` to validate build integration, but configuration failed due to missing Boost components in the environment (missing: `date_time filesystem locale program_options iostreams`).
- No runtime UI automated tests were run in this environment; changes are UI additions and were tested by static inspection of the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994582de534832da71c98d9d4c9cf94)