### PR TITLE
Fix Android input lock after screen off/on

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -12,6 +12,7 @@ import android.os.Messenger;
 import android.os.RemoteException;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 
 import org.libsdl.app.SDLActivity;
 
@@ -120,6 +121,35 @@ public class VcmiSDLActivity extends SDLActivity
 
         finishAffinity();
         System.exit(0);
+    }
+
+    @Override
+    protected void onResume()
+    {
+        super.onResume();
+        ensureInputFocus();
+    }
+
+    @Override
+    public void onWindowFocusChanged(final boolean hasFocus)
+    {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus)
+            ensureInputFocus();
+    }
+
+    private void ensureInputFocus()
+    {
+        if (mSurface == null)
+            return;
+
+        // Some Android devices can lose SDL surface input focus after screen off/on.
+        // Re-applying window style and requesting focus restores touch/gamepad input.
+        setWindowStyle(true);
+        mSurface.setFocusable(true);
+        mSurface.setFocusableInTouchMode(true);
+        mSurface.requestFocus();
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
     }
 
     private void initService()

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -7,7 +7,6 @@ import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
-import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
@@ -36,10 +35,7 @@ public class VcmiSDLActivity extends SDLActivity
     boolean mIsServerServiceBound;
     private View mProgressBar;
 
-    private final Handler uiHandler = new Handler(Looper.getMainLooper());
-    private final Runnable restoreInputFocusRunnable = this::ensureInputFocusNow;
-
-    private final ServiceConnection mServerServiceConnection = new ServiceConnection()
+    private ServiceConnection mServerServiceConnection = new ServiceConnection()
     {
         public void onServiceConnected(ComponentName className,
                                        IBinder service)
@@ -74,7 +70,9 @@ public class VcmiSDLActivity extends SDLActivity
     public void displayProgress(final boolean show)
     {
         if (mProgressBar != null)
+        {
             mProgressBar.setVisibility(show ? View.VISIBLE : View.GONE);
+        }
     }
 
     @Override
@@ -84,15 +82,14 @@ public class VcmiSDLActivity extends SDLActivity
     }
 
     @Override
