### PR TITLE
Add left/right navigation controls to launcher screenshot viewer

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1380,6 +1380,7 @@ void CModListView::loadScreenshots()
 			// managed to load cached image
 			QIcon icon(pixmap);
 			auto * item = new QListWidgetItem(icon, QString(tr("Screenshot %1")).arg(ui->screenshotsList->count() + 1));
+			item->setData(Qt::UserRole, fullPath);
 			ui->screenshotsList->addItem(item);
 		}
 	}
@@ -1389,9 +1390,17 @@ void CModListView::on_screenshotsList_clicked(const QModelIndex & index)
 {
 	if(index.isValid())
 	{
-		QIcon icon = ui->screenshotsList->item(index.row())->icon();
-		auto pixmap = icon.pixmap(icon.availableSizes()[0]);
-		ImageViewer::showPixmap(pixmap, this);
+		QStringList imagePaths;
+		for(int i = 0; i < ui->screenshotsList->count(); ++i)
+		{
+			auto * item = ui->screenshotsList->item(i);
+			const auto path = item->data(Qt::UserRole).toString();
+			if(!path.isEmpty())
+				imagePaths.push_back(path);
+		}
+
+		if(!imagePaths.empty())
+			ImageViewer::showImages(imagePaths, index.row(), this);
 	}
 }
 

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -18,6 +18,31 @@
 #include "imageviewer_moc.h"
 #include "ui_imageviewer_moc.h"
 
+namespace
+{
+int touchEventX(const QTouchEvent * touchEvent)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	if(touchEvent->points().empty())
+		return 0;
+	return static_cast<int>(touchEvent->points().first().position().x());
+#else
+	if(touchEvent->touchPoints().empty())
+		return 0;
+	return static_cast<int>(touchEvent->touchPoints().first().pos().x());
+#endif
+}
+
+int mouseEventX(const QMouseEvent * mouseEvent)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	return static_cast<int>(mouseEvent->position().x());
+#else
+	return static_cast<int>(mouseEvent->localPos().x());
+#endif
+}
+}
+
 ImageViewer::ImageViewer(QWidget * parent)
 	: QDialog(parent), ui(new Ui::ImageViewer)
 {
@@ -70,19 +95,15 @@ bool ImageViewer::event(QEvent * event)
 	if(event->type() == QEvent::TouchBegin)
 	{
 		auto * touchEvent = static_cast<QTouchEvent *>(event);
-		if(!touchEvent->points().empty())
-			touchStartX = static_cast<int>(touchEvent->points().first().position().x());
+		touchStartX = touchEventX(touchEvent);
 		return true;
 	}
 
 	if(event->type() == QEvent::TouchEnd)
 	{
 		auto * touchEvent = static_cast<QTouchEvent *>(event);
-		if(!touchEvent->points().empty())
-		{
-			const int touchEndX = static_cast<int>(touchEvent->points().first().position().x());
-			handleSwipeDelta(touchEndX - touchStartX);
-		}
+		const int touchEndX = touchEventX(touchEvent);
+		handleSwipeDelta(touchEndX - touchStartX);
 		return true;
 	}
 
@@ -190,13 +211,13 @@ void ImageViewer::resizeEvent(QResizeEvent * event)
 
 void ImageViewer::mousePressEvent(QMouseEvent * event)
 {
-	mouseStartX = static_cast<int>(event->position().x());
+	mouseStartX = mouseEventX(event);
 	QDialog::mousePressEvent(event);
 }
 
 void ImageViewer::mouseReleaseEvent(QMouseEvent * event)
 {
-	const int mouseEndX = static_cast<int>(event->position().x());
+	const int mouseEndX = mouseEventX(event);
 	handleSwipeDelta(mouseEndX - mouseStartX);
 	QDialog::mouseReleaseEvent(event);
 }

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -80,21 +80,6 @@ ImageViewer::ImageViewer(QWidget * parent)
 	connect(ui->buttonNext, &QPushButton::clicked, this, &ImageViewer::showNextImage);
 	connect(ui->buttonClose, &QPushButton::clicked, this, &ImageViewer::close);
 
-#ifdef VCMI_MOBILE
-	auto * layout = ui->gridLayout;
-	layout->removeWidget(ui->buttonPrevious);
-	layout->removeWidget(ui->buttonNext);
-	layout->removeWidget(ui->buttonClose);
-	layout->removeWidget(ui->label);
-	layout->addWidget(ui->label, 0, 0, 3, 3);
-
-	ui->buttonPrevious->setParent(this);
-	ui->buttonNext->setParent(this);
-	ui->buttonClose->setParent(this);
-	ui->buttonPrevious->raise();
-	ui->buttonNext->raise();
-	ui->buttonClose->raise();
-#endif
 }
 
 void ImageViewer::changeEvent(QEvent *event)
@@ -225,7 +210,6 @@ void ImageViewer::showCurrentImage()
 	ui->buttonNext->setVisible(images.size() > 1);
 	#ifdef VCMI_MOBILE
 	ui->buttonClose->setVisible(true);
-	updateMobileButtonsGeometry();
 	#else
 	ui->buttonClose->setVisible(false);
 	#endif
@@ -292,21 +276,8 @@ void ImageViewer::resizeEvent(QResizeEvent * event)
 {
 	QDialog::resizeEvent(event);
 	updateDisplayedPixmap();
-	updateMobileButtonsGeometry();
 }
 
