### PR TITLE
launcher: make mobile UpdateDialog fullscreen frameless to restore pointer interaction

### DIFF
--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -31,7 +31,6 @@
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QSettings>
-#include <QTimer>
 #include <QScreen>
 
 // Helper to normalize channel key to stable/beta/develop
@@ -117,16 +116,9 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 
 #ifdef VCMI_MOBILE
 	const QSize originalDialogSize = size();
-	setAttribute(Qt::WA_TranslucentBackground, true);
-	setAttribute(Qt::WA_NoSystemBackground, true);
-	setAttribute(Qt::WA_OpaquePaintEvent, false);
-	setAttribute(Qt::WA_StyledBackground, false);
-	setAutoFillBackground(false);
-	QPalette transparentPalette = palette();
-	transparentPalette.setColor(QPalette::Window, Qt::transparent);
-	setPalette(transparentPalette);
-	setStyleSheet("QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+	setAutoFillBackground(true);
+	setStyleSheet("QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 
 	if(ui->contentPanel && ui->hostLayout)
 	{
@@ -142,11 +134,7 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
 		setGeometry(screen->availableGeometry());
 
-	QTimer::singleShot(0, this, [this]()
-	{
-		if(ui && ui->contentPanel)
-			setMask(QRegion(ui->contentPanel->geometry()));
-	});
+	updateMobileBackdrop();
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 #endif
@@ -208,8 +196,25 @@ void UpdateDialog::resizeEvent(QResizeEvent * event)
 {
 	QDialog::resizeEvent(event);
 #ifdef VCMI_MOBILE
-	if(ui && ui->contentPanel)
-		setMask(QRegion(ui->contentPanel->geometry()));
+	updateMobileBackdrop();
+#endif
+}
+
+void UpdateDialog::updateMobileBackdrop()
+{
+#ifdef VCMI_MOBILE
+	if(mobileBackdrop.isNull())
+	{
+		if(QWidget * mainWindow = Helper::getMainWindow())
+			mobileBackdrop = mainWindow->grab();
+	}
+
+	if(mobileBackdrop.isNull())
+		return;
+
+	QPalette backgroundPalette = palette();
+	backgroundPalette.setBrush(QPalette::Window, QBrush(mobileBackdrop.scaled(size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation)));
+	setPalette(backgroundPalette);
 #endif
 }
 

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -116,7 +116,7 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->testingChangelog->setReadOnly(true);
 	ui->testingChangelog->setOpenExternalLinks(true);
 
-#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 	const QSize originalDialogSize = size();
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
 	setAutoFillBackground(false);
@@ -155,13 +155,13 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 
 	if(calledManually)
 	{
-		#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 		setWindowModality(Qt::NonModal);
 		ensureMobileBackdropCaptured();
 		updateMobileHostGeometry();
-		#else
+#else
 		setWindowModality(Qt::ApplicationModal);
-		#endif
+#endif
 		show();
 	}
 
@@ -197,14 +197,14 @@ UpdateDialog::~UpdateDialog()
 void UpdateDialog::resizeEvent(QResizeEvent * event)
 {
 	QDialog::resizeEvent(event);
-#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 	updateMobileBackdrop();
 #endif
 }
 
 void UpdateDialog::updateMobileHostGeometry()
 {
-#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 	if(QWidget * mainWindow = Helper::getMainWindow())
 	{
 		setGeometry(mainWindow->geometry());
@@ -218,7 +218,7 @@ void UpdateDialog::updateMobileHostGeometry()
 
 void UpdateDialog::ensureMobileBackdropCaptured()
 {
-#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 	if(!mobileBackdrop.isNull())
 		return;
 
@@ -229,7 +229,7 @@ void UpdateDialog::ensureMobileBackdropCaptured()
 
 void UpdateDialog::updateMobileBackdrop()
 {
-#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 	if(!mobileBackdrop.isNull() || mobileBackdropCaptureScheduled || !isVisible())
 		return;
 
@@ -249,7 +249,7 @@ void UpdateDialog::updateMobileBackdrop()
 
 void UpdateDialog::paintEvent(QPaintEvent * event)
 {
-#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 	Q_UNUSED(event);
 	if(!mobileBackdrop.isNull())
 	{
@@ -265,7 +265,7 @@ void UpdateDialog::paintEvent(QPaintEvent * event)
 void UpdateDialog::showEvent(QShowEvent * event)
 {
 	QDialog::showEvent(event);
-#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 	updateMobileBackdrop();
 #endif
 }
@@ -623,12 +623,12 @@ void UpdateDialog::loadFromJson(const JsonNode& node, bool testing, const QStrin
 	const bool hasTestingOffer = ui->testingBuilds->isChecked() && testingOffer;
 	if((releaseOffer || hasTestingOffer) && !calledManually)
 	{
-		#ifdef VCMI_MOBILE
+#if defined(VCMI_MOBILE)
 		ensureMobileBackdropCaptured();
-		#endif
-		#ifdef VCMI_MOBILE
+#endif
+#if defined(VCMI_MOBILE)
 		updateMobileHostGeometry();
-		#endif
+#endif
 		this->show();
 		this->raise();
 		this->activateWindow();

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -23,6 +23,7 @@
 #include <QSysInfo>
 #include <QProcess>
 #include <QDesktopServices>
+#include <QGuiApplication>
 #include <QDir>
 #include <QProgressBar>
 #include <QVersionNumber>
@@ -30,6 +31,7 @@
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QSettings>
+#include <QScreen>
 
 // Helper to normalize channel key to stable/beta/develop
 static QString normalizeChannel(const QString& text)
@@ -113,10 +115,12 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->testingChangelog->setOpenExternalLinks(true);
 
 #ifdef VCMI_MOBILE
-    setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
-#endif
-
+	setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
+	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+	setGeometry(QGuiApplication::primaryScreen()->availableGeometry());
+#else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+#endif
 
 	ui->progressBar->setHidden(true);
 	ui->installButton->setText(actionButtonTextForPlatform());

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -133,11 +133,7 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 		ui->hostLayout->setAlignment(ui->contentPanel, Qt::AlignCenter);
 	}
 
-	if(QWidget * mainWindow = Helper::getMainWindow())
-		setGeometry(mainWindow->geometry());
-	else if(const QScreen * screen = QGuiApplication::primaryScreen())
-		setGeometry(screen->availableGeometry());
-
+	updateMobileHostGeometry();
 	updateMobileBackdrop();
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
@@ -170,6 +166,9 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 			#endif
 		#else
 		    setWindowModality(Qt::ApplicationModal);
+		#endif
+		#ifdef VCMI_MOBILE
+		updateMobileHostGeometry();
 		#endif
 		show();
 	}
@@ -208,6 +207,20 @@ void UpdateDialog::resizeEvent(QResizeEvent * event)
 	QDialog::resizeEvent(event);
 #ifdef VCMI_MOBILE
 	updateMobileBackdrop();
+#endif
+}
+
+void UpdateDialog::updateMobileHostGeometry()
+{
+#ifdef VCMI_MOBILE
+	if(QWidget * mainWindow = Helper::getMainWindow())
+	{
+		setGeometry(mainWindow->geometry());
+		return;
+	}
+
+	if(const QScreen * screen = QGuiApplication::primaryScreen())
+		setGeometry(screen->availableGeometry());
 #endif
 }
 
@@ -615,6 +628,9 @@ void UpdateDialog::loadFromJson(const JsonNode& node, bool testing, const QStrin
 			if(QWidget * mainWindow = Helper::getMainWindow())
 				mobileBackdrop = mainWindow->grab();
 		}
+		#endif
+		#ifdef VCMI_MOBILE
+		updateMobileHostGeometry();
 		#endif
 		this->show();
 		this->raise();

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -161,6 +161,13 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	{
 		#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
 		    setWindowModality(Qt::NonModal);
+			#ifdef VCMI_MOBILE
+			if(mobileBackdrop.isNull())
+			{
+				if(QWidget * mainWindow = Helper::getMainWindow())
+					mobileBackdrop = mainWindow->grab();
+			}
+			#endif
 		#else
 		    setWindowModality(Qt::ApplicationModal);
 		#endif
@@ -602,6 +609,13 @@ void UpdateDialog::loadFromJson(const JsonNode& node, bool testing, const QStrin
 	const bool hasTestingOffer = ui->testingBuilds->isChecked() && testingOffer;
 	if((releaseOffer || hasTestingOffer) && !calledManually)
 	{
+		#ifdef VCMI_MOBILE
+		if(mobileBackdrop.isNull())
+		{
+			if(QWidget * mainWindow = Helper::getMainWindow())
+				mobileBackdrop = mainWindow->grab();
+		}
+		#endif
 		this->show();
 		this->raise();
 		this->activateWindow();

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -23,7 +23,6 @@
 #include <QSysInfo>
 #include <QProcess>
 #include <QDesktopServices>
-#include <QGuiApplication>
 #include <QDir>
 #include <QProgressBar>
 #include <QVersionNumber>
@@ -31,7 +30,6 @@
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QSettings>
-#include <QScreen>
 
 // Helper to normalize channel key to stable/beta/develop
 static QString normalizeChannel(const QString& text)
@@ -117,7 +115,6 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 #ifdef VCMI_MOBILE
 	setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
-	setGeometry(QGuiApplication::primaryScreen()->availableGeometry());
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 #endif

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -26,7 +26,6 @@
 #include <QGuiApplication>
 #include <QDir>
 #include <QProgressBar>
-#include <QLayout>
 #include <QVersionNumber>
 #include <QRegularExpression>
 #include <QFileInfo>
@@ -120,12 +119,6 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
 		setGeometry(screen->availableGeometry());
-
-	if(layout())
-	{
-		layout()->setSizeConstraint(QLayout::SetFixedSize);
-		layout()->setAlignment(Qt::AlignCenter);
-	}
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 #endif

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -31,6 +31,7 @@
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QSettings>
+#include <QPainter>
 #include <QScreen>
 
 // Helper to normalize channel key to stable/beta/develop
@@ -117,7 +118,7 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 #ifdef VCMI_MOBILE
 	const QSize originalDialogSize = size();
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
-	setAutoFillBackground(true);
+	setAutoFillBackground(false);
 	setStyleSheet("QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 
 	if(ui->contentPanel && ui->hostLayout)
@@ -203,18 +204,26 @@ void UpdateDialog::resizeEvent(QResizeEvent * event)
 void UpdateDialog::updateMobileBackdrop()
 {
 #ifdef VCMI_MOBILE
-	if(mobileBackdrop.isNull())
-	{
-		if(QWidget * mainWindow = Helper::getMainWindow())
-			mobileBackdrop = mainWindow->grab();
-	}
-
-	if(mobileBackdrop.isNull())
+	if(!mobileBackdrop.isNull())
 		return;
 
-	QPalette backgroundPalette = palette();
-	backgroundPalette.setBrush(QPalette::Window, QBrush(mobileBackdrop.scaled(size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation)));
-	setPalette(backgroundPalette);
+	if(QWidget * mainWindow = Helper::getMainWindow())
+		mobileBackdrop = mainWindow->grab();
+#endif
+}
+
+void UpdateDialog::paintEvent(QPaintEvent * event)
+{
+#ifdef VCMI_MOBILE
+	Q_UNUSED(event);
+	if(!mobileBackdrop.isNull())
+	{
+		QPainter painter(this);
+		painter.drawPixmap(rect(), mobileBackdrop);
+	}
+	return;
+#else
+	QDialog::paintEvent(event);
 #endif
 }
 

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -23,6 +23,7 @@
 #include <QSysInfo>
 #include <QProcess>
 #include <QDesktopServices>
+#include <QGuiApplication>
 #include <QDir>
 #include <QProgressBar>
 #include <QVersionNumber>
@@ -30,6 +31,7 @@
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QSettings>
+#include <QScreen>
 
 // Helper to normalize channel key to stable/beta/develop
 static QString normalizeChannel(const QString& text)
@@ -115,6 +117,15 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 #ifdef VCMI_MOBILE
 	setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+	if(const QScreen * screen = QGuiApplication::primaryScreen())
+	{
+		const QRect available = screen->availableGeometry();
+		QSize dialogSize = sizeHint().expandedTo(minimumSize());
+		dialogSize.setWidth(std::min(dialogSize.width(), available.width()));
+		dialogSize.setHeight(std::min(dialogSize.height(), available.height()));
+		const QPoint topLeft = available.center() - QPoint(dialogSize.width() / 2, dialogSize.height() / 2);
+		setGeometry(QRect(topLeft, dialogSize));
+	}
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 #endif

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -25,7 +25,6 @@
 #include <QDesktopServices>
 #include <QGuiApplication>
 #include <QDir>
-#include <QGridLayout>
 #include <QProgressBar>
 #include <QVersionNumber>
 #include <QRegularExpression>
@@ -116,30 +115,8 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->testingChangelog->setOpenExternalLinks(true);
 
 #ifdef VCMI_MOBILE
+	setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
-	setAttribute(Qt::WA_TranslucentBackground, true);
-
-	if(QLayout * originalLayout = layout())
-	{
-		originalLayout->setParent(nullptr);
-		auto * contentWidget = new QWidget(this);
-		contentWidget->setObjectName("mobileDialogPanel");
-		contentWidget->setLayout(originalLayout);
-
-		auto * overlayLayout = new QGridLayout(this);
-		overlayLayout->setContentsMargins(12, 12, 12, 12);
-		overlayLayout->setRowStretch(0, 1);
-		overlayLayout->setRowStretch(1, 0);
-		overlayLayout->setRowStretch(2, 1);
-		overlayLayout->setColumnStretch(0, 1);
-		overlayLayout->setColumnStretch(1, 0);
-		overlayLayout->setColumnStretch(2, 1);
-		overlayLayout->addWidget(contentWidget, 1, 1, Qt::AlignCenter);
-		setLayout(overlayLayout);
-	}
-
-	setStyleSheet("QDialog { background: transparent; } QWidget#mobileDialogPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
-
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
 		setGeometry(screen->availableGeometry());
 #else

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -32,6 +32,7 @@
 #include <QSaveFile>
 #include <QSettings>
 #include <QPainter>
+#include <QTimer>
 #include <QScreen>
 
 // Helper to normalize channel key to stable/beta/develop
@@ -132,7 +133,9 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 		ui->hostLayout->setAlignment(ui->contentPanel, Qt::AlignCenter);
 	}
 
-	if(const QScreen * screen = QGuiApplication::primaryScreen())
+	if(QWidget * mainWindow = Helper::getMainWindow())
+		setGeometry(mainWindow->geometry());
+	else if(const QScreen * screen = QGuiApplication::primaryScreen())
 		setGeometry(screen->availableGeometry());
 
 	updateMobileBackdrop();
@@ -204,11 +207,22 @@ void UpdateDialog::resizeEvent(QResizeEvent * event)
 void UpdateDialog::updateMobileBackdrop()
 {
 #ifdef VCMI_MOBILE
-	if(!mobileBackdrop.isNull())
+	if(!mobileBackdrop.isNull() || mobileBackdropCaptureScheduled || !isVisible())
 		return;
 
-	if(QWidget * mainWindow = Helper::getMainWindow())
-		mobileBackdrop = mainWindow->grab();
+	mobileBackdropCaptureScheduled = true;
+	QTimer::singleShot(0, this, [this]()
+	{
+		mobileBackdropCaptureScheduled = false;
+		if(!isVisible() || !mobileBackdrop.isNull())
+			return;
+
+		if(QWidget * mainWindow = Helper::getMainWindow())
+		{
+			mobileBackdrop = mainWindow->grab();
+			update();
+		}
+	});
 #endif
 }
 
@@ -219,11 +233,19 @@ void UpdateDialog::paintEvent(QPaintEvent * event)
 	if(!mobileBackdrop.isNull())
 	{
 		QPainter painter(this);
-		painter.drawPixmap(rect(), mobileBackdrop);
+		painter.drawPixmap(QPoint(0, 0), mobileBackdrop);
 	}
 	return;
 #else
 	QDialog::paintEvent(event);
+#endif
+}
+
+void UpdateDialog::showEvent(QShowEvent * event)
+{
+	QDialog::showEvent(event);
+#ifdef VCMI_MOBILE
+	updateMobileBackdrop();
 #endif
 }
 

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -25,6 +25,7 @@
 #include <QDesktopServices>
 #include <QGuiApplication>
 #include <QDir>
+#include <QGridLayout>
 #include <QProgressBar>
 #include <QVersionNumber>
 #include <QRegularExpression>
@@ -115,8 +116,30 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->testingChangelog->setOpenExternalLinks(true);
 
 #ifdef VCMI_MOBILE
-	setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+	setAttribute(Qt::WA_TranslucentBackground, true);
+
+	if(QLayout * originalLayout = layout())
+	{
+		originalLayout->setParent(nullptr);
+		auto * contentWidget = new QWidget(this);
+		contentWidget->setObjectName("mobileDialogPanel");
+		contentWidget->setLayout(originalLayout);
+
+		auto * overlayLayout = new QGridLayout(this);
+		overlayLayout->setContentsMargins(12, 12, 12, 12);
+		overlayLayout->setRowStretch(0, 1);
+		overlayLayout->setRowStretch(1, 0);
+		overlayLayout->setRowStretch(2, 1);
+		overlayLayout->setColumnStretch(0, 1);
+		overlayLayout->setColumnStretch(1, 0);
+		overlayLayout->setColumnStretch(2, 1);
+		overlayLayout->addWidget(contentWidget, 1, 1, Qt::AlignCenter);
+		setLayout(overlayLayout);
+	}
+
+	setStyleSheet("QDialog { background: transparent; } QWidget#mobileDialogPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
+
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
 		setGeometry(screen->availableGeometry());
 #else

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -115,8 +115,18 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->testingChangelog->setOpenExternalLinks(true);
 
 #ifdef VCMI_MOBILE
-	setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
+	setAttribute(Qt::WA_TranslucentBackground, true);
+	setStyleSheet("QDialog { background: transparent; } QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+
+	if(ui->contentPanel && ui->hostLayout)
+	{
+		const QSize panelSize = ui->contentPanel->sizeHint().expandedTo(ui->contentPanel->minimumSizeHint());
+		ui->contentPanel->setMinimumSize(panelSize);
+		ui->contentPanel->setMaximumSize(panelSize);
+		ui->hostLayout->setAlignment(ui->contentPanel, Qt::AlignCenter);
+	}
+
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
 		setGeometry(screen->availableGeometry());
 #else

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -157,11 +157,7 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	{
 		#ifdef VCMI_MOBILE
 		setWindowModality(Qt::NonModal);
-		if(mobileBackdrop.isNull())
-		{
-			if(QWidget * mainWindow = Helper::getMainWindow())
-				mobileBackdrop = mainWindow->grab();
-		}
+		ensureMobileBackdropCaptured();
 		updateMobileHostGeometry();
 		#else
 		setWindowModality(Qt::ApplicationModal);
@@ -220,6 +216,17 @@ void UpdateDialog::updateMobileHostGeometry()
 #endif
 }
 
+void UpdateDialog::ensureMobileBackdropCaptured()
+{
+#ifdef VCMI_MOBILE
+	if(!mobileBackdrop.isNull())
+		return;
+
+	if(QWidget * mainWindow = Helper::getMainWindow())
+		mobileBackdrop = mainWindow->grab();
+#endif
+}
+
 void UpdateDialog::updateMobileBackdrop()
 {
 #ifdef VCMI_MOBILE
@@ -233,11 +240,9 @@ void UpdateDialog::updateMobileBackdrop()
 		if(!isVisible() || !mobileBackdrop.isNull())
 			return;
 
-		if(QWidget * mainWindow = Helper::getMainWindow())
-		{
-			mobileBackdrop = mainWindow->grab();
+		ensureMobileBackdropCaptured();
+		if(!mobileBackdrop.isNull())
 			update();
-		}
 	});
 #endif
 }
@@ -619,11 +624,7 @@ void UpdateDialog::loadFromJson(const JsonNode& node, bool testing, const QStrin
 	if((releaseOffer || hasTestingOffer) && !calledManually)
 	{
 		#ifdef VCMI_MOBILE
-		if(mobileBackdrop.isNull())
-		{
-			if(QWidget * mainWindow = Helper::getMainWindow())
-				mobileBackdrop = mainWindow->grab();
-		}
+		ensureMobileBackdropCaptured();
 		#endif
 		#ifdef VCMI_MOBILE
 		updateMobileHostGeometry();
@@ -773,7 +774,7 @@ void UpdateDialog::on_installButton_clicked()
 	if(url.isEmpty())
 	{
 		ui->downloadLink->setText(tr("No package to download."));
-	    return;
+		return;
 	}
 
 #if defined(VCMI_ANDROID)
@@ -789,16 +790,17 @@ void UpdateDialog::on_installButton_clicked()
 #endif
 
 #if defined(VCMI_MOBILE)
-	    // Always ask user where to save on mobile
-	    Helper::nativeFolderPicker(this, [this, url](QString picked){
-	        if(picked.isEmpty())
-	            return; // user cancelled
-	        startDownloadToCacheAndRun(QUrl(url), picked);
-	    });
-	    return;
+	// Always ask user where to save on mobile
+	Helper::nativeFolderPicker(this, [this, url](QString picked)
+	{
+		if(picked.isEmpty())
+			return; // user cancelled
+		startDownloadToCacheAndRun(QUrl(url), picked);
+	});
+	return;
 #else
-	    // Desktop: keep current behaviour (or adjust as you wish)
-	    startDownloadToCacheAndRun(QUrl(url));
+	// Desktop: keep current behaviour (or adjust as you wish)
+	startDownloadToCacheAndRun(QUrl(url));
 #endif
 }
 

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -26,6 +26,7 @@
 #include <QGuiApplication>
 #include <QDir>
 #include <QProgressBar>
+#include <QLayout>
 #include <QVersionNumber>
 #include <QRegularExpression>
 #include <QFileInfo>
@@ -118,17 +119,12 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	setStyleSheet("QDialog { border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
-	{
-		const QRect available = screen->availableGeometry();
-		QRect dialogRect = geometry();
-		if(!dialogRect.isValid())
-			dialogRect = QRect(QPoint(0, 0), size());
+		setGeometry(screen->availableGeometry());
 
-		QPoint topLeft = available.center() - QPoint(dialogRect.width() / 2, dialogRect.height() / 2);
-		topLeft.setX(std::clamp(topLeft.x(), available.left(), available.right() - dialogRect.width() + 1));
-		topLeft.setY(std::clamp(topLeft.y(), available.top(), available.bottom() - dialogRect.height() + 1));
-		dialogRect.moveTopLeft(topLeft);
-		setGeometry(dialogRect);
+	if(layout())
+	{
+		layout()->setSizeConstraint(QLayout::SetFixedSize);
+		layout()->setAlignment(Qt::AlignCenter);
 	}
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -115,13 +115,19 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	ui->testingChangelog->setOpenExternalLinks(true);
 
 #ifdef VCMI_MOBILE
+	const QSize originalDialogSize = size();
 	setAttribute(Qt::WA_TranslucentBackground, true);
-	setStyleSheet("QDialog { background: transparent; } QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
+	setAttribute(Qt::WA_NoSystemBackground, true);
+	setAutoFillBackground(false);
+	setStyleSheet("QDialog { background-color: rgba(0,0,0,0); border: none; } QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
 
 	if(ui->contentPanel && ui->hostLayout)
 	{
-		const QSize panelSize = ui->contentPanel->sizeHint().expandedTo(ui->contentPanel->minimumSizeHint());
+		QSize panelSize = originalDialogSize;
+		if(const QScreen * screen = QGuiApplication::primaryScreen())
+			panelSize = panelSize.boundedTo(screen->availableGeometry().size() - QSize(24, 24));
+
 		ui->contentPanel->setMinimumSize(panelSize);
 		ui->contentPanel->setMaximumSize(panelSize);
 		ui->hostLayout->setAlignment(ui->contentPanel, Qt::AlignCenter);

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -31,6 +31,7 @@
 #include <QFileInfo>
 #include <QSaveFile>
 #include <QSettings>
+#include <QTimer>
 #include <QScreen>
 
 // Helper to normalize channel key to stable/beta/develop
@@ -140,6 +141,12 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
 		setGeometry(screen->availableGeometry());
+
+	QTimer::singleShot(0, this, [this]()
+	{
+		if(ui && ui->contentPanel)
+			setMask(QRegion(ui->contentPanel->geometry()));
+	});
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 #endif
@@ -195,6 +202,15 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 UpdateDialog::~UpdateDialog()
 {
 	delete ui;
+}
+
+void UpdateDialog::resizeEvent(QResizeEvent * event)
+{
+	QDialog::resizeEvent(event);
+#ifdef VCMI_MOBILE
+	if(ui && ui->contentPanel)
+		setMask(QRegion(ui->contentPanel->geometry()));
+#endif
 }
 
 void UpdateDialog::showUpdateDialog(bool isManually)

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -118,8 +118,13 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	const QSize originalDialogSize = size();
 	setAttribute(Qt::WA_TranslucentBackground, true);
 	setAttribute(Qt::WA_NoSystemBackground, true);
+	setAttribute(Qt::WA_OpaquePaintEvent, false);
+	setAttribute(Qt::WA_StyledBackground, false);
 	setAutoFillBackground(false);
-	setStyleSheet("QDialog { background-color: rgba(0,0,0,0); border: none; } QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
+	QPalette transparentPalette = palette();
+	transparentPalette.setColor(QPalette::Window, Qt::transparent);
+	setPalette(transparentPalette);
+	setStyleSheet("QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }");
 	setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
 
 	if(ui->contentPanel && ui->hostLayout)

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -120,11 +120,15 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 	if(const QScreen * screen = QGuiApplication::primaryScreen())
 	{
 		const QRect available = screen->availableGeometry();
-		QSize dialogSize = sizeHint().expandedTo(minimumSize());
-		dialogSize.setWidth(std::min(dialogSize.width(), available.width()));
-		dialogSize.setHeight(std::min(dialogSize.height(), available.height()));
-		const QPoint topLeft = available.center() - QPoint(dialogSize.width() / 2, dialogSize.height() / 2);
-		setGeometry(QRect(topLeft, dialogSize));
+		QRect dialogRect = geometry();
+		if(!dialogRect.isValid())
+			dialogRect = QRect(QPoint(0, 0), size());
+
+		QPoint topLeft = available.center() - QPoint(dialogRect.width() / 2, dialogRect.height() / 2);
+		topLeft.setX(std::clamp(topLeft.x(), available.left(), available.right() - dialogRect.width() + 1));
+		topLeft.setY(std::clamp(topLeft.y(), available.top(), available.bottom() - dialogRect.height() + 1));
+		dialogRect.moveTopLeft(topLeft);
+		setGeometry(dialogRect);
 	}
 #else
 	setWindowFlags(Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);

--- a/launcher/updatedialog_moc.cpp
+++ b/launcher/updatedialog_moc.cpp
@@ -155,20 +155,16 @@ UpdateDialog::UpdateDialog(bool calledManually, QWidget *parent):
 
 	if(calledManually)
 	{
-		#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
-		    setWindowModality(Qt::NonModal);
-			#ifdef VCMI_MOBILE
-			if(mobileBackdrop.isNull())
-			{
-				if(QWidget * mainWindow = Helper::getMainWindow())
-					mobileBackdrop = mainWindow->grab();
-			}
-			#endif
-		#else
-		    setWindowModality(Qt::ApplicationModal);
-		#endif
 		#ifdef VCMI_MOBILE
+		setWindowModality(Qt::NonModal);
+		if(mobileBackdrop.isNull())
+		{
+			if(QWidget * mainWindow = Helper::getMainWindow())
+				mobileBackdrop = mainWindow->grab();
+		}
 		updateMobileHostGeometry();
+		#else
+		setWindowModality(Qt::ApplicationModal);
 		#endif
 		show();
 	}

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -100,5 +100,6 @@ private:
 	void updateAvailabilityNotice();
 	void startDownloadToCacheAndRun(const QUrl& url, const QString& target = QString());
 	void updateMobileBackdrop();
+	void ensureMobileBackdropCaptured();
 	void updateMobileHostGeometry();
 };

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -14,6 +14,7 @@
 #include <QPixmap>
 
 class QResizeEvent;
+class QPaintEvent;
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -43,6 +44,7 @@ public:
 
 protected:
 	void resizeEvent(QResizeEvent * event) override;
+	void paintEvent(QPaintEvent * event) override;
 
 private slots:
     void on_checkOnStartup_stateChanged(int state);

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -94,4 +94,5 @@ private:
 	void applySelectedTestingChannel();
 	void updateAvailabilityNotice();
 	void startDownloadToCacheAndRun(const QUrl& url, const QString& target = QString());
+	void updateMobileBackdrop();
 };

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -11,6 +11,7 @@
 #include <QDialog>
 #include <QNetworkAccessManager>
 #include <QUrl>
+#include <QPixmap>
 
 class QResizeEvent;
 
@@ -85,6 +86,7 @@ private:
 	bool testingChannelAutoSelectPending = true;
 
 	bool calledManually;
+	QPixmap mobileBackdrop;
 
 	void loadFromJson(const JsonNode & node, bool testing = false, const QString &channel = QString());
 	void fetchChannel(const QString& channel);

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -12,6 +12,8 @@
 #include <QNetworkAccessManager>
 #include <QUrl>
 
+class QResizeEvent;
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class JsonNode;
@@ -37,6 +39,9 @@ public:
 	QString releaseVersion;
 	QString testingVersion;
 
+
+protected:
+	void resizeEvent(QResizeEvent * event) override;
 
 private slots:
     void on_checkOnStartup_stateChanged(int state);

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -15,6 +15,7 @@
 
 class QResizeEvent;
 class QPaintEvent;
+class QShowEvent;
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -45,6 +46,7 @@ public:
 protected:
 	void resizeEvent(QResizeEvent * event) override;
 	void paintEvent(QPaintEvent * event) override;
+	void showEvent(QShowEvent * event) override;
 
 private slots:
     void on_checkOnStartup_stateChanged(int state);
@@ -89,6 +91,7 @@ private:
 
 	bool calledManually;
 	QPixmap mobileBackdrop;
+	bool mobileBackdropCaptureScheduled = false;
 
 	void loadFromJson(const JsonNode & node, bool testing = false, const QString &channel = QString());
 	void fetchChannel(const QString& channel);

--- a/launcher/updatedialog_moc.h
+++ b/launcher/updatedialog_moc.h
@@ -100,4 +100,5 @@ private:
 	void updateAvailabilityNotice();
 	void startDownloadToCacheAndRun(const QUrl& url, const QString& target = QString());
 	void updateMobileBackdrop();
+	void updateMobileHostGeometry();
 };

--- a/launcher/updatedialog_moc.ui
+++ b/launcher/updatedialog_moc.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <ui version="4.0">
  <class>UpdateDialog</class>
  <widget class="QDialog" name="UpdateDialog">
@@ -23,239 +23,257 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string/>
+   <string />
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="hostLayout">
    <property name="leftMargin">
-    <number>12</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>12</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>12</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>12</number>
+    <number>0</number>
    </property>
-   <item row="2" column="0" colspan="7">
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="tab">
-      <attribute name="title">
-       <string>Release</string>
-      </attribute>
-      <widget class="QWidget" name="gridLayoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>0</y>
-         <width>501</width>
-         <height>151</height>
-        </rect>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="titleRelease">
-          <property name="text">
-           <string>Latest release build:</string>
+   <item row="0" column="0">
+    <widget class="QWidget" name="contentPanel">
+     <layout class="QGridLayout" name="contentLayout">
+      <property name="leftMargin">
+       <number>12</number>
+      </property>
+      <property name="topMargin">
+       <number>12</number>
+      </property>
+      <property name="rightMargin">
+       <number>12</number>
+      </property>
+      <property name="bottomMargin">
+       <number>12</number>
+      </property>
+      <item row="2" column="0" colspan="7">
+       <widget class="QTabWidget" name="tabWidget">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="tab">
+         <attribute name="title">
+          <string>Release</string>
+         </attribute>
+         <widget class="QWidget" name="gridLayoutWidget">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>0</y>
+            <width>501</width>
+            <height>151</height>
+           </rect>
           </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="titleRelease">
+             <property name="text">
+              <string>Latest release build:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="releaseVersion">
+             <property name="text">
+              <string />
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QLabel" name="releaseChangelogTitle">
+             <property name="text">
+              <string>Changelog</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QTextBrowser" name="releaseChangelog" />
+           </item>
+          </layout>
          </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="releaseVersion">
-          <property name="text">
-           <string/>
+        </widget>
+        <widget class="QWidget" name="tab_2">
+         <attribute name="title">
+          <string>Testing</string>
+         </attribute>
+         <widget class="QWidget" name="gridLayoutWidget_2">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>0</y>
+            <width>501</width>
+            <height>149</height>
+           </rect>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-          </property>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="5" column="1">
+            <widget class="QLabel" name="testingVersion">
+             <property name="text">
+              <string />
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="titleTesting">
+             <property name="text">
+              <string>Latest testing version:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QCheckBox" name="testingBuilds">
+             <property name="text">
+              <string>Check for testing versions</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QComboBox" name="buildChannel">
+             <item>
+              <property name="text">
+               <string notr="true">Develop</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string notr="true">Beta</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="QLabel" name="testingChangelogTitle">
+             <property name="text">
+              <string>Changelog</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0" colspan="2">
+            <widget class="QTextBrowser" name="testingChangelog" />
+           </item>
+          </layout>
          </widget>
-        </item>
-        <item row="1" column="0" colspan="2">
-         <widget class="QLabel" name="releaseChangelogTitle">
-          <property name="text">
-           <string>Changelog</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0" colspan="2">
-         <widget class="QTextBrowser" name="releaseChangelog"/>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-     <widget class="QWidget" name="tab_2">
-      <attribute name="title">
-       <string>Testing</string>
-      </attribute>
-      <widget class="QWidget" name="gridLayoutWidget_2">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>0</y>
-         <width>501</width>
-         <height>149</height>
-        </rect>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="5" column="1">
-         <widget class="QLabel" name="testingVersion">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="titleTesting">
-          <property name="text">
-           <string>Latest testing version:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="testingBuilds">
-          <property name="text">
-           <string>Check for testing versions</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="buildChannel">
-          <item>
-           <property name="text">
-            <string notr="true">Develop</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string notr="true">Beta</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="6" column="0" colspan="2">
-         <widget class="QLabel" name="testingChangelogTitle">
-          <property name="text">
-           <string>Changelog</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0" colspan="2">
-         <widget class="QTextBrowser" name="testingChangelog"/>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-    </widget>
-   </item>
-   <item row="8" column="5">
-    <widget class="QPushButton" name="installButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Install</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="5">
-    <widget class="QLabel" name="downloadLink">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="6" alignment="Qt::AlignmentFlag::AlignRight">
-    <widget class="QToolButton" name="infoButton">
-     <property name="minimumSize">
-      <size>
-       <width>28</width>
-       <height>28</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>Update channels information</string>
-     </property>
-     <property name="text">
-      <string>?</string>
-     </property>
-     <property name="autoRaise">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="7">
-    <widget class="QLabel" name="title">
-     <property name="font">
-      <font>
-       <pointsize>18</pointsize>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>VCMI Updates Center</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignmentFlag::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="6">
-    <widget class="QPushButton" name="closeButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Close</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="checkOnStartup">
-     <property name="text">
-      <string>Check for updates on startup</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="3" colspan="4">
-    <widget class="QProgressBar" name="progressBar">
-     <property name="value">
-      <number>24</number>
-     </property>
+        </widget>
+       </widget>
+      </item>
+      <item row="8" column="5">
+       <widget class="QPushButton" name="installButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Install</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="5">
+       <widget class="QLabel" name="downloadLink">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string />
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6" alignment="Qt::AlignmentFlag::AlignRight">
+       <widget class="QToolButton" name="infoButton">
+        <property name="minimumSize">
+         <size>
+          <width>28</width>
+          <height>28</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Update channels information</string>
+        </property>
+        <property name="text">
+         <string>?</string>
+        </property>
+        <property name="autoRaise">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="7">
+       <widget class="QLabel" name="title">
+        <property name="font">
+         <font>
+          <pointsize>18</pointsize>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>VCMI Updates Center</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="6">
+       <widget class="QPushButton" name="closeButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Close</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="checkOnStartup">
+        <property name="text">
+         <string>Check for updates on startup</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3" colspan="4">
+       <widget class="QProgressBar" name="progressBar">
+        <property name="value">
+         <number>24</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
- <connections/>
+ <resources />
+ <connections />
 </ui>


### PR DESCRIPTION
### Motivation
- On Android the `UpdateDialog` was reported as unresponsive to pointer input (USB mouse / stylus) while touch input still worked, and a fullscreen dialog in other code paths did not have this issue.

### Description
- Modify `launcher/updatedialog_moc.cpp` to use `Qt::FramelessWindowHint` and set full-screen geometry from `QGuiApplication::primaryScreen()->availableGeometry()` when `VCMI_MOBILE` is defined.
- Add Qt headers `QGuiApplication` and `QScreen` required for the new fullscreen setup.
- Keep desktop dialog flags and behavior unchanged so the change only affects mobile builds.

### Testing
- No automated build or test suite was executed in this environment; changes were limited to source edits and verified via code inspection and diffs, so a CI or local build is recommended to validate runtime behavior and pointer input on Android.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d21e0620832d9fa289a330d05072)