### PR TITLE
Make mobile image viewer responsive to screen size

### DIFF
--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -280,8 +280,12 @@ void ImageViewer::updateDisplayedPixmap()
 		return;
 
 	QSize targetSize = currentPixmap.size();
+#ifdef VCMI_MOBILE
+	targetSize.scale(labelSize, Qt::KeepAspectRatio);
+#else
 	if(targetSize.width() > labelSize.width() || targetSize.height() > labelSize.height())
 		targetSize.scale(labelSize, Qt::KeepAspectRatio);
+#endif
 
 	targetSize = targetSize * zoomFactor;
 	targetSize = targetSize.boundedTo(calculateWindowSize() * 2);
@@ -341,9 +345,12 @@ void ImageViewer::updateResponsiveLayout(const QSize & windowSize)
 	ui->buttonClose->setMinimumSize(buttonSize, buttonSize);
 	ui->buttonClose->setMaximumSize(buttonSize, buttonSize);
 
-	const int reservedWidth = (buttonSize * 2) + (margin * 2) + spacing;
-	const int minimumLabelWidth = std::max(0, windowSize.width() - reservedWidth);
-	ui->label->setMaximumWidth(minimumLabelWidth);
+	ui->gridLayout->setColumnStretch(0, 0);
+	ui->gridLayout->setColumnStretch(1, 1);
+	ui->gridLayout->setColumnStretch(2, 0);
+	ui->gridLayout->setColumnMinimumWidth(0, buttonSize);
+	ui->gridLayout->setColumnMinimumWidth(2, buttonSize);
+	ui->label->setMaximumWidth(QWIDGETSIZE_MAX);
 	ui->label->setMinimumWidth(0);
 #else
 	Q_UNUSED(windowSize);

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -57,7 +57,9 @@ QPointF touchEventPos(const QTouchEvent * touchEvent)
 #endif
 }
 
+#ifdef VCMI_MOBILE
 constexpr int sideButtonSize = 48;
+#endif
 
 int mouseEventX(const QMouseEvent * mouseEvent)
 {

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -57,9 +57,7 @@ QPointF touchEventPos(const QTouchEvent * touchEvent)
 #endif
 }
 
-#ifdef VCMI_MOBILE
 constexpr int sideButtonSize = 48;
-#endif
 
 int mouseEventX(const QMouseEvent * mouseEvent)
 {
@@ -237,9 +235,17 @@ void ImageViewer::showCurrentImage()
 	zoomFactor = 1.0;
 
 #ifndef VCMI_MOBILE
-	QSize windowSize = currentPixmap.size();
-	windowSize.scale(calculateWindowSize(), Qt::KeepAspectRatio);
-	resize(windowSize);
+	const QSize availableWindowSize = calculateWindowSize();
+	const int desktopMargin = 12;
+	const int desktopSpacing = 8;
+	const int reservedWidth = (sideButtonSize * 2) + (desktopMargin * 2) + desktopSpacing;
+	const int reservedHeight = desktopMargin * 2;
+	const int maxLabelWidth = std::max(1, std::min(availableWindowSize.width() - reservedWidth, availableWindowSize.height()));
+	const int maxLabelHeight = std::max(1, availableWindowSize.height() - reservedHeight);
+
+	QSize labelTargetSize = currentPixmap.size();
+	labelTargetSize.scale(QSize(maxLabelWidth, maxLabelHeight), Qt::KeepAspectRatio);
+	resize(labelTargetSize.width() + reservedWidth, labelTargetSize.height() + reservedHeight);
 #endif
 	updateDisplayedPixmap();
 
@@ -280,12 +286,7 @@ void ImageViewer::updateDisplayedPixmap()
 		return;
 
 	QSize targetSize = currentPixmap.size();
-#ifdef VCMI_MOBILE
 	targetSize.scale(labelSize, Qt::KeepAspectRatio);
-#else
-	if(targetSize.width() > labelSize.width() || targetSize.height() > labelSize.height())
-		targetSize.scale(labelSize, Qt::KeepAspectRatio);
-#endif
 
 	targetSize = targetSize * zoomFactor;
 	targetSize = targetSize.boundedTo(calculateWindowSize() * 2);
@@ -333,6 +334,12 @@ void ImageViewer::updateResponsiveLayout(const QSize & windowSize)
 	const int spacing = compactLayout ? 2 : 4;
 	const int margin = compactLayout ? 2 : 4;
 	const int buttonSize = compactLayout ? 40 : sideButtonSize;
+#else
+	Q_UNUSED(windowSize);
+	const int spacing = 8;
+	const int margin = 12;
+	const int buttonSize = sideButtonSize;
+#endif
 
 	ui->gridLayout->setContentsMargins(margin, margin, margin, margin);
 	ui->gridLayout->setHorizontalSpacing(spacing);
@@ -352,10 +359,8 @@ void ImageViewer::updateResponsiveLayout(const QSize & windowSize)
 	ui->gridLayout->setColumnMinimumWidth(2, buttonSize);
 	ui->label->setMaximumWidth(QWIDGETSIZE_MAX);
 	ui->label->setMinimumWidth(0);
-#else
-	Q_UNUSED(windowSize);
-#endif
 }
