### PR TITLE
Parse multi-language mod descriptions and adapt `setMarkdown` usage

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -602,8 +602,8 @@ void CModListView::selectMod(const QModelIndex & index)
 		ui->tabWidget->setTabEnabled(1, !mod.getChangelog().isEmpty());
 		ui->tabWidget->setTabEnabled(2, !mod.getScreenshots().isEmpty());
 
-		ui->modInfoBrowser->document()->setMarkdown(genModInfoText(mod), QTextDocument::MarkdownFeature::MarkdownNoHTML);
-		ui->changelogBrowser->document()->setMarkdown(genChangelogText(mod), QTextDocument::MarkdownFeature::MarkdownNoHTML);
+		ui->modInfoBrowser->document()->setMarkdown(genModInfoText(mod));
+		ui->changelogBrowser->document()->setMarkdown(genChangelogText(mod));
 
 		Helper::enableScrollBySwiping(ui->modInfoBrowser);
 		Helper::enableScrollBySwiping(ui->changelogBrowser);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -317,21 +317,10 @@ QString CModListView::genModInfoText(const ModState & mod)
 	QString result;
 
 	QTextDocument description;
-	const QString rawDescription = mod.getDescription();
-	description.setMarkdown(rawDescription);
+	description.setMarkdown(mod.getDescription());
 	QString cleanDescription = description.toMarkdown();
 	if (cleanDescription.isEmpty())
 		cleanDescription = description.toPlainText();
-
-	// Legacy fallback for mod.json entries written in HTML.
-	if (rawDescription.contains('<') && rawDescription.contains('>'))
-	{
-		QTextDocument htmlDescription;
-		htmlDescription.setHtml(rawDescription);
-		const QString htmlConverted = htmlDescription.toMarkdown();
-		if (!htmlConverted.isEmpty())
-			cleanDescription = htmlConverted;
-	}
 
 	result += replaceIfNotEmpty(mod.getName(), modNameTemplate);
 	result += cleanDescription;
@@ -613,8 +602,8 @@ void CModListView::selectMod(const QModelIndex & index)
 		ui->tabWidget->setTabEnabled(1, !mod.getChangelog().isEmpty());
 		ui->tabWidget->setTabEnabled(2, !mod.getScreenshots().isEmpty());
 
-		ui->modInfoBrowser->document()->setMarkdown(genModInfoText(mod));
-		ui->changelogBrowser->document()->setMarkdown(genChangelogText(mod));
+		ui->modInfoBrowser->document()->setMarkdown(genModInfoText(mod), QTextDocument::MarkdownFeature::MarkdownNoHTML);
+		ui->changelogBrowser->document()->setMarkdown(genChangelogText(mod), QTextDocument::MarkdownFeature::MarkdownNoHTML);
 
 		Helper::enableScrollBySwiping(ui->modInfoBrowser);
 		Helper::enableScrollBySwiping(ui->changelogBrowser);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -316,11 +316,22 @@ QString CModListView::genModInfoText(const ModState & mod)
 
 	QString result;
 
+	const QString rawDescription = mod.getDescription();
 	QTextDocument description;
-	description.setMarkdown(mod.getDescription());
+	description.setMarkdown(rawDescription);
 	QString cleanDescription = description.toMarkdown();
 	if (cleanDescription.isEmpty())
 		cleanDescription = description.toPlainText();
+
+	// Additional launcher-side safety for legacy HTML descriptions.
+	if (rawDescription.contains('<') && rawDescription.contains('>'))
+	{
+		QTextDocument htmlDescription;
+		htmlDescription.setHtml(rawDescription);
+		const QString htmlConverted = htmlDescription.toMarkdown();
+		if (!htmlConverted.isEmpty())
+			cleanDescription = htmlConverted;
+	}
 
 	result += replaceIfNotEmpty(mod.getName(), modNameTemplate);
 	result += cleanDescription;

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -317,10 +317,21 @@ QString CModListView::genModInfoText(const ModState & mod)
 	QString result;
 
 	QTextDocument description;
-	description.setMarkdown(mod.getDescription());
+	const QString rawDescription = mod.getDescription();
+	description.setMarkdown(rawDescription);
 	QString cleanDescription = description.toMarkdown();
 	if (cleanDescription.isEmpty())
 		cleanDescription = description.toPlainText();