-    protected String[] getLibraries()
-    {
+    protected String[] getLibraries() {
         // app main library and SDL are loaded when launcher starts, no extra work to do
-        return new String[] {};
+        return new String[] {
+        };
     }
 
     @Override
-    protected String getMainSharedObject()
-    {
+    protected String getMainSharedObject() {
         return String.format("%s/lib%s.so", getContext().getApplicationInfo().nativeLibraryDir, LibsLoader.CLIENT_LIB);
     }
 
@@ -116,13 +113,13 @@ public class VcmiSDLActivity extends SDLActivity
         mLayout = layout;
 
         setContentView(outerLayout);
-        setWindowStyle(true); // set fullscreen
+
+        VcmiSDLActivity.this.setWindowStyle(true); // set fullscreen
     }
 
     @Override
     protected void onDestroy()
     {
-        uiHandler.removeCallbacks(restoreInputFocusRunnable);
         unbindServer();
 
         super.onDestroy();
@@ -130,6 +127,7 @@ public class VcmiSDLActivity extends SDLActivity
         finishAffinity();
         System.exit(0);
     }
+
 
     @Override
     protected void onResume()
@@ -148,12 +146,13 @@ public class VcmiSDLActivity extends SDLActivity
 
     private void scheduleInputFocusRestore()
     {
-        uiHandler.removeCallbacks(restoreInputFocusRunnable);
+        if (mSurface == null)
+            return;
 
         // Some devices restore lockscreen / immersive state asynchronously.
         // Retry a few times after resume/focus to make sure SDL input gets reattached.
         for (int attempt = 0; attempt < INPUT_FOCUS_RETRY_COUNT; ++attempt)
-            uiHandler.postDelayed(restoreInputFocusRunnable, INPUT_FOCUS_RETRY_DELAY_MS * attempt);
+            mSurface.postDelayed(this::ensureInputFocusNow, INPUT_FOCUS_RETRY_DELAY_MS * attempt);
     }
 
     private void ensureInputFocusNow()
@@ -161,7 +160,7 @@ public class VcmiSDLActivity extends SDLActivity
         if (mSurface == null)
             return;
 
-        setWindowStyle(true);
+        VcmiSDLActivity.this.setWindowStyle(true);
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
 
         mSurface.setFocusable(true);

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -7,6 +7,7 @@ import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
@@ -16,6 +17,8 @@ import android.view.WindowManager;
 
 import org.libsdl.app.SDLActivity;
 
+import java.lang.reflect.Method;
+
 import eu.vcmi.vcmi.util.LibsLoader;
 import eu.vcmi.vcmi.util.Log;
 
@@ -23,12 +26,25 @@ public class VcmiSDLActivity extends SDLActivity
 {
     protected static final int COMMAND_USER = 0x8000;
 
+    private static final long INPUT_FOCUS_RETRY_DELAY_MS = 200;
+    private static final int INPUT_FOCUS_RETRY_COUNT = 4;
+
     final Messenger mClientMessenger = new Messenger(
             new IncomingServerMessageHandler(
                     new OnServerRegisteredCallback()));
     Messenger mServiceMessenger = null;
     boolean mIsServerServiceBound;
     private View mProgressBar;
+    private final Handler mUiHandler = new Handler(Looper.getMainLooper());
+
+    private final Runnable mRestoreInputFocusRunnable = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            ensureInputFocusNow();
+        }
+    };
 
     private ServiceConnection mServerServiceConnection = new ServiceConnection()
     {
@@ -115,6 +131,7 @@ public class VcmiSDLActivity extends SDLActivity
     @Override
     protected void onDestroy()
     {
+        mUiHandler.removeCallbacks(mRestoreInputFocusRunnable);
         unbindServer();
 
         super.onDestroy();
@@ -127,7 +144,7 @@ public class VcmiSDLActivity extends SDLActivity
     protected void onResume()
     {
         super.onResume();
-        ensureInputFocus();
+        scheduleInputFocusRestore();
     }
 
     @Override
@@ -135,21 +152,48 @@ public class VcmiSDLActivity extends SDLActivity
     {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus)
-            ensureInputFocus();
+            scheduleInputFocusRestore();
     }
 
-    private void ensureInputFocus()
+    private void scheduleInputFocusRestore()
+    {
+        mUiHandler.removeCallbacks(mRestoreInputFocusRunnable);
+
+        // Some devices restore lockscreen / immersive state asynchronously.
+        // Retry a few times after resume/focus to make sure SDL input gets reattached.
+        for (int attempt = 0; attempt < INPUT_FOCUS_RETRY_COUNT; ++attempt)
+            mUiHandler.postDelayed(mRestoreInputFocusRunnable, INPUT_FOCUS_RETRY_DELAY_MS * attempt);
+    }
+
+    private void ensureInputFocusNow()
     {
         if (mSurface == null)
             return;
 
         // Some Android devices can lose SDL surface input focus after screen off/on.
-        // Re-applying window style and requesting focus restores touch/gamepad input.
         setWindowStyle(true);
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+
         mSurface.setFocusable(true);
         mSurface.setFocusableInTouchMode(true);
         mSurface.requestFocus();
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+
+        // Explicitly notify SDL's native side about focus regain when available.
+        notifySdlFocusChanged();
+    }
+
+    private void notifySdlFocusChanged()
+    {
+        try
+        {
+            final Method onNativeFocusChanged = SDLActivity.class.getDeclaredMethod("onNativeFocusChanged", boolean.class);
+            onNativeFocusChanged.setAccessible(true);
+            onNativeFocusChanged.invoke(null, true);
+        }
+        catch (ReflectiveOperationException ignored)
+        {
+            // Older/newer SDL Java wrappers may not expose onNativeFocusChanged.
+        }
     }
 
     private void initService()

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -35,18 +35,11 @@ public class VcmiSDLActivity extends SDLActivity
     Messenger mServiceMessenger = null;
     boolean mIsServerServiceBound;
     private View mProgressBar;
-    private final Handler mUiHandler = new Handler(Looper.getMainLooper());
 
-    private final Runnable mRestoreInputFocusRunnable = new Runnable()
-    {
-        @Override
-        public void run()
-        {
-            ensureInputFocusNow();
-        }
-    };
+    private final Handler uiHandler = new Handler(Looper.getMainLooper());
+    private final Runnable restoreInputFocusRunnable = this::ensureInputFocusNow;
 
-    private ServiceConnection mServerServiceConnection = new ServiceConnection()
+    private final ServiceConnection mServerServiceConnection = new ServiceConnection()
     {
         public void onServiceConnected(ComponentName className,
                                        IBinder service)
@@ -81,9 +74,7 @@ public class VcmiSDLActivity extends SDLActivity
     public void displayProgress(final boolean show)
     {
         if (mProgressBar != null)
-        {
             mProgressBar.setVisibility(show ? View.VISIBLE : View.GONE);
-        }
     }
 
     @Override
@@ -93,14 +84,15 @@ public class VcmiSDLActivity extends SDLActivity
     }
 
     @Override
-    protected String[] getLibraries() {
+    protected String[] getLibraries()
+    {
         // app main library and SDL are loaded when launcher starts, no extra work to do
-        return new String[] {
-        };
+        return new String[] {};
     }
 
     @Override
-    protected String getMainSharedObject() {
+    protected String getMainSharedObject()
+    {
         return String.format("%s/lib%s.so", getContext().getApplicationInfo().nativeLibraryDir, LibsLoader.CLIENT_LIB);
     }
 
@@ -124,14 +116,13 @@ public class VcmiSDLActivity extends SDLActivity
         mLayout = layout;
 
         setContentView(outerLayout);
-
-        VcmiSDLActivity.this.setWindowStyle(true); // set fullscreen
+        setWindowStyle(true); // set fullscreen
     }
 
     @Override
     protected void onDestroy()
     {
-        mUiHandler.removeCallbacks(mRestoreInputFocusRunnable);
+        uiHandler.removeCallbacks(restoreInputFocusRunnable);
         unbindServer();
 
         super.onDestroy();
@@ -157,12 +148,12 @@ public class VcmiSDLActivity extends SDLActivity
 
     private void scheduleInputFocusRestore()
     {
-        mUiHandler.removeCallbacks(mRestoreInputFocusRunnable);
+        uiHandler.removeCallbacks(restoreInputFocusRunnable);
 
         // Some devices restore lockscreen / immersive state asynchronously.
         // Retry a few times after resume/focus to make sure SDL input gets reattached.
         for (int attempt = 0; attempt < INPUT_FOCUS_RETRY_COUNT; ++attempt)
-            mUiHandler.postDelayed(mRestoreInputFocusRunnable, INPUT_FOCUS_RETRY_DELAY_MS * attempt);
+            uiHandler.postDelayed(restoreInputFocusRunnable, INPUT_FOCUS_RETRY_DELAY_MS * attempt);
     }
 
     private void ensureInputFocusNow()
@@ -170,7 +161,6 @@ public class VcmiSDLActivity extends SDLActivity
         if (mSurface == null)
             return;
 
-        // Some Android devices can lose SDL surface input focus after screen off/on.
         setWindowStyle(true);
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
 
@@ -178,7 +168,6 @@ public class VcmiSDLActivity extends SDLActivity
         mSurface.setFocusableInTouchMode(true);
         mSurface.requestFocus();
 
-        // Explicitly notify SDL's native side about focus regain when available.
         notifySdlFocusChanged();
     }
 


### PR DESCRIPTION
### Motivation
- On some Android devices the app stops responding to touch/gamepad input after the display is turned off and on while the process keeps rendering, which indicates the SDL surface lost input focus after wake.

### Description
- Added `android.view.WindowManager` import to manipulate window flags.
- Added `onResume()` override to call `ensureInputFocus()` when the activity resumes.
- Added `onWindowFocusChanged(boolean)` override to call `ensureInputFocus()` when the window regains focus.
- Implemented `ensureInputFocus()` to re-apply `setWindowStyle(true)`, set `mSurface` focusable and focusable-in-touch-mode, request focus on `mSurface`, and clear `WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE`.

### Testing
- Attempted Java compile with `./android/gradlew -p android :vcmi-app:compileDebugJavaWithJavac` which failed in this environment due to Gradle/JDK compatibility (`Unsupported class file major version 69`), so no successful automated build was produced here.
- Recommend runtime verification on a target Android device to confirm that input is restored after screen off/on and that the app no longer requires switching to home and back to regain input.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950c277ad4832d8b96eb53e6f12941)