-void ImageViewer::updateMobileButtonsGeometry()
-{
-#ifdef VCMI_MOBILE
-	constexpr int margin = 12;
-	const int buttonSize = ui->buttonPrevious->width();
-	const int middleY = (height() - buttonSize) / 2;
-
-	ui->buttonPrevious->move(margin, middleY);
-	ui->buttonNext->move(width() - buttonSize - margin, middleY);
-	ui->buttonClose->move(width() - buttonSize - margin, margin);
-#endif
-}
 
 void ImageViewer::mousePressEvent(QMouseEvent * event)
 {

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -21,6 +21,15 @@
 
 namespace
 {
+int touchPointsCount(const QTouchEvent * touchEvent)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	return static_cast<int>(touchEvent->points().size());
+#else
+	return touchEvent->touchPoints().size();
+#endif
+}
+
 int touchEventX(const QTouchEvent * touchEvent)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -98,6 +107,11 @@ bool ImageViewer::event(QEvent * event)
 		auto * gestureEvent = static_cast<QGestureEvent *>(event);
 		if(auto * pinch = static_cast<QPinchGesture *>(gestureEvent->gesture(Qt::PinchGesture)))
 		{
+			if(pinch->state() == Qt::GestureStarted || pinch->state() == Qt::GestureUpdated)
+			{
+				suppressTouchSwipe = true;
+				touchSwipeActive = false;
+			}
 			if(pinch->state() == Qt::GestureUpdated)
 				applyZoomStep(pinch->scaleFactor());
 			return true;
@@ -119,6 +133,13 @@ bool ImageViewer::event(QEvent * event)
 	if(event->type() == QEvent::TouchBegin)
 	{
 		auto * touchEvent = static_cast<QTouchEvent *>(event);
+		if(touchPointsCount(touchEvent) > 1)
+		{
+			suppressTouchSwipe = true;
+			touchSwipeActive = false;
+			return true;
+		}
+
 		const auto pos = touchEventPos(touchEvent);
 		if(pos.isNull())
 			return QDialog::event(event);
@@ -135,6 +156,13 @@ bool ImageViewer::event(QEvent * event)
 	if(event->type() == QEvent::TouchEnd)
 	{
 		auto * touchEvent = static_cast<QTouchEvent *>(event);
+		if(suppressTouchSwipe)
+		{
+			suppressTouchSwipe = false;
+			touchSwipeActive = false;
+			return true;
+		}
+
 		if(!touchSwipeActive)
 			return QDialog::event(event);
 

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -18,6 +18,9 @@ ImageViewer::ImageViewer(QWidget * parent)
 	: QDialog(parent), ui(new Ui::ImageViewer)
 {
 	ui->setupUi(this);
+
+	connect(ui->buttonPrevious, &QPushButton::clicked, this, &ImageViewer::showPreviousImage);
+	connect(ui->buttonNext, &QPushButton::clicked, this, &ImageViewer::showNextImage);
 }
 
 void ImageViewer::changeEvent(QEvent *event)
@@ -39,33 +42,76 @@ QSize ImageViewer::calculateWindowSize()
 	return QGuiApplication::primaryScreen()->availableGeometry().size() * 0.8;
 }
 
-void ImageViewer::showPixmap(QPixmap & pixmap, QWidget * parent)
+void ImageViewer::showImages(const QStringList & imagePaths, int startIndex, QWidget * parent)
 {
-	assert(!pixmap.isNull());
+	if(imagePaths.empty())
+		return;
 
 	auto * iw = new ImageViewer(parent);
-
-	QSize size = pixmap.size();
-	size.scale(iw->calculateWindowSize(), Qt::KeepAspectRatio);
-	iw->resize(size);
-
-	iw->setPixmap(pixmap);
+	iw->setImages(imagePaths, startIndex);
 	iw->setAttribute(Qt::WA_DeleteOnClose, true);
 	iw->setModal(Qt::WindowModal);
 	iw->show();
 }
 
-void ImageViewer::setPixmap(QPixmap & pixmap)
+void ImageViewer::setImages(const QStringList & imagePaths, int startIndex)
 {
-	ui->label->setPixmap(pixmap);
+	assert(!imagePaths.empty());
+
+	images = imagePaths;
+	currentImageIndex = std::clamp(startIndex, 0, images.size() - 1);
+	showCurrentImage();
 }
 
-void ImageViewer::mousePressEvent(QMouseEvent * event)
+void ImageViewer::showCurrentImage()
 {
-	close();
+	assert(!images.empty());
+
+	QPixmap pixmap(images.at(currentImageIndex));
+	assert(!pixmap.isNull());
+
+	QSize size = pixmap.size();
+	size.scale(calculateWindowSize(), Qt::KeepAspectRatio);
+	resize(size);
+
+	ui->label->setPixmap(pixmap);
+	ui->buttonPrevious->setVisible(images.size() > 1);
+	ui->buttonNext->setVisible(images.size() > 1);
+}
+
+void ImageViewer::showPreviousImage()
+{
+	if(images.size() <= 1)
+		return;
+
+	currentImageIndex = (currentImageIndex - 1 + images.size()) % images.size();
+	showCurrentImage();
+}
+
+void ImageViewer::showNextImage()
+{
+	if(images.size() <= 1)
+		return;
+
+	currentImageIndex = (currentImageIndex + 1) % images.size();
+	showCurrentImage();
 }
 
 void ImageViewer::keyPressEvent(QKeyEvent * event)
 {
-	close(); // FIXME: it also closes on pressing modifiers (e.g. Ctrl/Alt). Not exactly expected
+	switch(event->key())
+	{
+	case Qt::Key_Left:
+		showPreviousImage();
+		break;
+	case Qt::Key_Right:
+		showNextImage();
+		break;
+	case Qt::Key_Escape:
+		close();
+		break;
+	default:
+		QDialog::keyPressEvent(event);
+		break;
+	}
 }

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -11,6 +11,7 @@
 
 #include <QGuiApplication>
 #include <QGestureEvent>
+#include <QPinchGesture>
 #include <QShortcut>
 #include <QSwipeGesture>
 #include <QTouchEvent>
@@ -33,6 +34,19 @@ int touchEventX(const QTouchEvent * touchEvent)
 #endif
 }
 
+QPointF touchEventPos(const QTouchEvent * touchEvent)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	if(touchEvent->points().empty())
+		return QPointF{};
+	return touchEvent->points().first().position();
+#else
+	if(touchEvent->touchPoints().empty())
+		return QPointF{};
+	return touchEvent->touchPoints().first().pos();
+#endif
+}
+
 int mouseEventX(const QMouseEvent * mouseEvent)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -52,6 +66,7 @@ ImageViewer::ImageViewer(QWidget * parent)
 	setAttribute(Qt::WA_AcceptTouchEvents, true);
 	ui->label->setAttribute(Qt::WA_AcceptTouchEvents, true);
 	grabGesture(Qt::SwipeGesture);
+	grabGesture(Qt::PinchGesture);
 
 	shortcutPrevious = new QShortcut(QKeySequence(Qt::Key_Left), this);
 	shortcutNext = new QShortcut(QKeySequence(Qt::Key_Right), this);
@@ -63,6 +78,7 @@ ImageViewer::ImageViewer(QWidget * parent)
 
 	connect(ui->buttonPrevious, &QPushButton::clicked, this, &ImageViewer::showPreviousImage);
 	connect(ui->buttonNext, &QPushButton::clicked, this, &ImageViewer::showNextImage);
+	connect(ui->buttonClose, &QPushButton::clicked, this, &ImageViewer::close);
 }
 
 void ImageViewer::changeEvent(QEvent *event)
