### PR TITLE
Add optional adventure-spell garrison dialog selection

### DIFF
--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -126,7 +126,8 @@
 							"movementPointsRequired" : { "type" : "number" },
 							"movementPointsTaken" : { "type" : "number" },
 							"allowTownSelection" : { "type" : "boolean" },
-							"skipOccupiedTowns" : { "type" : "boolean" }
+							"skipOccupiedTowns" : { "type" : "boolean" },
+							"showGarrisonDialog" : { "type" : "boolean" }
 						},
 						"additionalProperties" : false
 					}

--- a/config/spells/adventure.json
+++ b/config/spells/adventure.json
@@ -434,5 +434,62 @@
 		"flags" : {
 			"indifferent": true
 		}
+	},
+	"reinforcements" : {
+		"name" : "Reinforcements",
+		"type" : "adventure",
+		"targetType": "NO_TARGET",
+		"school" : {
+			"fire" : true
+		},
+		"level" : 1,
+		"power" : 0,
+		"defaultGainChance" : 15,
+		"gainChance" : {},
+		"sounds": {
+			"cast": "TELPTOUT"
+		},
+		"graphics" : {
+			"iconBook" : "zspel102",
+			"iconEffect" : "zvs/Lib1.res/TPSR",
+			"iconScenarioBonus" : "zspel102",
+			"iconScroll" : "zspel102"
+		},
+		"levels" : {
+			"base":{
+				"range" : "X",
+				"adventureEffect" : {
+					"type" : "townPortal",
+					"castsPerDay" : 1,
+					"allowTownSelection" : false,
+					"skipOccupiedTowns" : true,
+					"showGarrisonDialog" : true,
+					"movementPointsRequired" : 0,
+					"movementPointsTaken" : 0
+				}
+			},
+			"none":{
+			},
+			"basic":{
+				"adventureEffect" : {
+					"castsPerDay" : 2
+				}
+			},
+			"advanced":{
+				"adventureEffect" : {
+					"castsPerDay" : 3,
+					"allowTownSelection" : true
+				}
+			},
+			"expert":{
+				"adventureEffect" : {
+					"castsPerDay" : 4,
+					"allowTownSelection" : true
+				}
+			}
+		},
+		"flags" : {
+			"indifferent": true
+		}
 	}
 }

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -65,6 +65,7 @@ public:
 
 	virtual void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) = 0;
 	virtual bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) = 0;	//TODO: remove
+	virtual void showGarrisonDialog(ObjectInstanceID townId, ObjectInstanceID heroId, bool removableUnits) = 0;
 
 	virtual void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) = 0;//TODO: type safety on query, use generic query packet when implemented
 };

--- a/lib/spells/adventure/TownPortalEffect.cpp
+++ b/lib/spells/adventure/TownPortalEffect.cpp
@@ -31,6 +31,7 @@ TownPortalEffect::TownPortalEffect(const CSpell * s, const JsonNode & config)
 	, movementPointsTaken(config["movementPointsTaken"].Integer())
 	, allowTownSelection(config["allowTownSelection"].Bool())
 	, skipOccupiedTowns(config["skipOccupiedTowns"].Bool())
+	, showGarrisonDialog(config["showGarrisonDialog"].Bool())
 {
 }
 