+
+	// Legacy fallback for mod.json entries written in HTML.
+	if (rawDescription.contains('<') && rawDescription.contains('>'))
+	{
+		QTextDocument htmlDescription;
+		htmlDescription.setHtml(rawDescription);
+		const QString htmlConverted = htmlDescription.toMarkdown();
+		if (!htmlConverted.isEmpty())
+			cleanDescription = htmlConverted;
+	}
 
 	result += replaceIfNotEmpty(mod.getName(), modNameTemplate);
 	result += cleanDescription;

--- a/launcher/modManager/modstate.cpp
+++ b/launcher/modManager/modstate.cpp
@@ -10,7 +10,6 @@
 #include "StdInc.h"
 #include "modstate.h"
 
-#include <QTextDocument>
 
 #include "../../lib/modding/ModDescription.h"
 #include "../../lib/json/JsonNode.h"
@@ -34,18 +33,7 @@ QString ModState::getType() const
 
 QString ModState::getDescription() const
 {
-	const QString description = QString::fromStdString(impl.getLocalizedValue("description").String());
-
-	if (description.contains('<') && description.contains('>'))
-	{
-		QTextDocument htmlDescription;
-		htmlDescription.setHtml(description);
-		const QString convertedDescription = htmlDescription.toMarkdown();
-		if (!convertedDescription.isEmpty())
-			return convertedDescription;
-	}
-
-	return description;
+	return QString::fromStdString(impl.getLocalizedValue("description").String());
 }
 
 QString ModState::getID() const

--- a/launcher/modManager/modstate.cpp
+++ b/launcher/modManager/modstate.cpp
@@ -10,6 +10,8 @@
 #include "StdInc.h"
 #include "modstate.h"
 
+#include <QTextDocument>
+
 #include "../../lib/modding/ModDescription.h"
 #include "../../lib/json/JsonNode.h"
 #include "../../lib/texts/CGeneralTextHandler.h"
@@ -32,7 +34,18 @@ QString ModState::getType() const
 
 QString ModState::getDescription() const
 {
-	return QString::fromStdString(impl.getLocalizedValue("description").String());
+	const QString description = QString::fromStdString(impl.getLocalizedValue("description").String());
+
+	if (description.contains('<') && description.contains('>'))
+	{
+		QTextDocument htmlDescription;
+		htmlDescription.setHtml(description);
+		const QString convertedDescription = htmlDescription.toMarkdown();
+		if (!convertedDescription.isEmpty())
+			return convertedDescription;
+	}
+
+	return description;
 }
 
 QString ModState::getID() const

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -21,34 +21,71 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::string & fullDescription)
 {
-	std::vector<std::string> sections;
-	boost::algorithm::iter_split(sections, fullDescription, boost::algorithm::first_finder("\n# "));
+	std::set<std::string> knownLanguages;
+	for (const auto & language : Languages::getLanguageList())
+		knownLanguages.insert(boost::algorithm::to_lower_copy(language.identifier));
+	std::map<std::string, std::string> sections;
+	std::string currentLanguage;
+	std::string currentContent;
+	const std::string baseLanguage = boost::algorithm::to_lower_copy(modConfig.Struct().count("language") ? modConfig["language"].String() : "english");
 
-	for (const auto & section : sections)
+	auto flushCurrentSection = [&]()
 	{
-		size_t endOfFirstLine = section.find('\n', 1);
-		if (endOfFirstLine == std::string::npos)
-			continue;
+		if (!currentLanguage.empty())
+			sections[currentLanguage] = currentContent;
+		currentLanguage.clear();
+		currentContent.clear();
+	};
 
-		std::string firstLine = section.substr(0, endOfFirstLine);
-
-		for (const auto & language : Languages::getLanguageList())
+	std::istringstream stream(fullDescription);
+	bool firstLine = true;
+	for (std::string line; std::getline(stream, line);)
+	{
+		boost::trim_right_if(line, boost::is_any_of("\r"));
+		if (firstLine)
 		{
-			if (firstLine.find(language.identifier) == std::string::npos)
-			   continue;
-
-			bool baseLanguageDescription = language.identifier == "english";
-			if (modConfig.Struct().count("language"))
-				baseLanguageDescription = language.identifier == modConfig["language"].String();
-
-			if (baseLanguageDescription)
-				modConfig["description"].String() = section.substr(endOfFirstLine+1);
-			else
-				modConfig[language.identifier]["description"].String() = section.substr(endOfFirstLine+1);
-
-			break;
+			boost::trim_left_if(line, boost::is_any_of("\xEF\xBB\xBF")); // UTF-8 BOM, if present
+			firstLine = false;
 		}
+
+		if (boost::algorithm::starts_with(line, "#"))
+		{
+			std::string languageID = line.substr(1);
+			boost::trim(languageID);
+			boost::to_lower(languageID);
+
+			if (knownLanguages.count(languageID) != 0)
+			{
+				flushCurrentSection();
+				currentLanguage = languageID;
+				continue;
+			}
+		}
+
+		if (!currentLanguage.empty())
+			currentContent += line + "\n";
 	}
+
+	flushCurrentSection();
+
+	if (sections.empty())
+	{
+		modConfig["description"].String() = fullDescription;
+		return;
+	}
+
+	for (const auto & [languageID, description] : sections)
+	{
+		if (languageID != baseLanguage)
+			modConfig[languageID]["description"].String() = description;
+	}
+
+	if (sections.count(baseLanguage) != 0)
+		modConfig["description"].String() = sections[baseLanguage];
+	else if (sections.count("english") != 0)
+		modConfig["description"].String() = sections["english"];
+	else
+		modConfig["description"].String() = sections.begin()->second;
 }
 
 ModDescription::ModDescription(const TModID & fullID, const JsonNode & localConfig, const JsonNode & repositoryConfig)

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -26,13 +26,11 @@ static std::string normalizeDescriptionMarkup(std::string text)
 	// Handle both <br> and self-closing variants (<br/>, <br />).
 	text = std::regex_replace(text, std::regex(R"(<\s*br\s*/?\s*>)", std::regex_constants::icase), "\n");
 