@@ -79,6 +95,13 @@ bool ImageViewer::event(QEvent * event)
 	if(event->type() == QEvent::Gesture)
 	{
 		auto * gestureEvent = static_cast<QGestureEvent *>(event);
+		if(auto * pinch = static_cast<QPinchGesture *>(gestureEvent->gesture(Qt::PinchGesture)))
+		{
+			if(pinch->state() == Qt::GestureUpdated)
+				applyZoomStep(pinch->scaleFactor());
+			return true;
+		}
+
 		if(auto * swipe = static_cast<QSwipeGesture *>(gestureEvent->gesture(Qt::SwipeGesture)))
 		{
 			if(swipe->state() == Qt::GestureFinished)
@@ -95,15 +118,28 @@ bool ImageViewer::event(QEvent * event)
 	if(event->type() == QEvent::TouchBegin)
 	{
 		auto * touchEvent = static_cast<QTouchEvent *>(event);
-		touchStartX = touchEventX(touchEvent);
+		const auto pos = touchEventPos(touchEvent);
+		if(pos.isNull())
+			return QDialog::event(event);
+
+		auto * touched = childAt(pos.toPoint());
+		if(touched == ui->buttonPrevious || touched == ui->buttonNext || touched == ui->buttonClose)
+			return QDialog::event(event);
+
+		touchStartX = static_cast<int>(pos.x());
+		touchSwipeActive = true;
 		return true;
 	}
 
 	if(event->type() == QEvent::TouchEnd)
 	{
 		auto * touchEvent = static_cast<QTouchEvent *>(event);
+		if(!touchSwipeActive)
+			return QDialog::event(event);
+
 		const int touchEndX = touchEventX(touchEvent);
 		handleSwipeDelta(touchEndX - touchStartX);
+		touchSwipeActive = false;
 		return true;
 	}
 
@@ -117,7 +153,11 @@ ImageViewer::~ImageViewer()
 
 QSize ImageViewer::calculateWindowSize()
 {
+#ifdef VCMI_MOBILE
+	return QGuiApplication::primaryScreen()->availableGeometry().size();
+#else
 	return QGuiApplication::primaryScreen()->availableGeometry().size() * 0.8;
+#endif
 }
 
 void ImageViewer::showImages(const QStringList & imagePaths, int startIndex, QWidget * parent)
@@ -129,7 +169,11 @@ void ImageViewer::showImages(const QStringList & imagePaths, int startIndex, QWi
 	iw->setImages(imagePaths, startIndex);
 	iw->setAttribute(Qt::WA_DeleteOnClose, true);
 	iw->setModal(Qt::WindowModal);
+#ifdef VCMI_MOBILE
+	iw->showFullScreen();
+#else
 	iw->show();
+#endif
 	iw->setFocus();
 }
 
@@ -152,6 +196,7 @@ void ImageViewer::showCurrentImage()
 		return;
 
 	currentPixmap = pixmap;
+	zoomFactor = 1.0;
 
 	QSize windowSize = currentPixmap.size();
 	windowSize.scale(calculateWindowSize(), Qt::KeepAspectRatio);
@@ -160,6 +205,11 @@ void ImageViewer::showCurrentImage()
 
 	ui->buttonPrevious->setVisible(images.size() > 1);
 	ui->buttonNext->setVisible(images.size() > 1);
+	#ifdef VCMI_MOBILE
+	ui->buttonClose->setVisible(true);
+	#else
+	ui->buttonClose->setVisible(false);
+	#endif
 }
 
 void ImageViewer::showPreviousImage()
@@ -189,8 +239,21 @@ void ImageViewer::updateDisplayedPixmap()
 	if(labelSize.isEmpty())
 		return;
 
-	const auto scaledPixmap = currentPixmap.scaled(labelSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	QSize targetSize = labelSize * zoomFactor;
+	targetSize = targetSize.boundedTo(calculateWindowSize() * 2);
+
+	const auto scaledPixmap = currentPixmap.scaled(targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	ui->label->setPixmap(scaledPixmap);
+}
+
+void ImageViewer::applyZoomStep(qreal zoomStep)
+{
+	if(zoomStep <= 0.0)
+		return;
+
+	zoomFactor *= zoomStep;
+	zoomFactor = std::clamp(zoomFactor, 0.5, 3.0);
+	updateDisplayedPixmap();
 }
 
 void ImageViewer::handleSwipeDelta(int deltaX)

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -10,6 +10,10 @@
 #include "StdInc.h"
 
 #include <QGuiApplication>
+#include <QGestureEvent>
+#include <QShortcut>
+#include <QSwipeGesture>
+#include <QTouchEvent>
 
 #include "imageviewer_moc.h"
 #include "ui_imageviewer_moc.h"
@@ -18,6 +22,19 @@ ImageViewer::ImageViewer(QWidget * parent)
 	: QDialog(parent), ui(new Ui::ImageViewer)
 {
 	ui->setupUi(this);
+
+	setFocusPolicy(Qt::StrongFocus);
+	setAttribute(Qt::WA_AcceptTouchEvents, true);
+	ui->label->setAttribute(Qt::WA_AcceptTouchEvents, true);
+	grabGesture(Qt::SwipeGesture);
+
+	shortcutPrevious = new QShortcut(QKeySequence(Qt::Key_Left), this);
+	shortcutNext = new QShortcut(QKeySequence(Qt::Key_Right), this);
+	shortcutClose = new QShortcut(QKeySequence(Qt::Key_Escape), this);
+
+	connect(shortcutPrevious, &QShortcut::activated, this, &ImageViewer::showPreviousImage);
+	connect(shortcutNext, &QShortcut::activated, this, &ImageViewer::showNextImage);
+	connect(shortcutClose, &QShortcut::activated, this, &ImageViewer::close);
 
 	connect(ui->buttonPrevious, &QPushButton::clicked, this, &ImageViewer::showPreviousImage);
 	connect(ui->buttonNext, &QPushButton::clicked, this, &ImageViewer::showNextImage);
@@ -30,6 +47,46 @@ void ImageViewer::changeEvent(QEvent *event)
 		ui->retranslateUi(this);
 	}
 	QDialog::changeEvent(event);
+}
+
+bool ImageViewer::event(QEvent * event)
+{
+	if(event->type() == QEvent::Gesture)
+	{
+		auto * gestureEvent = static_cast<QGestureEvent *>(event);
+		if(auto * swipe = static_cast<QSwipeGesture *>(gestureEvent->gesture(Qt::SwipeGesture)))
+		{
+			if(swipe->state() == Qt::GestureFinished)
+			{
+				if(swipe->horizontalDirection() == QSwipeGesture::Left)
+					showNextImage();
+				else if(swipe->horizontalDirection() == QSwipeGesture::Right)
+					showPreviousImage();
+			}
+			return true;
+		}
+	}
+
+	if(event->type() == QEvent::TouchBegin)
+	{
+		auto * touchEvent = static_cast<QTouchEvent *>(event);
+		if(!touchEvent->points().empty())
+			touchStartX = static_cast<int>(touchEvent->points().first().position().x());
+		return true;
+	}
+
+	if(event->type() == QEvent::TouchEnd)
+	{
+		auto * touchEvent = static_cast<QTouchEvent *>(event);
+		if(!touchEvent->points().empty())
+		{
+			const int touchEndX = static_cast<int>(touchEvent->points().first().position().x());
+			handleSwipeDelta(touchEndX - touchStartX);
+		}
+		return true;
+	}
+
+	return QDialog::event(event);
 }
 
 ImageViewer::~ImageViewer()
@@ -52,6 +109,7 @@ void ImageViewer::showImages(const QStringList & imagePaths, int startIndex, QWi
 	iw->setAttribute(Qt::WA_DeleteOnClose, true);
 	iw->setModal(Qt::WindowModal);
 	iw->show();
+	iw->setFocus();
 }
 
 void ImageViewer::setImages(const QStringList & imagePaths, int startIndex)
@@ -69,13 +127,16 @@ void ImageViewer::showCurrentImage()
 	assert(!images.empty());
 
 	QPixmap pixmap(images.at(currentImageIndex));
-	assert(!pixmap.isNull());
+	if(pixmap.isNull())
+		return;
 
-	QSize size = pixmap.size();
-	size.scale(calculateWindowSize(), Qt::KeepAspectRatio);
-	resize(size);
+	currentPixmap = pixmap;
 
-	ui->label->setPixmap(pixmap);
+	QSize windowSize = currentPixmap.size();
+	windowSize.scale(calculateWindowSize(), Qt::KeepAspectRatio);
+	resize(windowSize);
+	updateDisplayedPixmap();
+
 	ui->buttonPrevious->setVisible(images.size() > 1);
 	ui->buttonNext->setVisible(images.size() > 1);
 }