+
 
 void ImageViewer::mousePressEvent(QMouseEvent * event)
 {

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -11,6 +11,7 @@
 
 #include <QGuiApplication>
 #include <QGestureEvent>
+#include <QPainter>
 #include <QPinchGesture>
 #include <QScreen>
 #include <QShortcut>
@@ -143,6 +144,7 @@ bool ImageViewer::event(QEvent * event)
 		{
 			suppressTouchSwipe = true;
 			touchSwipeActive = false;
+			touchPanActive = false;
 			return true;
 		}
 
@@ -154,8 +156,25 @@ bool ImageViewer::event(QEvent * event)
 		if(touched == ui->buttonPrevious || touched == ui->buttonNext || touched == ui->buttonClose)
 			return QDialog::event(event);
 
+		lastPointerPosition = pos;
 		touchStartX = static_cast<int>(pos.x());
-		touchSwipeActive = true;
+		touchPanActive = zoomFactor > 1.0;
+		touchSwipeActive = !touchPanActive;
+		return true;
+	}
+
+	if(event->type() == QEvent::TouchUpdate)
+	{
+		auto * touchEvent = static_cast<QTouchEvent *>(event);
+		if(!touchPanActive)
+			return QDialog::event(event);
+
+		const auto pos = touchEventPos(touchEvent);
+		if(pos.isNull())
+			return true;
+
+		panImage(pos - lastPointerPosition);
+		lastPointerPosition = pos;
 		return true;
 	}
 
@@ -166,6 +185,13 @@ bool ImageViewer::event(QEvent * event)
 		{
 			suppressTouchSwipe = false;
 			touchSwipeActive = false;
+			touchPanActive = false;
+			return true;
+		}
+
+		if(touchPanActive)
+		{
+			touchPanActive = false;
 			return true;
 		}
 
@@ -233,19 +259,24 @@ void ImageViewer::showCurrentImage()
 
 	currentPixmap = pixmap;
 	zoomFactor = 1.0;
+	panOffset = QPointF{};
 
 #ifndef VCMI_MOBILE
