### PR TITLE
Add support for multiple native terrains for factions

### DIFF
--- a/AI/Nullkiller/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller/Analyzers/ArmyManager.cpp
@@ -139,17 +139,13 @@ std::vector<SlotInfo>::iterator ArmyManager::getBestUnitForScout(std::vector<Slo
 
 		if (terrainHasPenalty)
 		{
-			auto leftNativeTerrain = left.creature->getFactionID().toFaction()->nativeTerrain;
-			auto rightNativeTerrain = right.creature->getFactionID().toFaction()->nativeTerrain;
+			auto leftFaction = left.creature->getFactionID().toFaction();
+			auto rightFaction = right.creature->getFactionID().toFaction();
+			bool leftNativeTerrain = leftFaction->isNativeTerrain(armyTerrain);
+			bool rightNativeTerrain = rightFaction->isNativeTerrain(armyTerrain);
 
-			if (leftNativeTerrain != rightNativeTerrain)
-			{
-				if (leftNativeTerrain == armyTerrain)
-					return true;
-
-				if (rightNativeTerrain == armyTerrain)
-					return false;
-			}
+			if(leftNativeTerrain != rightNativeTerrain)
+				return leftNativeTerrain;
 		}
 
 		int leftEffectiveMovement = std::min<int>(movementPointsLimits.size() - 1, left.creature->getMovementRange());

--- a/AI/Nullkiller2/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller2/Analyzers/ArmyManager.cpp
@@ -139,17 +139,13 @@ std::vector<SlotInfo>::iterator ArmyManager::getBestUnitForScout(std::vector<Slo
 
 		if (terrainHasPenalty)
 		{
-			auto leftNativeTerrain = left.creature->getFactionID().toFaction()->nativeTerrain;
-			auto rightNativeTerrain = right.creature->getFactionID().toFaction()->nativeTerrain;
+			auto leftFaction = left.creature->getFactionID().toFaction();
+			auto rightFaction = right.creature->getFactionID().toFaction();
+			bool leftNativeTerrain = leftFaction->isNativeTerrain(armyTerrain);
+			bool rightNativeTerrain = rightFaction->isNativeTerrain(armyTerrain);
 
-			if (leftNativeTerrain != rightNativeTerrain)
-			{
-				if (leftNativeTerrain == armyTerrain)
-					return true;
-
-				if (rightNativeTerrain == armyTerrain)
-					return false;
-			}
+			if(leftNativeTerrain != rightNativeTerrain)
+				return leftNativeTerrain;
 		}
 
 		int leftEffectiveMovement = std::min<int>(movementPointsLimits.size() - 1, left.creature->getMovementRange());

--- a/config/schemas/faction.json
+++ b/config/schemas/faction.json
@@ -57,8 +57,15 @@
 			"description" : "Faction alignment, good, neutral or evil"
 		},
 		"nativeTerrain" : {
-			"type" : "string",
-			"description" : "Native terrain for creatures. Creatures fighting on native terrain receive several bonuses"
+			"oneOf" : [
+				{ "type" : "string" },
+				{
+					"type" : "array",
+					"items" : { "type" : "string" },
+					"minItems" : 1
+				}
+			],
+			"description" : "Native terrain for creatures. Supports either single terrain string or array of terrain strings"
 		},
 		"boat" : {
 			"type" : "string",

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -55,8 +55,9 @@ Each town requires a set of buildings (Around 30-45 buildings)
 	// Optional but it should be present for playable faction
 	"town" : { ... },
 
-	// Native terrain for creatures. Creatures fighting on native terrain receive several bonuses
-	"nativeTerrain" : "grass",
+	// Native terrain for creatures. Supports single terrain or array of terrains.
+	// Creatures fighting on one of native terrains receive several bonuses
+	"nativeTerrain" : ["grass", "dirt"],
 
 	// Localizable faction name, e.g. "Rampart"
 	"name" : "", 

--- a/include/vcmi/Entity.h
+++ b/include/vcmi/Entity.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <vector>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class IBonusBearer;
@@ -26,6 +28,7 @@ class DLL_LINKAGE INativeTerrainProvider
 {
 public:
 	virtual TerrainId getNativeTerrain() const = 0;
+	virtual std::vector<TerrainId> getNativeTerrains() const;
 	virtual FactionID getFactionID() const = 0;
 	virtual bool isNativeTerrain(TerrainId terrain) const;
 };

--- a/lib/BasicTypes.cpp
+++ b/lib/BasicTypes.cpp
@@ -24,10 +24,20 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+std::vector<TerrainId> INativeTerrainProvider::getNativeTerrains() const
+{
+	return {getNativeTerrain()};
+}
+
 bool INativeTerrainProvider::isNativeTerrain(TerrainId terrain) const
 {
-	auto native = getNativeTerrain();
-	return native == terrain || native == ETerrainId::ANY_TERRAIN;
+	for(const auto & nativeTerrain : getNativeTerrains())
+	{
+		if(nativeTerrain == terrain || nativeTerrain == ETerrainId::ANY_TERRAIN)
+			return true;
+	}
+
+	return false;
 }
 
 TerrainId AFactionMember::getNativeTerrain() const

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -281,8 +281,7 @@ bool CStack::canBeHealed() const
 
 bool CStack::isOnNativeTerrain() const
 {
-	auto nativeTerrain = getNativeTerrain();
-	return nativeTerrain == ETerrainId::ANY_TERRAIN || getCurrentTerrain() == nativeTerrain;
+	return isNativeTerrain(getCurrentTerrain());
 }
 
 TerrainId CStack::getCurrentTerrain() const

--- a/lib/bonuses/Limiters.cpp
+++ b/lib/bonuses/Limiters.cpp
@@ -327,8 +327,7 @@ ILimiter::EDecision TerrainLimiter::limit(const BonusLimitationContext &context)
 			return ILimiter::EDecision::NOT_SURE;
 
 		const auto * node = dynamic_cast<const INativeTerrainProvider *>(&context.node);
-		auto nativeTerrain = node->getFactionID().toEntity(LIBRARY)->getNativeTerrain();
-		return currentTerrain == nativeTerrain ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;
+		return node->isNativeTerrain(currentTerrain) ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;
 	}
 
 	return currentTerrain == terrainType ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;

--- a/lib/entities/faction/CFaction.cpp
+++ b/lib/entities/faction/CFaction.cpp
@@ -108,7 +108,15 @@ BoatId CFaction::getBoatType() const
 
 TerrainId CFaction::getNativeTerrain() const
 {
-	return nativeTerrain;
+	if(nativeTerrains.empty())
+		return TerrainId::NONE;
+
+	return nativeTerrains.front();
+}
+
+std::vector<TerrainId> CFaction::getNativeTerrains() const
+{
+	return nativeTerrains;
 }
 
 void CFaction::updateFrom(const JsonNode & data)

--- a/lib/entities/faction/CFaction.h
+++ b/lib/entities/faction/CFaction.h
@@ -42,7 +42,7 @@ class DLL_LINKAGE CFaction : public Faction
 	FactionID getFactionID() const override; //This function should not be used
 
 public:
-	TerrainId nativeTerrain;
+	std::vector<TerrainId> nativeTerrains;
 	EAlignment alignment = EAlignment::NEUTRAL;
 	bool preferUndergroundPlacement = false;
 	bool special = false;
@@ -75,6 +75,7 @@ public:
 
 	bool hasTown() const override;
 	TerrainId getNativeTerrain() const override;
+	std::vector<TerrainId> getNativeTerrains() const override;
 	EAlignment getAlignment() const override;
 	BoatId getBoatType() const override;
 

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -795,13 +795,44 @@ std::shared_ptr<CFaction> CTownHandler::loadFromJson(const std::string & scope, 
 	// Towns without one are exceptions. So, vcmi requires nativeTerrain to be defined
 	// But allows it to be defined with explicit value of "none" if town should not have native terrain
 	// This is better than allowing such terrain-less towns silently, leading to issues with RMG
-	faction->nativeTerrain = ETerrainId::NONE;
-	if (!source["nativeTerrain"].isNull() && source["nativeTerrain"].String() != "none")
+	faction->nativeTerrains = {ETerrainId::NONE};
+	if(!source["nativeTerrain"].isNull())
 	{
-		LIBRARY->identifiers()->requestIdentifier("terrain", source["nativeTerrain"], [=](int32_t index){
-			faction->nativeTerrain = TerrainId(index);
-		});
+		bool hasNativeTerrainDefinition = false;
+
+		if(source["nativeTerrain"].getType() == JsonNode::JsonType::DATA_STRING)
+		{
+			if(source["nativeTerrain"].String() != "none")
+			{
+				hasNativeTerrainDefinition = true;
+				faction->nativeTerrains.clear();
+				LIBRARY->identifiers()->requestIdentifier("terrain", source["nativeTerrain"], [=](int32_t index)
+				{
+					faction->nativeTerrains.push_back(TerrainId(index));
+				});
+			}
+		}
+		else if(source["nativeTerrain"].getType() == JsonNode::JsonType::DATA_VECTOR)
+		{
+			for(const auto & nativeTerrainNode : source["nativeTerrain"].Vector())
+			{
+				if(nativeTerrainNode.String() == "none")
+					continue;
+
+				if(!hasNativeTerrainDefinition)
+				{
+					hasNativeTerrainDefinition = true;
+					faction->nativeTerrains.clear();
+				}
+
+				LIBRARY->identifiers()->requestIdentifier("terrain", nativeTerrainNode, [=](int32_t index)
+				{
+					faction->nativeTerrains.push_back(TerrainId(index));
+				});
+			}
+		}
 	}
+
 
 	if (!source["town"].isNull())
 	{

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -92,18 +92,36 @@ const IBonusBearer* CGHeroInstance::getBonusBearer() const
 
 TerrainId CGHeroInstance::getNativeTerrain() const
 {
-	TerrainId nativeTerrain = ETerrainId::ANY_TERRAIN;
+	auto nativeTerrains = getNativeTerrains();
+	if(nativeTerrains.empty())
+		return ETerrainId::NONE;
+
+	return nativeTerrains.front();
+}
+
+std::vector<TerrainId> CGHeroInstance::getNativeTerrains() const
+{
+	std::vector<TerrainId> nativeTerrains = {ETerrainId::ANY_TERRAIN};
 
 	for(const auto & stack : stacks)
 	{
-		TerrainId stackNativeTerrain = stack.second->getNativeTerrain(); //consider terrain bonuses e.g. Lodestar.
+		auto stackNativeTerrains = stack.second->getNativeTerrains();
+		if(vstd::contains(stackNativeTerrains, TerrainId(ETerrainId::ANY_TERRAIN)))
+			continue;
 
-		if(nativeTerrain == ETerrainId::ANY_TERRAIN)
-			nativeTerrain = stackNativeTerrain;
-		else if(nativeTerrain != stackNativeTerrain)
-			return ETerrainId::NONE;
+		if(vstd::contains(nativeTerrains, TerrainId(ETerrainId::ANY_TERRAIN)))
+			nativeTerrains = stackNativeTerrains;
+		else
+			vstd::erase_if(nativeTerrains, [&](const TerrainId & terrain) -> bool
+			{
+				return !vstd::contains(stackNativeTerrains, terrain);
+			});
+
+		if(nativeTerrains.empty())
+			return {ETerrainId::NONE};
 	}
-	return nativeTerrain;
+
+	return nativeTerrains;
 }
 
 bool CGHeroInstance::isCoastVisitable() const

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -169,6 +169,7 @@ public:
 	//INativeTerrainProvider
 	FactionID getFactionID() const override;
 	TerrainId getNativeTerrain() const override;
+	std::vector<TerrainId> getNativeTerrains() const override;
 	int getLowestCreatureSpeed() const;
 	si32 manaRegain() const; //how many points of mana can hero regain "naturally" in one day
 	si32 getManaNewTurn() const; //calculate how much mana this hero is going to have the next day

--- a/lib/mapObjects/army/CStackInstance.cpp
+++ b/lib/mapObjects/army/CStackInstance.cpp
@@ -257,6 +257,14 @@ TerrainId CStackInstance::getNativeTerrain() const
 	return getFactionID().toEntity(LIBRARY)->getNativeTerrain();
 }
 
+std::vector<TerrainId> CStackInstance::getNativeTerrains() const
+{
+	if(nativeTerrain.hasBonus())
+		return {TerrainId::ANY_TERRAIN};
+
+	return getFactionID().toEntity(LIBRARY)->getNativeTerrains();
+}
+
 TerrainId CStackInstance::getCurrentTerrain() const
 {
 	if (armyInstance)

--- a/lib/mapObjects/army/CStackInstance.h
+++ b/lib/mapObjects/army/CStackInstance.h
@@ -96,6 +96,7 @@ public:
 	const IBonusBearer * getBonusBearer() const override;
 	//INativeTerrainProvider
 	FactionID getFactionID() const override;
+	std::vector<TerrainId> getNativeTerrains() const override;
 
 	virtual ui64 getPower() const;
 	/// Returns total market value of resources needed to recruit this unit

--- a/lib/pathfinder/TurnInfo.cpp
+++ b/lib/pathfinder/TurnInfo.cpp
@@ -170,12 +170,14 @@ TurnInfo::TurnInfo(TurnInfoCache * sharedCache, const CGHeroInstance * target, i
 			noterrainPenalty.at(affectedTerrain.num) = true;
 		}
 
-		const auto nativeTerrain = target->getNativeTerrain();
-		if (nativeTerrain.hasValue())
-			noterrainPenalty.at(nativeTerrain.num) = true;
+		for(const auto & nativeTerrain : target->getNativeTerrains())
+		{
+			if(nativeTerrain.hasValue())
+				noterrainPenalty.at(nativeTerrain.num) = true;
 
-		if (nativeTerrain == ETerrainId::ANY_TERRAIN)
-			boost::range::fill(noterrainPenalty, true);
+			if(nativeTerrain == ETerrainId::ANY_TERRAIN)
+				boost::range::fill(noterrainPenalty, true);
+		}
 	}
 }
 

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -523,16 +523,26 @@ void CZonePlacer::prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const 
 				zonesToPlace.push_back(zone);
 			else
 			{
-				auto & tt = (*LIBRARY->townh)[faction]->nativeTerrain;
-				if(tt == ETerrainId::NONE)
+				auto nativeTerrains = (*LIBRARY->townh)[faction]->getNativeTerrains();
+				if(nativeTerrains.empty() || vstd::contains(nativeTerrains, TerrainId(ETerrainId::NONE)))
 				{
 					//any / random
 					zonesToPlace.push_back(zone);
 				}
 				else
 				{
-					const auto & terrainType = LIBRARY->terrainTypeHandler->getById(tt);
-					if(terrainType->isUnderground() && !terrainType->isSurface())
+					bool undergroundOnly = true;
+					for(const auto & nativeTerrain : nativeTerrains)
+					{
+						const auto & terrainType = LIBRARY->terrainTypeHandler->getById(nativeTerrain);
+						if(terrainType->isSurface())
+						{
+							undergroundOnly = false;
+							break;
+						}
+					}
+
+					if(undergroundOnly)
 					{
 						//underground only
 						zonesOnLevel[1]++;

--- a/lib/rmg/modificators/TerrainPainter.cpp
+++ b/lib/rmg/modificators/TerrainPainter.cpp
@@ -60,9 +60,10 @@ void TerrainPainter::initTerrainType()
 	{
 		if(zone.isMatchTerrainToTown() && zone.getTownType() != ETownType::NEUTRAL)
 		{
-			auto terrainType = (*LIBRARY->townh)[zone.getTownType()]->nativeTerrain;
+			auto nativeTerrains = (*LIBRARY->townh)[zone.getTownType()]->getNativeTerrains();
+			auto terrainType = nativeTerrains.empty() ? TerrainId(ETerrainId::NONE) : *RandomGeneratorUtil::nextItem(nativeTerrains, zone.getRand());
 
-			if (terrainType <= ETerrainId::NONE)
+			if(terrainType <= ETerrainId::NONE)
 			{
 				logGlobal->warn("Town %s has invalid terrain type: %d", zone.getTownType(), terrainType);
 				zone.setTerrainType(ETerrainId::DIRT);


### PR DESCRIPTION
### Motivation
- Factions currently expose a single `nativeTerrain` but we need to allow specifying multiple native terrains (vector) so bonuses and RMG/AI logic can consider several terrain types.
- All subsystems that query or compare native terrain must be updated to accept either a single string or an array from JSON and work with a list at runtime.

### Description
- Added `INativeTerrainProvider::getNativeTerrains()` and made `isNativeTerrain` iterate over the returned list so providers can expose multiple native terrains while preserving legacy `getNativeTerrain()` behavior.
- Replaced `CFaction::nativeTerrain` with `CFaction::nativeTerrains` (`std::vector<TerrainId>`) and added `CFaction::getNativeTerrains()`; `getNativeTerrain()` continues to return the first/legacy value.
- Updated `CTownHandler` faction loader to accept `nativeTerrain` as either a string or an array of strings (and to treat `"none"` correctly), and updated JSON schema and docs to document array support.
- Propagated multi-terrain logic across systems: stacks/hero instances expose native-terrain lists, `CGHeroInstance` computes the intersection across stacks, `CStack::isOnNativeTerrain` and bonus limiters use the new provider API, `TurnInfo` considers all native terrains for no-penalty handling, RMG (`CZonePlacer`, `TerrainPainter`) now respects multiple native terrains, and AI scout/unit selection uses the provider check.
- Minor header change: added `#include <vector>` to the entity header for the new API.

### Testing
- Ran `git diff --check` with no whitespace or diff-check issues detected.
- Ran CMake configure (`cmake -S /workspace/vcmi -B /workspace/vcmi/build -G Ninja`) which aborted due to missing Boost development packages in the environment, so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999aeb5356c832d833c1515d8a2388e)