### PR TITLE
Keep spellbook settings as two mutually-exclusive checkboxes

### DIFF
--- a/client/windows/settings/GeneralOptionsTab.cpp
+++ b/client/windows/settings/GeneralOptionsTab.cpp
@@ -109,9 +109,21 @@ GeneralOptionsTab::GeneralOptionsTab()
 #endif
 
 	const JsonNode config(JsonPath::builtin("config/widgets/settings/generalOptionsTab.json"));
-	addCallback("spellbookAnimationChanged", [](bool value)
+	addCallback("enableLargeSpellbookChanged", [this](bool value)
 	{
+		std::shared_ptr<CToggleButton> spellbookAnimationCheckbox = widget<CToggleButton>("spellbookAnimationCheckbox");
+		spellbookAnimationCheckbox->setSelectedSilent(!value);
+
+		setBoolSetting("gameTweaks", "enableLargeSpellbook", value);
+		setBoolSetting("video", "spellbookAnimation", !value);
+	});
+	addCallback("spellbookAnimationChanged", [this](bool value)
+	{
+		std::shared_ptr<CToggleButton> enableLargeSpellbookCheckbox = widget<CToggleButton>("enableLargeSpellbookCheckbox");
+		enableLargeSpellbookCheckbox->setSelectedSilent(!value);
+
 		setBoolSetting("video", "spellbookAnimation", value);
+		setBoolSetting("gameTweaks", "enableLargeSpellbook", !value);
 	});
 	addCallback("setMusic", [this](int value)
 	{
@@ -170,17 +182,6 @@ GeneralOptionsTab::GeneralOptionsTab()
 		setBoolSetting("general", "enableUiEnhancements", value);
 	});
 
-	addCallback("enableLargeSpellbookChanged", [this](bool value)
-	{
-		setBoolSetting("gameTweaks", "enableLargeSpellbook", value);
-		std::shared_ptr<CToggleButton> spellbookAnimationCheckbox = widget<CToggleButton>("spellbookAnimationCheckbox");
-		if(value)
-			spellbookAnimationCheckbox->disable();
-		else
-			spellbookAnimationCheckbox->enable();
-		redraw();
-	});
-
 	addCallback("audioMuteFocusChanged", [](bool value)
 	{
 		setBoolSetting("general", "audioMuteFocus", value);
@@ -211,12 +212,12 @@ GeneralOptionsTab::GeneralOptionsTab()
 	if (longTouchLabel)
 		longTouchLabel->setText(longTouchToLabelString(settings["general"]["longTouchTimeMilliseconds"].Integer()));
 
+	std::shared_ptr<CToggleButton> enableLargeSpellbookCheckbox = widget<CToggleButton>("enableLargeSpellbookCheckbox");
+	if (enableLargeSpellbookCheckbox)
+		enableLargeSpellbookCheckbox->setSelectedSilent(settings["gameTweaks"]["enableLargeSpellbook"].Bool());
+
 	std::shared_ptr<CToggleButton> spellbookAnimationCheckbox = widget<CToggleButton>("spellbookAnimationCheckbox");
-	spellbookAnimationCheckbox->setSelected(settings["video"]["spellbookAnimation"].Bool());
-	if(settings["gameTweaks"]["enableLargeSpellbook"].Bool())
-		spellbookAnimationCheckbox->disable();
-	else
-		spellbookAnimationCheckbox->enable();
+	spellbookAnimationCheckbox->setSelectedSilent(!settings["gameTweaks"]["enableLargeSpellbook"].Bool());
 
 	std::shared_ptr<CToggleButton> fullscreenBorderlessCheckbox = widget<CToggleButton>("fullscreenBorderlessCheckbox");
 	if (fullscreenBorderlessCheckbox)
@@ -240,10 +241,6 @@ GeneralOptionsTab::GeneralOptionsTab()
 	std::shared_ptr<CToggleButton> enableUiEnhancementsCheckbox = widget<CToggleButton>("enableUiEnhancementsCheckbox");
 	if (enableUiEnhancementsCheckbox)
 		enableUiEnhancementsCheckbox->setSelected(settings["general"]["enableUiEnhancements"].Bool());
-
-	std::shared_ptr<CToggleButton> enableLargeSpellbookCheckbox = widget<CToggleButton>("enableLargeSpellbookCheckbox");
-	if (enableLargeSpellbookCheckbox)
-		enableLargeSpellbookCheckbox->setSelected(settings["gameTweaks"]["enableLargeSpellbook"].Bool());
 
 	std::shared_ptr<CToggleButton> audioMuteFocusCheckbox = widget<CToggleButton>("audioMuteFocusCheckbox");
 	if (audioMuteFocusCheckbox)

--- a/config/widgets/settings/generalOptionsTab.json
+++ b/config/widgets/settings/generalOptionsTab.json
@@ -147,7 +147,7 @@
 				},
 				{
 					"name": "spellbookAnimationCheckbox",
-					"help": "core.help.364",
+					"help": "core.help.577",
 					"callback": "spellbookAnimationChanged"
 				},
 				{


### PR DESCRIPTION
### Motivation

- Restore the original UI: keep two separate checkboxes for `Large Spell Book` and `Spell Book Animation` instead of a single radio/toggle group, as requested.
- Ensure the two checkboxes are mutually exclusive and that a single click updates the other checkbox icon/state immediately.

### Description

- Replaced the previous `toggleGroup` approach with two checkboxes in `config/widgets/settings/generalOptionsTab.json` (`enableLargeSpellbookCheckbox` and `spellbookAnimationCheckbox`).
- Added two callbacks in `client/windows/settings/GeneralOptionsTab.cpp`: `enableLargeSpellbookChanged` and `spellbookAnimationChanged`, each calling `setSelectedSilent(!value)` on the opposite checkbox to update its icon instantly and writing both settings together (`gameTweaks.enableLargeSpellbook` and `video.spellbookAnimation`).
- Initialize both checkboxes on tab build so their displayed icons reflect the current settings on open.
- Removed the `spellbookDisplayMode` toggle group usage and restored the original checkbox placement/style.

### Testing

- Ran targeted static checks with `rg` to verify callback and widget references (succeeded).
- Reviewed diffs with `git -C /workspace/vcmi diff` and inspected modified files with `nl`/`sed` to confirm the intended changes (succeeded).
- Verified repository state with `git -C /workspace/vcmi status --short` and committed the change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d94fd5fc0832daeca3ce535f3e05f)