@@ -98,18 +159,63 @@ void ImageViewer::showNextImage()
 	showCurrentImage();
 }
 
+void ImageViewer::updateDisplayedPixmap()
+{
+	if(currentPixmap.isNull())
+		return;
+
+	const QSize labelSize = ui->label->size();
+	if(labelSize.isEmpty())
+		return;
+
+	const auto scaledPixmap = currentPixmap.scaled(labelSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	ui->label->setPixmap(scaledPixmap);
+}
+
+void ImageViewer::handleSwipeDelta(int deltaX)
+{
+	constexpr int swipeThreshold = 40;
+	if(deltaX > swipeThreshold)
+		showPreviousImage();
+	else if(deltaX < -swipeThreshold)
+		showNextImage();
+}
+
+void ImageViewer::resizeEvent(QResizeEvent * event)
+{
+	QDialog::resizeEvent(event);
+	updateDisplayedPixmap();
+}
+
+
+void ImageViewer::mousePressEvent(QMouseEvent * event)
+{
+	mouseStartX = static_cast<int>(event->position().x());
+	QDialog::mousePressEvent(event);
+}
+
+void ImageViewer::mouseReleaseEvent(QMouseEvent * event)
+{
+	const int mouseEndX = static_cast<int>(event->position().x());
+	handleSwipeDelta(mouseEndX - mouseStartX);
+	QDialog::mouseReleaseEvent(event);
+}
+
 void ImageViewer::keyPressEvent(QKeyEvent * event)
 {
 	switch(event->key())
 	{
 	case Qt::Key_Left:
 		showPreviousImage();
+		event->accept();
 		break;
 	case Qt::Key_Right:
 		showNextImage();
+		event->accept();
 		break;
 	case Qt::Key_Escape:
 		close();
+		event->accept();
 		break;
 	default:
 		QDialog::keyPressEvent(event);

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -59,7 +59,8 @@ void ImageViewer::setImages(const QStringList & imagePaths, int startIndex)
 	assert(!imagePaths.empty());
 
 	images = imagePaths;
-	currentImageIndex = std::clamp(startIndex, 0, images.size() - 1);
+	const int lastImageIndex = static_cast<int>(images.size() - 1);
+	currentImageIndex = std::clamp(startIndex, 0, lastImageIndex);
 	showCurrentImage();
 }
 

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -198,9 +198,11 @@ void ImageViewer::showCurrentImage()
 	currentPixmap = pixmap;
 	zoomFactor = 1.0;
 
+	#ifndef VCMI_MOBILE
 	QSize windowSize = currentPixmap.size();
 	windowSize.scale(calculateWindowSize(), Qt::KeepAspectRatio);
 	resize(windowSize);
+	#endif
 	updateDisplayedPixmap();
 
 	ui->buttonPrevious->setVisible(images.size() > 1);
@@ -239,7 +241,11 @@ void ImageViewer::updateDisplayedPixmap()
 	if(labelSize.isEmpty())
 		return;
 
-	QSize targetSize = labelSize * zoomFactor;
+	QSize targetSize = currentPixmap.size();
+	if(targetSize.width() > labelSize.width() || targetSize.height() > labelSize.height())
+		targetSize.scale(labelSize, Qt::KeepAspectRatio);
+
+	targetSize = targetSize * zoomFactor;
 	targetSize = targetSize.boundedTo(calculateWindowSize() * 2);
 
 	const auto scaledPixmap = currentPixmap.scaled(targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -79,6 +79,22 @@ ImageViewer::ImageViewer(QWidget * parent)
 	connect(ui->buttonPrevious, &QPushButton::clicked, this, &ImageViewer::showPreviousImage);
 	connect(ui->buttonNext, &QPushButton::clicked, this, &ImageViewer::showNextImage);
 	connect(ui->buttonClose, &QPushButton::clicked, this, &ImageViewer::close);
+
+#ifdef VCMI_MOBILE
+	auto * layout = ui->gridLayout;
+	layout->removeWidget(ui->buttonPrevious);
+	layout->removeWidget(ui->buttonNext);
+	layout->removeWidget(ui->buttonClose);
+	layout->removeWidget(ui->label);
+	layout->addWidget(ui->label, 0, 0, 3, 3);
+
+	ui->buttonPrevious->setParent(this);
+	ui->buttonNext->setParent(this);
+	ui->buttonClose->setParent(this);
+	ui->buttonPrevious->raise();
+	ui->buttonNext->raise();
+	ui->buttonClose->raise();
+#endif
 }
 
 void ImageViewer::changeEvent(QEvent *event)
@@ -209,6 +225,7 @@ void ImageViewer::showCurrentImage()
 	ui->buttonNext->setVisible(images.size() > 1);
 	#ifdef VCMI_MOBILE
 	ui->buttonClose->setVisible(true);
+	updateMobileButtonsGeometry();
 	#else
 	ui->buttonClose->setVisible(false);
 	#endif
@@ -275,8 +292,21 @@ void ImageViewer::resizeEvent(QResizeEvent * event)
 {
 	QDialog::resizeEvent(event);
 	updateDisplayedPixmap();
+	updateMobileButtonsGeometry();
 }
 
+void ImageViewer::updateMobileButtonsGeometry()
+{
+#ifdef VCMI_MOBILE
+	constexpr int margin = 12;
+	const int buttonSize = ui->buttonPrevious->width();
+	const int middleY = (height() - buttonSize) / 2;
+
+	ui->buttonPrevious->move(margin, middleY);
+	ui->buttonNext->move(width() - buttonSize - margin, middleY);
+	ui->buttonClose->move(width() - buttonSize - margin, margin);
+#endif
+}
 
 void ImageViewer::mousePressEvent(QMouseEvent * event)
 {

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -25,15 +25,20 @@ public:
 	explicit ImageViewer(QWidget * parent = nullptr);
 	~ImageViewer();
 
-	void setPixmap(QPixmap & pixmap);
+	void setImages(const QStringList & imagePaths, int startIndex);
 
-	static void showPixmap(QPixmap & pixmap, QWidget * parent = nullptr);
+	static void showImages(const QStringList & imagePaths, int startIndex, QWidget * parent = nullptr);
 
 protected:
-	void mousePressEvent(QMouseEvent * event) override;
 	void keyPressEvent(QKeyEvent * event) override;
 	QSize calculateWindowSize();
 
 private:
+	void showCurrentImage();
+	void showPreviousImage();
+	void showNextImage();
+
 	Ui::ImageViewer * ui;
+	QStringList images;
+	int currentImageIndex = -1;
 };

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -58,4 +58,5 @@ private:
 	int mouseStartX = 0;
 	qreal zoomFactor = 1.0;
 	bool touchSwipeActive = false;
+	bool suppressTouchSwipe = false;
 };

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -46,6 +46,7 @@ private:
 	void updateDisplayedPixmap();
 	void handleSwipeDelta(int deltaX);
 	void applyZoomStep(qreal zoomStep);
+	void updateMobileButtonsGeometry();
 
 	Ui::ImageViewer * ui;
 	QShortcut * shortcutPrevious = nullptr;

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -11,6 +11,8 @@
 
 #include <QDialog>
 
+class QShortcut;
+
 namespace Ui
 {
 class ImageViewer;
@@ -21,6 +23,7 @@ class ImageViewer : public QDialog
 	Q_OBJECT
 
 	void changeEvent(QEvent *event) override;
+	bool event(QEvent * event) override;
 public:
 	explicit ImageViewer(QWidget * parent = nullptr);
 	~ImageViewer();
@@ -31,14 +34,25 @@ public:
 
 protected:
 	void keyPressEvent(QKeyEvent * event) override;
+	void resizeEvent(QResizeEvent * event) override;
+	void mousePressEvent(QMouseEvent * event) override;
+	void mouseReleaseEvent(QMouseEvent * event) override;
 	QSize calculateWindowSize();
 
 private:
 	void showCurrentImage();
 	void showPreviousImage();
 	void showNextImage();
+	void updateDisplayedPixmap();
+	void handleSwipeDelta(int deltaX);
 
 	Ui::ImageViewer * ui;
+	QShortcut * shortcutPrevious = nullptr;
+	QShortcut * shortcutNext = nullptr;
+	QShortcut * shortcutClose = nullptr;
 	QStringList images;
+	QPixmap currentPixmap;
 	int currentImageIndex = -1;
+	int touchStartX = 0;
+	int mouseStartX = 0;
 };

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -45,6 +45,7 @@ private:
 	void showNextImage();
 	void updateDisplayedPixmap();
 	void handleSwipeDelta(int deltaX);
+	void applyZoomStep(qreal zoomStep);
 
 	Ui::ImageViewer * ui;
 	QShortcut * shortcutPrevious = nullptr;
@@ -55,4 +56,6 @@ private:
 	int currentImageIndex = -1;
 	int touchStartX = 0;
 	int mouseStartX = 0;
+	qreal zoomFactor = 1.0;
+	bool touchSwipeActive = false;
 };

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -46,7 +46,6 @@ private:
 	void updateDisplayedPixmap();
 	void handleSwipeDelta(int deltaX);
 	void applyZoomStep(qreal zoomStep);
