### PR TITLE
Add uninstall confirmation dialog with silent override

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1120,8 +1120,7 @@ void CModListView::installMods(QStringList archives)
 			if (modStateModel->isModEnabled(mod))
 				modsToEnable.push_back(mod);
 
-			manager->uninstallMod(mod);
-			reload(mod);
+			doUninstallMod(mod, true);
 		}
 		else
 		{
@@ -1407,15 +1406,28 @@ void CModListView::doInstallMod(const QString & modName)
 	}
 }
 
-void CModListView::doUninstallMod(const QString & modName)
+void CModListView::doUninstallMod(const QString & modName, bool silent)
 {
-	if(modStateModel->isModExists(modName) && modStateModel->getMod(modName).isInstalled())
+	if(!modStateModel->isModExists(modName) || !modStateModel->getMod(modName).isInstalled())
+		return;
+
+	if(!silent)
 	{
-		if(modStateModel->isModEnabled(modName))
-			manager->disableMod(modName);
-		manager->uninstallMod(modName);
-		reload(modName);
+		int result = QMessageBox::question(
+			this,
+			tr("Uninstall"),
+			tr("Are you sure you want to uninstall mod: %1").arg(modStateModel->getMod(modName).getName()),
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::No
+		);
+		if(result != QMessageBox::Yes)
+			return;
 	}
+
+	if(modStateModel->isModEnabled(modName))
+		manager->disableMod(modName);
+	manager->uninstallMod(modName);
+	reload(modName);
 }
 
 bool CModListView::isModAvailable(const QString & modName)

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -86,7 +86,7 @@ public:
 	void doInstallMod(const QString & modName);
 
 	/// uninstall mod by name
-	void doUninstallMod(const QString & modName);
+	void doUninstallMod(const QString & modName, bool silent = false);
 
 	/// update mod by name
 	void doUpdateMod(const QString & modName);


### PR DESCRIPTION
### Motivation

- Ensure UI-triggered uninstall prompts the user for confirmation while allowing automated flows to uninstall without interrupts.

### Description

- Added a `silent` parameter (`bool silent = false`) to `CModListView::doUninstallMod` in the header to allow silent/unattended uninstalls.
- Implemented a confirmation dialog using `QMessageBox::question` that shows `tr("Are you sure you want to uninstall mod: %1")` when `silent` is `false` and cancels on `No`.
- Replaced direct uninstall calls in the install/reinstall flow with `doUninstallMod(mod, true)` to skip the confirmation during automated replacement.
- Added early-exit checks and preserved the existing disable/uninstall/reload sequence after confirmation.

### Testing

- Ran codebase searches with `rg` to verify updated call sites and presence of the new confirmation text, and the checks succeeded.
- Inspected the source diff to confirm the header and implementation changes and that the install flow now calls `doUninstallMod(mod, true)`, and the inspection succeeded.
- No full build or runtime tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995abef05e4832d9bc79c16ef93d740)