-	const QSize availableWindowSize = calculateWindowSize();
-	const int desktopMargin = 12;
-	const int desktopSpacing = 8;
-	const int reservedWidth = (sideButtonSize * 2) + (desktopMargin * 2) + desktopSpacing;
-	const int reservedHeight = desktopMargin * 2;
-	const int maxLabelWidth = std::max(1, std::min(availableWindowSize.width() - reservedWidth, availableWindowSize.height()));
-	const int maxLabelHeight = std::max(1, availableWindowSize.height() - reservedHeight);
+	if(!desktopWindowInitialized)
+	{
+		const QSize availableWindowSize = calculateWindowSize();
+		const int desktopMargin = 12;
+		const int desktopSpacing = 8;
+		const int reservedWidth = (sideButtonSize * 2) + (desktopMargin * 2) + desktopSpacing;
+		const int reservedHeight = desktopMargin * 2;
+		const int maxLabelWidth = std::max(1, std::min(availableWindowSize.width() - reservedWidth, availableWindowSize.height()));
+		const int maxLabelHeight = std::max(1, availableWindowSize.height() - reservedHeight);
 
-	QSize labelTargetSize = currentPixmap.size();
-	labelTargetSize.scale(QSize(maxLabelWidth, maxLabelHeight), Qt::KeepAspectRatio);
-	resize(labelTargetSize.width() + reservedWidth, labelTargetSize.height() + reservedHeight);
+		QSize labelTargetSize = currentPixmap.size();
+		labelTargetSize.scale(QSize(maxLabelWidth, maxLabelHeight), Qt::KeepAspectRatio);
+		resize(labelTargetSize.width() + reservedWidth, labelTargetSize.height() + reservedHeight);
+		desktopWindowInitialized = true;
+	}
 #endif
 	updateDisplayedPixmap();
 
@@ -287,12 +318,23 @@ void ImageViewer::updateDisplayedPixmap()
 
 	QSize targetSize = currentPixmap.size();
 	targetSize.scale(labelSize, Qt::KeepAspectRatio);
-
 	targetSize = targetSize * zoomFactor;
 	targetSize = targetSize.boundedTo(calculateWindowSize() * 2);
 
 	const auto scaledPixmap = currentPixmap.scaled(targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-	ui->label->setPixmap(scaledPixmap);
+	const int maxPanX = std::max(0, (scaledPixmap.width() - labelSize.width()) / 2);
+	const int maxPanY = std::max(0, (scaledPixmap.height() - labelSize.height()) / 2);
+	panOffset.setX(std::clamp(panOffset.x(), static_cast<qreal>(-maxPanX), static_cast<qreal>(maxPanX)));
+	panOffset.setY(std::clamp(panOffset.y(), static_cast<qreal>(-maxPanY), static_cast<qreal>(maxPanY)));
+
+	QPixmap canvas(labelSize);
+	canvas.fill(palette().color(QPalette::Window));
+	QPainter painter(&canvas);
+	const QPoint drawPos((labelSize.width() - scaledPixmap.width()) / 2 + static_cast<int>(panOffset.x()),
+		(labelSize.height() - scaledPixmap.height()) / 2 + static_cast<int>(panOffset.y()));
+	painter.drawPixmap(drawPos, scaledPixmap);
+	painter.end();
+	ui->label->setPixmap(canvas);
 }
 
 void ImageViewer::applyZoomStep(qreal zoomStep)
@@ -307,6 +349,17 @@ void ImageViewer::applyZoomStep(qreal zoomStep)
 	constexpr qreal minZoomFactor = 0.5;
 #endif
 	zoomFactor = std::clamp(zoomFactor, minZoomFactor, 3.0);
+	if(zoomFactor <= 1.0)
+		panOffset = QPointF{};
+	updateDisplayedPixmap();
+}
+
+void ImageViewer::panImage(const QPointF & delta)
+{
+	if(zoomFactor <= 1.0)
+		return;
+
+	panOffset += delta;
 	updateDisplayedPixmap();
 }
 
@@ -364,15 +417,66 @@ void ImageViewer::updateResponsiveLayout(const QSize & windowSize)
 
 void ImageViewer::mousePressEvent(QMouseEvent * event)
 {
+	if(event->button() == Qt::LeftButton && zoomFactor > 1.0)
+	{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		lastPointerPosition = event->position();
+#else
+		lastPointerPosition = event->localPos();
+#endif
+		mousePanActive = true;
+		event->accept();
+		return;
+	}
+
 	mouseStartX = mouseEventX(event);
 	QDialog::mousePressEvent(event);
 }
 