-	void updateMobileButtonsGeometry();
 
 	Ui::ImageViewer * ui;
 	QShortcut * shortcutPrevious = nullptr;

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -93,8 +93,8 @@ QPushButton:pressed {
      <property name="scaledContents">
       <bool>false</bool>
      </property>
-    </widget>
-   </item>
+   </widget>
+  </item>
    <item row="0" column="2">
     <widget class="QPushButton" name="buttonNext">
      <property name="minimumSize">
@@ -130,6 +130,44 @@ QPushButton:pressed {
      </property>
      <property name="text">
       <string>&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QPushButton" name="buttonClose">
+     <property name="minimumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton {
+	background-color: rgba(0, 0, 0, 170);
+	color: white;
+	border: 2px solid white;
+	border-radius: 24px;
+	font-size: 20px;
+	font-weight: bold;
+}
+QPushButton:hover {
+	background-color: rgba(0, 0, 0, 215);
+}
+QPushButton:pressed {
+	background-color: rgba(0, 0, 0, 255);
+}</string>
+     </property>
+     <property name="text">
+      <string>✕</string>
      </property>
     </widget>
    </item>

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -41,9 +41,6 @@
    <property name="verticalSpacing">
     <number>8</number>
    </property>
-   <property name="rowStretch">
-    <string>0,1,0</string>
-   </property>
    <item row="0" column="2" alignment="Qt::AlignRight|Qt::AlignTop">
     <widget class="QPushButton" name="buttonClose">
      <property name="minimumSize">

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -24,16 +24,19 @@
     <enum>QLayout::SetNoConstraint</enum>
    </property>
    <property name="leftMargin">
-    <number>0</number>
+    <number>12</number>
    </property>
    <property name="topMargin">
-    <number>0</number>
+    <number>12</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>12</number>
    </property>
    <property name="bottomMargin">
-    <number>0</number>
+    <number>12</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>8</number>
    </property>
    <item row="0" column="0">
     <widget class="QPushButton" name="buttonPrevious">
@@ -54,7 +57,7 @@
      </property>
      <property name="styleSheet">
       <string notr="true">QPushButton {
-	background-color: transparent;
+	background-color: rgba(0, 0, 0, 170);
 	color: white;
 	border: 2px solid white;
 	border-radius: 24px;
@@ -62,11 +65,14 @@
 	font-weight: bold;
 }
 QPushButton:hover {
-	background-color: rgba(255, 255, 255, 35);
+	background-color: rgba(0, 0, 0, 215);
+}
+QPushButton:pressed {
+	background-color: rgba(0, 0, 0, 255);
 }</string>
      </property>
      <property name="text">
-      <string>◀</string>
+      <string>&lt;</string>
      </property>
     </widget>
    </item>
@@ -81,8 +87,11 @@ QPushButton:hover {
      <property name="text">
       <string/>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
      <property name="scaledContents">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -105,7 +114,7 @@ QPushButton:hover {
      </property>
      <property name="styleSheet">
       <string notr="true">QPushButton {
-	background-color: transparent;
+	background-color: rgba(0, 0, 0, 170);
 	color: white;
 	border: 2px solid white;
 	border-radius: 24px;
@@ -113,11 +122,14 @@ QPushButton:hover {
 	font-weight: bold;
 }
 QPushButton:hover {
-	background-color: rgba(255, 255, 255, 35);
+	background-color: rgba(0, 0, 0, 215);
+}
+QPushButton:pressed {
+	background-color: rgba(0, 0, 0, 255);
 }</string>
      </property>
      <property name="text">
-      <string>▶</string>
+      <string>&gt;</string>
      </property>
     </widget>
    </item>

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -41,6 +41,9 @@
    <property name="verticalSpacing">
     <number>8</number>
    </property>
+   <property name="rowStretch">
+    <string>0,1,0</string>
+   </property>
    <item row="0" column="2" alignment="Qt::AlignRight|Qt::AlignTop">
     <widget class="QPushButton" name="buttonClose">
      <property name="minimumSize">
@@ -64,7 +67,7 @@
 	color: white;
 	border: 2px solid white;
 	border-radius: 24px;
-	font-size: 20px;
+	font-size: 28px;
 	font-weight: bold;
 }
 QPushButton:hover {
@@ -75,7 +78,7 @@ QPushButton:pressed {
 }</string>
      </property>
      <property name="text">
-      <string>✕</string>
+      <string>X</string>
      </property>
     </widget>
    </item>
@@ -173,6 +176,19 @@ QPushButton:pressed {
       <string>&gt;</string>
      </property>
     </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <spacer name="verticalSpacerBottom">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>48</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -36,6 +36,41 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
+    <widget class="QPushButton" name="buttonPrevious">
+     <property name="minimumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton {
+	background-color: transparent;
+	color: white;
+	border: 2px solid white;
+	border-radius: 24px;
+	font-size: 24px;
+	font-weight: bold;
+}
+QPushButton:hover {
+	background-color: rgba(255, 255, 255, 35);
+}</string>
+     </property>
+     <property name="text">
+      <string>◀</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -48,6 +83,41 @@
      </property>
      <property name="scaledContents">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QPushButton" name="buttonNext">
+     <property name="minimumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton {
+	background-color: transparent;
+	color: white;
+	border: 2px solid white;
+	border-radius: 24px;
+	font-size: 24px;
+	font-weight: bold;
+}
+QPushButton:hover {
+	background-color: rgba(255, 255, 255, 35);
+}</string>
+     </property>
+     <property name="text">
+      <string>▶</string>
      </property>
     </widget>
    </item>

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -174,19 +174,6 @@ QPushButton:pressed {
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <spacer name="verticalSpacerBottom">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>48</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -45,14 +45,14 @@
     <widget class="QPushButton" name="buttonClose">
      <property name="minimumSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>40</width>
+       <height>40</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>40</width>
+       <height>40</height>
       </size>
      </property>
      <property name="cursor">
@@ -63,7 +63,7 @@
 	background-color: rgba(0, 0, 0, 170);
 	color: white;
 	border: 2px solid white;
-	border-radius: 24px;
+	border-radius: 20px;
 	font-size: 28px;
 	font-weight: bold;
 }
@@ -83,14 +83,14 @@ QPushButton:pressed {
     <widget class="QPushButton" name="buttonPrevious">
      <property name="minimumSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>40</width>
+       <height>40</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>40</width>
+       <height>40</height>
       </size>
      </property>
      <property name="cursor">
@@ -101,7 +101,7 @@ QPushButton:pressed {
 	background-color: rgba(0, 0, 0, 170);
 	color: white;
 	border: 2px solid white;
-	border-radius: 24px;
+	border-radius: 20px;
 	font-size: 24px;
 	font-weight: bold;
 }
@@ -120,7 +120,7 @@ QPushButton:pressed {
    <item row="1" column="1">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -140,14 +140,14 @@ QPushButton:pressed {
     <widget class="QPushButton" name="buttonNext">
      <property name="minimumSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>40</width>
+       <height>40</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>48</width>
-       <height>48</height>
+       <width>40</width>
+       <height>40</height>
       </size>
      </property>
      <property name="cursor">
@@ -158,7 +158,7 @@ QPushButton:pressed {
 	background-color: rgba(0, 0, 0, 170);
 	color: white;
 	border: 2px solid white;
-	border-radius: 24px;
+	border-radius: 20px;
 	font-size: 24px;
 	font-weight: bold;
 }

--- a/launcher/modManager/imageviewer_moc.ui
+++ b/launcher/modManager/imageviewer_moc.ui
@@ -38,7 +38,48 @@
    <property name="horizontalSpacing">
     <number>8</number>
    </property>
-   <item row="0" column="0">
+   <property name="verticalSpacing">
+    <number>8</number>
+   </property>
+   <item row="0" column="2" alignment="Qt::AlignRight|Qt::AlignTop">
+    <widget class="QPushButton" name="buttonClose">
+     <property name="minimumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>48</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QPushButton {
+	background-color: rgba(0, 0, 0, 170);
+	color: white;
+	border: 2px solid white;
+	border-radius: 24px;
+	font-size: 20px;
+	font-weight: bold;
+}
+QPushButton:hover {
+	background-color: rgba(0, 0, 0, 215);
+}
+QPushButton:pressed {
+	background-color: rgba(0, 0, 0, 255);
+}</string>
+     </property>
+     <property name="text">
+      <string>✕</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" alignment="Qt::AlignLeft|Qt::AlignVCenter">
     <widget class="QPushButton" name="buttonPrevious">
      <property name="minimumSize">
       <size>
@@ -76,7 +117,7 @@ QPushButton:pressed {
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="1" column="1">
     <widget class="QLabel" name="label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -93,9 +134,9 @@ QPushButton:pressed {
      <property name="scaledContents">
       <bool>false</bool>
      </property>
-   </widget>
-  </item>
-   <item row="0" column="2">
+    </widget>
+   </item>
+   <item row="1" column="2" alignment="Qt::AlignRight|Qt::AlignVCenter">
     <widget class="QPushButton" name="buttonNext">
      <property name="minimumSize">
       <size>
@@ -130,44 +171,6 @@ QPushButton:pressed {
      </property>
      <property name="text">
       <string>&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QPushButton" name="buttonClose">
-     <property name="minimumSize">
-      <size>
-       <width>48</width>
-       <height>48</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>48</width>
-       <height>48</height>
-      </size>
-     </property>
-     <property name="cursor">
-      <cursorShape>PointingHandCursor</cursorShape>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QPushButton {
-	background-color: rgba(0, 0, 0, 170);
-	color: white;
-	border: 2px solid white;
-	border-radius: 24px;
-	font-size: 20px;
-	font-weight: bold;
-}
-QPushButton:hover {
-	background-color: rgba(0, 0, 0, 215);
-}
-QPushButton:pressed {
-	background-color: rgba(0, 0, 0, 255);
-}</string>
-     </property>
-     <property name="text">
-      <string>✕</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
### Motivation
- The launcher image viewer opened single images and required clicking each screenshot separately; users expect to navigate between screenshots with arrows and keyboard.

### Description
- Replace single-image API with an image-list API by adding `ImageViewer::showImages(const QStringList&, int, QWidget*)` and `void ImageViewer::setImages(const QStringList&, int)` in `launcher/modManager/imageviewer_moc.h` and `launcher/modManager/imageviewer_moc.cpp`.
- Add previous/next navigation methods (`showPreviousImage`, `showNextImage`, `showCurrentImage`) and keyboard support for `Left`, `Right`, and `Esc` in `ImageViewer` implementation.
- Add visible circular left/right arrow buttons and styles to `launcher/modManager/imageviewer_moc.ui`, and wire their clicks to navigation in the constructor (`connect` to `buttonPrevious` / `buttonNext`).
- Update screenshot list handling in `launcher/modManager/cmodlistview_moc.cpp` to store each cached image path in `Qt::UserRole` and open the viewer with the full list at the clicked index via `ImageViewer::showImages`.

### Testing
- Ran `git diff --check` which reported no whitespace errors.
- Attempted `cmake --build build --target launcher -j2` which failed because the `build/` directory did not exist in this environment.
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` which configured but failed to complete due to missing Boost development packages on the machine (missing Boost include components).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699826d9a9e8832daddbfdb9a00cb596)