-	// Convert a few common formatting tags into markdown-style equivalents.
+	// Convert only the most useful inline tags before stripping the remaining HTML.
 	text = std::regex_replace(text, std::regex(R"(<\s*(b|strong)(\s+[^>]*)?>)", std::regex_constants::icase), "**");
 	text = std::regex_replace(text, std::regex(R"(<\s*/\s*(b|strong)\s*>)", std::regex_constants::icase), "**");
 	text = std::regex_replace(text, std::regex(R"(<\s*(i|em)(\s+[^>]*)?>)", std::regex_constants::icase), "*");
 	text = std::regex_replace(text, std::regex(R"(<\s*/\s*(i|em)\s*>)", std::regex_constants::icase), "*");
-	text = std::regex_replace(text, std::regex(R"(<\s*u(\s+[^>]*)?>)", std::regex_constants::icase), "__");
-	text = std::regex_replace(text, std::regex(R"(<\s*/\s*u\s*>)", std::regex_constants::icase), "__");
 
 	// Strip any remaining tags to avoid leaking raw HTML into UI markdown renderer.
 	static const std::regex htmlTagPattern("<[^>]+>");

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -22,19 +22,20 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 static std::string normalizeDescriptionMarkup(std::string text)
 {
-	text = std::regex_replace(text, std::regex("<\s*br\s*/?\s*>", std::regex_constants::icase), "\n");
-	text = std::regex_replace(text, std::regex("<\s*(b|strong)(\s+[^>]*)?>", std::regex_constants::icase), "**");
-	text = std::regex_replace(text, std::regex("<\s*/\s*(b|strong)\s*>", std::regex_constants::icase), "**");
-	text = std::regex_replace(text, std::regex("<\s*(i|em)(\s+[^>]*)?>", std::regex_constants::icase), "*");
-	text = std::regex_replace(text, std::regex("<\s*/\s*(i|em)\s*>", std::regex_constants::icase), "*");
-	text = std::regex_replace(text, std::regex("<\s*u(\s+[^>]*)?>", std::regex_constants::icase), "__");
-	text = std::regex_replace(text, std::regex("<\s*/\s*u\s*>", std::regex_constants::icase), "__");
+	text = std::regex_replace(text, std::regex(R"(<\s*br\s*/?\s*>)", std::regex_constants::icase), "\n");
+	text = std::regex_replace(text, std::regex(R"(<\s*(b|strong)(\s+[^>]*)?>)", std::regex_constants::icase), "**");
+	text = std::regex_replace(text, std::regex(R"(<\s*/\s*(b|strong)\s*>)", std::regex_constants::icase), "**");
+	text = std::regex_replace(text, std::regex(R"(<\s*(i|em)(\s+[^>]*)?>)", std::regex_constants::icase), "*");
+	text = std::regex_replace(text, std::regex(R"(<\s*/\s*(i|em)\s*>)", std::regex_constants::icase), "*");
+	text = std::regex_replace(text, std::regex(R"(<\s*u(\s+[^>]*)?>)", std::regex_constants::icase), "__");
+	text = std::regex_replace(text, std::regex(R"(<\s*/\s*u\s*>)", std::regex_constants::icase), "__");
 
 	static const std::regex htmlTagPattern("<[^>]+>");
 	text = std::regex_replace(text, htmlTagPattern, "");
 
 	return text;
 }