+void ImageViewer::mouseMoveEvent(QMouseEvent * event)
+{
+	if(!mousePanActive)
+	{
+		QDialog::mouseMoveEvent(event);
+		return;
+	}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	const QPointF currentPosition = event->position();
+#else
+	const QPointF currentPosition = event->localPos();
+#endif
+	panImage(currentPosition - lastPointerPosition);
+	lastPointerPosition = currentPosition;
+	event->accept();
+}
+
 void ImageViewer::mouseReleaseEvent(QMouseEvent * event)
 {
+	if(mousePanActive && event->button() == Qt::LeftButton)
+	{
+		mousePanActive = false;
+		event->accept();
+		return;
+	}
+
 	const int mouseEndX = mouseEventX(event);
 	handleSwipeDelta(mouseEndX - mouseStartX);
 	QDialog::mouseReleaseEvent(event);
+}
+
+void ImageViewer::wheelEvent(QWheelEvent * event)
+{
+	const QPoint numDegrees = event->angleDelta() / 8;
+	if(numDegrees.y() == 0)
+	{
+		QDialog::wheelEvent(event);
+		return;
+	}
+
+	const qreal zoomStep = numDegrees.y() > 0 ? 1.1 : (1.0 / 1.1);
+	applyZoomStep(zoomStep);
+	event->accept();
 }
 
 void ImageViewer::keyPressEvent(QKeyEvent * event)

--- a/launcher/modManager/imageviewer_moc.cpp
+++ b/launcher/modManager/imageviewer_moc.cpp
@@ -12,6 +12,7 @@
 #include <QGuiApplication>
 #include <QGestureEvent>
 #include <QPinchGesture>
+#include <QScreen>
 #include <QShortcut>
 #include <QSwipeGesture>
 #include <QTouchEvent>
@@ -56,6 +57,8 @@ QPointF touchEventPos(const QTouchEvent * touchEvent)
 #endif
 }
 
+constexpr int sideButtonSize = 48;
+
 int mouseEventX(const QMouseEvent * mouseEvent)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -70,6 +73,8 @@ ImageViewer::ImageViewer(QWidget * parent)
 	: QDialog(parent), ui(new Ui::ImageViewer)
 {
 	ui->setupUi(this);
+	ui->label->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+	ui->label->setMinimumSize(0, 0);
 
 	setFocusPolicy(Qt::StrongFocus);
 	setAttribute(Qt::WA_AcceptTouchEvents, true);
@@ -89,6 +94,7 @@ ImageViewer::ImageViewer(QWidget * parent)
 	connect(ui->buttonNext, &QPushButton::clicked, this, &ImageViewer::showNextImage);
 	connect(ui->buttonClose, &QPushButton::clicked, this, &ImageViewer::close);
 
+	updateResponsiveLayout(size());
 }
 
 void ImageViewer::changeEvent(QEvent *event)
