### PR TITLE
Launcher: show content.zip extraction progress during install

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -716,6 +716,7 @@
 				"extraRepositoryURL",
 				"extraRepositoryEnabled",
 				"autoCheckRepositories",
+				"fullModExtraction",
 				"ignoreSslErrors",
 				"updateOnStartup",
 				"updateConfigUrl",
@@ -749,6 +750,10 @@
 				"autoCheckRepositories" : {
 					"type" : "boolean",
 					"default" : true
+				},
+				"fullModExtraction" : {
+					"type" : "boolean",
+					"default" : false
 				},
 				"updateOnStartup" : {
 					"type" : "boolean",

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -833,6 +833,9 @@ void CModListView::downloadFile(QString file, QUrl url, QString description, qin
 		connect(manager.get(), SIGNAL(extractionProgress(qint64,qint64)),
 			this, SLOT(extractionProgress(qint64,qint64)));
 
+		connect(manager.get(), SIGNAL(contentExtractionProgress(QString,qint64,qint64)),
+			this, SLOT(contentExtractionProgress(QString,qint64,qint64)));
+
 		connect(modModel, &ModStateItemModel::dataChanged, filterModel, &QAbstractItemModel::dataChanged);
 
 		const auto progressBarFormat = tr("Downloading %1. %p% (%v MB out of %m MB) finished").arg(description);
@@ -855,6 +858,14 @@ void CModListView::extractionProgress(qint64 current, qint64 max)
 {
 	// display progress, in extracted files
 	ui->progressBar->setVisible(true);
+	ui->progressBar->setMaximum(max);
+	ui->progressBar->setValue(current);
+}
+
+void CModListView::contentExtractionProgress(QString modName, qint64 current, qint64 max)
+{
+	ui->progressBar->setVisible(true);
+	ui->progressBar->setFormat(tr("Extracting %1/%2 content.zip from %3").arg(current).arg(max).arg(modName));
 	ui->progressBar->setMaximum(max);
 	ui->progressBar->setValue(current);
 }

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -52,6 +52,12 @@ void CModListView::setupModModel()
 
 	modModel = new ModStateItemModel(modStateModel, this);
 	manager = std::make_unique<ModStateController>(modStateModel);
+
+	connect(manager.get(), SIGNAL(extractionProgress(qint64,qint64)),
+		this, SLOT(extractionProgress(qint64,qint64)));
+
+	connect(manager.get(), SIGNAL(contentExtractionProgress(QString,qint64,qint64)),
+		this, SLOT(contentExtractionProgress(QString,qint64,qint64)));
 }
 
 void CModListView::changeEvent(QEvent *event)
@@ -829,12 +835,6 @@ void CModListView::downloadFile(QString file, QUrl url, QString description, qin
 
 		connect(dlManager, SIGNAL(finished(QStringList,QStringList,QStringList)),
 			this, SLOT(downloadFinished(QStringList,QStringList,QStringList)));
-
-		connect(manager.get(), SIGNAL(extractionProgress(qint64,qint64)),
-			this, SLOT(extractionProgress(qint64,qint64)));
-
-		connect(manager.get(), SIGNAL(contentExtractionProgress(QString,qint64,qint64)),
-			this, SLOT(contentExtractionProgress(QString,qint64,qint64)));
 
 		connect(modModel, &ModStateItemModel::dataChanged, filterModel, &QAbstractItemModel::dataChanged);
 

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -140,6 +140,7 @@ private slots:
 	void modSelected(const QModelIndex & current, const QModelIndex & previous);
 	void downloadProgress(qint64 current, qint64 max);
 	void extractionProgress(qint64 current, qint64 max);
+	void contentExtractionProgress(QString modName, qint64 current, qint64 max);
 	void downloadFinished(QStringList savedFiles, QStringList failedFiles, QStringList errors);
 	void modelReset();
 	void hideProgressBar();

--- a/launcher/modManager/modstatecontroller.cpp
+++ b/launcher/modManager/modstatecontroller.cpp
@@ -13,6 +13,7 @@
 #include "modstatemodel.h"
 
 #include "../../lib/VCMIDirs.h"
+#include "../../lib/CConfigHandler.h"
 #include "../../lib/filesystem/Filesystem.h"
 #include "../../lib/filesystem/CZipLoader.h"
 #include "../../lib/modding/CModHandler.h"

--- a/launcher/modManager/modstatecontroller.cpp
+++ b/launcher/modManager/modstatecontroller.cpp
@@ -25,8 +25,59 @@
 
 #include <future>
 
+#include <QDirIterator>
+
 namespace
 {
+bool extractModContentArchives(ModStateController * controller, const QString & modName, const QString & modPath)
+{
+	QDirIterator it(modPath, QDir::Files, QDirIterator::Subdirectories);
+	QVector<QString> archives;
+	while(it.hasNext())
+	{
+		const QString archivePath = it.next();
+		if(it.fileName().compare("content.zip", Qt::CaseInsensitive) != 0)
+			continue;
+
+		archives.push_back(archivePath);
+	}
+
+	for(qint64 archiveIndex = 0; archiveIndex < archives.size(); ++archiveIndex)
+	{
+		controller->contentExtractionProgress(modName, archiveIndex + 1, archives.size());
+
+		const QString archivePath = archives[archiveIndex];
+		const QFileInfo archiveInfo(archivePath);
+		const QString contentDirPath = archiveInfo.dir().filePath("content");
+
+		QDir contentDir(contentDirPath);
+		if(!contentDir.exists() && !archiveInfo.dir().mkpath("content"))
+		{
+			logGlobal->error("Failed to create content directory for '%s'", archivePath.toStdString().c_str());
+			return false;
+		}
+
+		ZipArchive archive(qstringToPath(archivePath));
+		for(const auto & file : archive.listFiles())
+		{
+			if(!archive.extract(qstringToPath(contentDirPath), file))
+			{
+				logGlobal->error("Failed to extract '%s' from '%s'", file, archivePath.toStdString().c_str());
+				return false;
+			}
+		}
+
+		if(!QFile::remove(archivePath))
+		{
+			logGlobal->error("Failed to remove extracted archive '%s'", archivePath.toStdString().c_str());
+			return false;
+		}
+	}
+
+	controller->contentExtractionProgress(modName, archives.size(), archives.size());
+	return true;
+}
+
 QString detectModArchive(QString path, QString modName, std::vector<std::string> & filesToExtract)
 {
 	try {
@@ -242,6 +293,20 @@ bool ModStateController::doInstallMod(QString modname, QString archivePath)
 	QString upperLevel = modDirName.section('/', 0, 0);
 	if(upperLevel != modDirName)
 		removeModDir(destDir + upperLevel);
+
+	if(settings["launcher"]["fullModExtraction"].Bool())
+	{
+		try
+		{
+			if(!extractModContentArchives(this, modname, extractedDir.path()))
+				return addError(modname, tr("Failed to extract mod data"));
+		}
+		catch (const std::runtime_error & e)
+		{
+			logGlobal->error("Failed to extract nested mod archive. Reason: %s", e.what());
+			return addError(modname, tr("Failed to extract mod data"));
+		}
+	}
 
 	return true;
 }

--- a/launcher/modManager/modstatecontroller.cpp
+++ b/launcher/modManager/modstatecontroller.cpp
@@ -46,6 +46,7 @@ bool extractModContentArchives(ModStateController * controller, const QString & 
 	for(qint64 archiveIndex = 0; archiveIndex < archives.size(); ++archiveIndex)
 	{
 		controller->contentExtractionProgress(modName, archiveIndex + 1, archives.size());
+		qApp->processEvents();
 
 		const QString archivePath = archives[archiveIndex];
 		const QFileInfo archiveInfo(archivePath);
@@ -76,6 +77,7 @@ bool extractModContentArchives(ModStateController * controller, const QString & 
 	}
 
 	controller->contentExtractionProgress(modName, archives.size(), archives.size());
+	qApp->processEvents();
 	return true;
 }
 

--- a/launcher/modManager/modstatecontroller.h
+++ b/launcher/modManager/modstatecontroller.h
@@ -54,4 +54,5 @@ public:
 	
 signals:
 	void extractionProgress(qint64 currentAmount, qint64 maxAmount);
+	void contentExtractionProgress(QString modName, qint64 currentAmount, qint64 maxAmount);
 };

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -291,6 +291,7 @@ void CSettingsView::loadToggleButtonSettings()
 	setCheckbuttonState(ui->buttonShowIntro, settings["video"]["showIntro"].Bool());
 	setCheckbuttonState(ui->buttonAllowPortrait, settings["video"]["allowPortrait"].Bool());
 	setCheckbuttonState(ui->buttonAutoCheck, settings["launcher"]["autoCheckRepositories"].Bool());
+	setCheckbuttonState(ui->buttonFullModExtraction, settings["launcher"]["fullModExtraction"].Bool());
 
 	setCheckbuttonState(ui->buttonRepositoryDefault, settings["launcher"]["defaultRepositoryEnabled"].Bool());
 	setCheckbuttonState(ui->buttonRepositoryExtra, settings["launcher"]["extraRepositoryEnabled"].Bool());
@@ -526,6 +527,13 @@ void CSettingsView::on_buttonAutoCheck_toggled(bool value)
 	Settings node = settings.write["launcher"]["autoCheckRepositories"];
 	node->Bool() = value;
 	updateCheckbuttonText(ui->buttonAutoCheck);
+}
+
+void CSettingsView::on_buttonFullModExtraction_toggled(bool value)
+{
+	Settings node = settings.write["launcher"]["fullModExtraction"];
+	node->Bool() = value;
+	updateCheckbuttonText(ui->buttonFullModExtraction);
 }
 
 void CSettingsView::on_comboBoxDisplayIndex_currentIndexChanged(int index)

--- a/launcher/settingsView/csettingsview_moc.h
+++ b/launcher/settingsView/csettingsview_moc.h
@@ -52,6 +52,7 @@ private slots:
 	void on_buttonShowIntro_toggled(bool value);
 	void on_buttonAllowPortrait_toggled(bool value);
 	void on_buttonAutoCheck_toggled(bool value);
+	void on_buttonFullModExtraction_toggled(bool value);
 	void on_comboBoxDisplayIndex_currentIndexChanged(int index);
 	void on_buttonAutoSave_toggled(bool value);
 	void on_comboBoxLanguage_currentIndexChanged(int index);

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -431,14 +431,14 @@
          </property>
         </widget>
        </item>
-       <item row="67" column="0">
+       <item row="66" column="0">
         <widget class="QLabel" name="labelFullModExtraction">
          <property name="text">
-          <string>Enable full mod extraction</string>
+          <string>Full mod extraction</string>
          </property>
         </widget>
        </item>
-       <item row="67" column="1" colspan="5">
+       <item row="66" column="1" colspan="5">
         <widget class="QToolButton" name="buttonFullModExtraction">
          <property name="enabled">
           <bool>true</bool>
@@ -460,7 +460,7 @@
          </property>
         </widget>
        </item>
-       <item row="66" column="1" colspan="5">
+       <item row="67" column="1" colspan="5">
         <widget class="QPushButton" name="buttonConfigEditor">
          <property name="text">
           <string>Open editor</string>
@@ -1372,7 +1372,7 @@
          </property>
         </widget>
        </item>
-       <item row="66" column="0">
+       <item row="67" column="0">
         <widget class="QLabel" name="labelConfigEditor">
          <property name="text">
           <string>Config editor</string>

--- a/launcher/settingsView/csettingsview_moc.ui
+++ b/launcher/settingsView/csettingsview_moc.ui
@@ -49,7 +49,7 @@
         <x>0</x>
         <y>0</y>
         <width>729</width>
-        <height>1647</height>
+        <height>1720</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout" columnstretch="20,5,5,5,5,10">
@@ -428,6 +428,35 @@
         <widget class="QLabel" name="labelAutoSave">
          <property name="text">
           <string>Autosave</string>
+         </property>
+        </widget>
+       </item>
+       <item row="67" column="0">
+        <widget class="QLabel" name="labelFullModExtraction">
+         <property name="text">
+          <string>Enable full mod extraction</string>
+         </property>
+        </widget>
+       </item>
+       <item row="67" column="1" colspan="5">
+        <widget class="QToolButton" name="buttonFullModExtraction">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
### Motivation
- Improve installer UX by reporting progress when extracting nested `content.zip` archives inside mods so users see "Extracting x/x content.zip from <modName>" in the existing install progress bar.
- Reuse existing install progress UI instead of adding a separate UI element for nested extraction feedback.

### Description
- Add a new signal `contentExtractionProgress(QString modName, qint64 currentAmount, qint64 maxAmount)` to `ModStateController` and emit it from the nested-extraction helper so extraction progress can be reported per-mod.
- Change `extractModContentArchives(...)` to first collect all case-insensitive `content.zip` matches, emit progress before each archive extraction using 1-based indexing and once at completion, and accept the controller and mod name to emit the signal.
- Wire the new signal in the launcher UI by connecting it in `CModListView`, adding a new slot `contentExtractionProgress(...)` that updates the existing progress bar format to `Extracting %1/%2 content.zip from %3`, and add the corresponding slot declaration.
- Add the launcher setting UI wiring for `fullModExtraction` (settings JSON, UI, header and implementation changes) so users can enable the nested extraction behavior via settings.

### Testing
- Searched and inspected changed code with `rg` to confirm new signal names and progress format strings and verified modifications in `modstatecontroller.*` and `cmodlistview_moc.*` succeeded.
- Printed relevant file regions with `sed` and reviewed the updated helper and slot implementations to ensure the progress emission points are present and 1-based indexing is used; these inspections succeeded.
- Committed the changes (`git commit` produced commit `c12857f6f`) and verified working tree status; commit succeeded but no build was performed in this environment so compilation was not validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba7c5c32c832db9b49c11c3e58342)