@@ -196,7 +197,7 @@ ESpellCastResult TownPortalEffect::beginCast(SpellCastEnvironment * env, const A
 
 	if(!parameters.pos.isValid() && allowTownSelection)
 	{
-		auto queryCallback = [&mechanics, env, parameters](std::optional<int32_t> reply) -> void
+		auto queryCallback = [&mechanics, this, env, parameters](std::optional<int32_t> reply) -> void
 		{
 			if(reply.has_value())
 			{
@@ -209,9 +210,16 @@ ESpellCastResult TownPortalEffect::beginCast(SpellCastEnvironment * env, const A
 					return;
 				}
 
-				if(!dynamic_cast<const CGTownInstance *>(o))
+				auto selectedTown = dynamic_cast<const CGTownInstance *>(o);
+				if(selectedTown == nullptr)
 				{
 					env->complain("Object instance is not town");
+					return;
+				}
+
+				if(showGarrisonDialog)
+				{
+					env->showGarrisonDialog(selectedTown->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), false);
 					return;
 				}
 

--- a/lib/spells/adventure/TownPortalEffect.cpp
+++ b/lib/spells/adventure/TownPortalEffect.cpp
@@ -155,6 +155,12 @@ void TownPortalEffect::endCast(SpellCastEnvironment * env, const AdventureSpellC
 		destination = dynamic_cast<const CGTownInstance *>(topObj);
 	}
 
+	if(showGarrisonDialog)
+	{
+		env->showGarrisonDialog(destination->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), false);
+		return;
+	}
+
 	if(env->moveHero(ObjectInstanceID(parameters.caster->getCasterUnitId()), parameters.caster->getHeroCaster()->convertFromVisitablePos(destination->visitablePos()), EMovementMode::TOWN_PORTAL))
 	{
 		SetMovePoints smp;
@@ -214,12 +220,6 @@ ESpellCastResult TownPortalEffect::beginCast(SpellCastEnvironment * env, const A
 				if(selectedTown == nullptr)
 				{
 					env->complain("Object instance is not town");
-					return;
-				}
-
-				if(showGarrisonDialog)
-				{
-					env->showGarrisonDialog(selectedTown->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), false);
 					return;
 				}
 

--- a/lib/spells/adventure/TownPortalEffect.h
+++ b/lib/spells/adventure/TownPortalEffect.h
@@ -23,6 +23,7 @@ class DLL_LINKAGE TownPortalEffect final : public IAdventureSpellEffect
 	int movementPointsTaken;
 	bool allowTownSelection;
 	bool skipOccupiedTowns;
+	bool showGarrisonDialog;
 
 public:
 	TownPortalEffect(const CSpell * s, const JsonNode & config);

--- a/server/ServerSpellCastEnvironment.cpp
+++ b/server/ServerSpellCastEnvironment.cpp
@@ -94,6 +94,11 @@ bool ServerSpellCastEnvironment::moveHero(ObjectInstanceID hid, int3 dst, EMovem
 	return gh->moveHero(hid, dst, mode, false);
 }
 
+void ServerSpellCastEnvironment::showGarrisonDialog(ObjectInstanceID townId, ObjectInstanceID heroId, bool removableUnits)
+{
+	gh->showGarrisonDialog(townId, heroId, removableUnits);
+}
+
 void ServerSpellCastEnvironment::createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator)
 {
 	return gh->createBoat(visitablePosition, type, initiator);

--- a/server/ServerSpellCastEnvironment.h
+++ b/server/ServerSpellCastEnvironment.h
@@ -37,6 +37,7 @@ public:
 	const CMap * getMap() const override;
 	const IGameInfoCallback * getCb() const override;
 	bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) override;
+	void showGarrisonDialog(ObjectInstanceID townId, ObjectInstanceID heroId, bool removableUnits) override;
 	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override;
 	void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) override;
 private:

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -134,6 +134,10 @@ public:
 		return false;
 	}
 
+	void showGarrisonDialog(ObjectInstanceID townId, ObjectInstanceID heroId, bool removableUnits) override
+	{
+	}
+
 	void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) override
 	{
 		//todo:


### PR DESCRIPTION
### Motivation
- Allow adventure spells (e.g. Reinforcements-style spells) to reuse the Town Portal-style town selection UI and optionally open the town garrison / recruit dialog instead of performing the default teleport action.

### Description
- Add a new server callback method `showGarrisonDialog(ObjectInstanceID townId, ObjectInstanceID heroId, bool removableUnits)` to `SpellCastEnvironment` so spell mechanics can open the standard garrison UI via the server.
- Implement the new hook in `ServerSpellCastEnvironment` and provide a no-op override in the `CGameStateTest` test fixture.
- Extend `TownPortalEffect` to read a new optional adventureEffect JSON flag `showGarrisonDialog` and, when enabled and a town is selected, call the new `showGarrisonDialog` hook instead of immediately performing the teleport.
- Update the spell schema (`config/schemas/spell.json`) to allow `showGarrisonDialog` for `townPortal` adventure effects so mod authors can opt in.

### Testing
- Attempted to configure the project with `cmake -S . -B build -GNinja`; configuration failed in this environment due to missing Boost development components (`date_time`, `filesystem`, `locale`, `program_options`, `iostreams`).
- No further automated builds or unit tests were executed because the configure step could not complete in the container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db61ac988832da478f19a35bc987b)