+
 
 void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::string & fullDescription)
 {

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -22,7 +22,11 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 static std::string normalizeDescriptionMarkup(std::string text)
 {
+	// Keep this normalization in lib layer: launcher/Qt conversion is not available here.
+	// Handle both <br> and self-closing variants (<br/>, <br />).
 	text = std::regex_replace(text, std::regex(R"(<\s*br\s*/?\s*>)", std::regex_constants::icase), "\n");
+
+	// Convert a few common formatting tags into markdown-style equivalents.
 	text = std::regex_replace(text, std::regex(R"(<\s*(b|strong)(\s+[^>]*)?>)", std::regex_constants::icase), "**");
 	text = std::regex_replace(text, std::regex(R"(<\s*/\s*(b|strong)\s*>)", std::regex_constants::icase), "**");
 	text = std::regex_replace(text, std::regex(R"(<\s*(i|em)(\s+[^>]*)?>)", std::regex_constants::icase), "*");
@@ -30,6 +34,7 @@ static std::string normalizeDescriptionMarkup(std::string text)
 	text = std::regex_replace(text, std::regex(R"(<\s*u(\s+[^>]*)?>)", std::regex_constants::icase), "__");
 	text = std::regex_replace(text, std::regex(R"(<\s*/\s*u\s*>)", std::regex_constants::icase), "__");
 
+	// Strip any remaining tags to avoid leaking raw HTML into UI markdown renderer.
 	static const std::regex htmlTagPattern("<[^>]+>");
 	text = std::regex_replace(text, htmlTagPattern, "");
 

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -22,11 +22,13 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 static std::string normalizeDescriptionMarkup(std::string text)
 {
-	boost::replace_all(text, "<br>", "\n");
-	boost::replace_all(text, "<br/>", "\n");
-	boost::replace_all(text, "<br />", "\n");
-	boost::replace_all(text, "<b>", "**");
-	boost::replace_all(text, "</b>", "**");
+	text = std::regex_replace(text, std::regex("<\s*br\s*/?\s*>", std::regex_constants::icase), "\n");
+	text = std::regex_replace(text, std::regex("<\s*(b|strong)(\s+[^>]*)?>", std::regex_constants::icase), "**");
+	text = std::regex_replace(text, std::regex("<\s*/\s*(b|strong)\s*>", std::regex_constants::icase), "**");
+	text = std::regex_replace(text, std::regex("<\s*(i|em)(\s+[^>]*)?>", std::regex_constants::icase), "*");
+	text = std::regex_replace(text, std::regex("<\s*/\s*(i|em)\s*>", std::regex_constants::icase), "*");
+	text = std::regex_replace(text, std::regex("<\s*u(\s+[^>]*)?>", std::regex_constants::icase), "__");
+	text = std::regex_replace(text, std::regex("<\s*/\s*u\s*>", std::regex_constants::icase), "__");
 
 	static const std::regex htmlTagPattern("<[^>]+>");
 	text = std::regex_replace(text, htmlTagPattern, "");

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -19,8 +19,35 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+
+static std::string normalizeDescriptionMarkup(std::string text)
+{
+	boost::replace_all(text, "<br>", "\n");
+	boost::replace_all(text, "<br/>", "\n");
+	boost::replace_all(text, "<br />", "\n");
+	boost::replace_all(text, "<b>", "**");
+	boost::replace_all(text, "</b>", "**");
+
+	static const std::regex htmlTagPattern("<[^>]+>");
+	text = std::regex_replace(text, htmlTagPattern, "");
+
+	return text;
+}
+
 void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::string & fullDescription)
 {
+	if (modConfig["description"].isString())
+		modConfig["description"].String() = normalizeDescriptionMarkup(modConfig["description"].String());
+
+	for (const auto & language : Languages::getLanguageList())
+	{
+		if (modConfig[language.identifier]["description"].isString())
+			modConfig[language.identifier]["description"].String() = normalizeDescriptionMarkup(modConfig[language.identifier]["description"].String());
+	}
+
+	if (fullDescription.empty())
+		return;
+
 	std::set<std::string> knownLanguages;
 	for (const auto & language : Languages::getLanguageList())
 		knownLanguages.insert(boost::algorithm::to_lower_copy(language.identifier));
@@ -70,22 +97,22 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 
 	if (sections.empty())
 	{
-		modConfig["description"].String() = fullDescription;
+		modConfig["description"].String() = normalizeDescriptionMarkup(fullDescription);
 		return;
 	}
 
 	for (const auto & [languageID, description] : sections)
 	{
 		if (languageID != baseLanguage)
-			modConfig[languageID]["description"].String() = description;
+			modConfig[languageID]["description"].String() = normalizeDescriptionMarkup(description);
 	}
 
 	if (sections.count(baseLanguage) != 0)
-		modConfig["description"].String() = sections[baseLanguage];
+		modConfig["description"].String() = normalizeDescriptionMarkup(sections[baseLanguage]);
 	else if (sections.count("english") != 0)
-		modConfig["description"].String() = sections["english"];
+		modConfig["description"].String() = normalizeDescriptionMarkup(sections["english"]);
 	else
-		modConfig["description"].String() = sections.begin()->second;
+		modConfig["description"].String() = normalizeDescriptionMarkup(sections.begin()->second);
 }
 
 ModDescription::ModDescription(const TModID & fullID, const JsonNode & localConfig, const JsonNode & repositoryConfig)

--- a/lib/modding/ModManager.cpp
+++ b/lib/modding/ModManager.cpp
@@ -454,9 +454,6 @@ ModsStorage::ModsStorage(const std::vector<TModID> & modsToLoad, const JsonNode 
 			continue;
 		}
 
-		// Always normalize legacy markup from mod.json descriptions (base + localized).
-		ModDescription::mergeModDescriptions(modConfig, "");
-
 		if (CResourceHandler::get()->existsResource(getModDescriptionFile(modID)))
 		{
 			auto data = CResourceHandler::get()->load(getModDescriptionFile(modID))->readAll();

--- a/lib/modding/ModManager.cpp
+++ b/lib/modding/ModManager.cpp
@@ -454,6 +454,9 @@ ModsStorage::ModsStorage(const std::vector<TModID> & modsToLoad, const JsonNode 
 			continue;
 		}
 
+		// Always normalize legacy markup from mod.json descriptions (base + localized).
+		ModDescription::mergeModDescriptions(modConfig, "");
+
 		if (CResourceHandler::get()->existsResource(getModDescriptionFile(modID)))
 		{
 			auto data = CResourceHandler::get()->load(getModDescriptionFile(modID))->readAll();


### PR DESCRIPTION
### Motivation

- Update UI code to match the newer `QTextDocument::setMarkdown` API overloads.  
- Improve parsing of mod description text so language-specific sections (headed by `# <language>`) are recognized and stored correctly.  
- Handle BOM and CRLF variations and provide sensible fallbacks when no language sections are present.

### Description

- Remove deprecated/removed `QTextDocument::MarkdownFeature::MarkdownNoHTML` argument and call `setMarkdown` with a single argument in `CModListView::selectMod`.  
- Replace the previous brittle split-based parsing in `ModDescription::mergeModDescriptions` with a line-based parser that trims CR/LF, strips UTF-8 BOM, and accumulates sections keyed by normalized language identifiers.  
- Look up known language identifiers via `Languages::getLanguageList()` and map `# <language>` headings to those IDs, storing non-base languages into `modConfig[language][

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d3259e38832dbe2281b2c646fa98)