@@ -199,7 +205,8 @@ void ImageViewer::showImages(const QStringList & imagePaths, int startIndex, QWi
 	viewer->setAttribute(Qt::WA_DeleteOnClose, true);
 	viewer->setModal(Qt::WindowModal);
 #ifdef VCMI_MOBILE
-	viewer->showFullScreen();
+	viewer->setGeometry(QGuiApplication::primaryScreen()->availableGeometry());
+	viewer->show();
 #else
 	viewer->show();
 #endif
@@ -308,9 +315,38 @@ void ImageViewer::handleSwipeDelta(int deltaX)
 void ImageViewer::resizeEvent(QResizeEvent * event)
 {
 	QDialog::resizeEvent(event);
+	updateResponsiveLayout(event->size());
 	updateDisplayedPixmap();
 }
 
+void ImageViewer::updateResponsiveLayout(const QSize & windowSize)
+{
+#ifdef VCMI_MOBILE
+	const int shortestSide = std::min(windowSize.width(), windowSize.height());
+	const bool compactLayout = shortestSide < 560;
+	const int spacing = compactLayout ? 2 : 4;
+	const int margin = compactLayout ? 2 : 4;
+	const int buttonSize = compactLayout ? 40 : sideButtonSize;
+
+	ui->gridLayout->setContentsMargins(margin, margin, margin, margin);
+	ui->gridLayout->setHorizontalSpacing(spacing);
+	ui->gridLayout->setVerticalSpacing(spacing);
+
+	ui->buttonPrevious->setMinimumSize(buttonSize, buttonSize);
+	ui->buttonPrevious->setMaximumSize(buttonSize, buttonSize);
+	ui->buttonNext->setMinimumSize(buttonSize, buttonSize);
+	ui->buttonNext->setMaximumSize(buttonSize, buttonSize);
+	ui->buttonClose->setMinimumSize(buttonSize, buttonSize);
+	ui->buttonClose->setMaximumSize(buttonSize, buttonSize);
+
+	const int reservedWidth = (buttonSize * 2) + (margin * 2) + spacing;
+	const int minimumLabelWidth = std::max(0, windowSize.width() - reservedWidth);
+	ui->label->setMaximumWidth(minimumLabelWidth);
+	ui->label->setMinimumWidth(0);
+#else
+	Q_UNUSED(windowSize);
+#endif
+}
 
 void ImageViewer::mousePressEvent(QMouseEvent * event)
 {

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -36,7 +36,9 @@ protected:
 	void keyPressEvent(QKeyEvent * event) override;
 	void resizeEvent(QResizeEvent * event) override;
 	void mousePressEvent(QMouseEvent * event) override;
+	void mouseMoveEvent(QMouseEvent * event) override;
 	void mouseReleaseEvent(QMouseEvent * event) override;
+	void wheelEvent(QWheelEvent * event) override;
 	QSize calculateWindowSize();
 	void updateResponsiveLayout(const QSize & windowSize);
 
@@ -47,6 +49,7 @@ private:
 	void updateDisplayedPixmap();
 	void handleSwipeDelta(int deltaX);
 	void applyZoomStep(qreal zoomStep);
+	void panImage(const QPointF & delta);
 
 	Ui::ImageViewer * ui;
 	QShortcut * shortcutPrevious = nullptr;
@@ -58,6 +61,11 @@ private:
 	int touchStartX = 0;
 	int mouseStartX = 0;
 	qreal zoomFactor = 1.0;
+	QPointF panOffset;
+	QPointF lastPointerPosition;
 	bool touchSwipeActive = false;
+	bool touchPanActive = false;
+	bool mousePanActive = false;
 	bool suppressTouchSwipe = false;
+	bool desktopWindowInitialized = false;
 };

--- a/launcher/modManager/imageviewer_moc.h
+++ b/launcher/modManager/imageviewer_moc.h
@@ -38,6 +38,7 @@ protected:
 	void mousePressEvent(QMouseEvent * event) override;
 	void mouseReleaseEvent(QMouseEvent * event) override;
 	QSize calculateWindowSize();
+	void updateResponsiveLayout(const QSize & windowSize);
 
 private:
 	void showCurrentImage();


### PR DESCRIPTION
### Motivation
- The previous change only allowed the preview label to shrink, but on very narrow phones the image could still push the right-side controls out of view, so the viewer must adapt its layout dynamically to the actual available screen area.

### Description
- Added `updateResponsiveLayout(const QSize &)` to `ImageViewer` and call it from the constructor and `resizeEvent` to update margins, spacing and control sizes based on the current window size.
- Reserve horizontal space for side controls by capping the preview label width with `setMaximumWidth` and adjust button sizes (compact mode) so navigation/close buttons remain visible on narrow screens.
- On mobile builds, open the viewer to `QGuiApplication::primaryScreen()->availableGeometry()` and use `show()` (instead of `showFullScreen()`) so the layout can react to the actual available geometry.
- Set the preview `QLabel` to a shrinkable size policy and minimum size (`QSizePolicy::Ignored` and `setMinimumSize(0,0)`), and centralize grid spacing/margins changes into the responsive function.

### Testing
- Ran `git diff --check` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e7e76d8c832db123b37ae8e451bf)