### PR TITLE
Launcher: synthesize mouse events for tablet/stylus input

### DIFF
--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -49,6 +49,7 @@ int MAIN_EXPORT main(int argc, char * argv[])
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
+	QApplication::setAttribute(Qt::AA_SynthesizeMouseForUnhandledTabletEvents, true);
 	QApplication vcmilauncher(argc, argv);
 
 	// use system proxy


### PR DESCRIPTION
### Motivation
- Some widgets (notably the build-channel combobox in the Update dialog) only react to mouse input, causing stylus/tablet taps to be ignored; the change enables synthesizing mouse events for unhandled tablet events so those widgets respond to stylus input.

### Description
- Set `Qt::AA_SynthesizeMouseForUnhandledTabletEvents` to `true` early in launcher startup by adding `QApplication::setAttribute(Qt::AA_SynthesizeMouseForUnhandledTabletEvents, true);` in `launcher/main.cpp` before creating the `QApplication` instance.

### Testing
- Ran `git -C /workspace/vcmi diff --check` to validate the working tree changes and check for whitespace/errors, and it completed without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7016c758832db420693ac27e71a3)