### PR TITLE
Improve mod description parsing and add HTML-to-Markdown fallback for mod info display

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -316,11 +316,22 @@ QString CModListView::genModInfoText(const ModState & mod)
 
 	QString result;
 
+	const QString rawDescription = mod.getDescription();
 	QTextDocument description;
-	description.setMarkdown(mod.getDescription());
+	description.setMarkdown(rawDescription);
 	QString cleanDescription = description.toMarkdown();
 	if (cleanDescription.isEmpty())
 		cleanDescription = description.toPlainText();
+
+	// Additional launcher-side safety for legacy HTML descriptions.
+	if (rawDescription.contains('<') && rawDescription.contains('>'))
+	{
+		QTextDocument htmlDescription;
+		htmlDescription.setHtml(rawDescription);
+		const QString htmlConverted = htmlDescription.toMarkdown();
+		if (!htmlConverted.isEmpty())
+			cleanDescription = htmlConverted;
+	}
 
 	result += replaceIfNotEmpty(mod.getName(), modNameTemplate);
 	result += cleanDescription;

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -27,9 +27,9 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 
 	std::set<std::string> knownLanguages;
 	for (const auto & language : Languages::getLanguageList())
-		knownLanguages.insert(boost::algorithm::to_lower_copy(language.identifier));
+		knownLanguages.insert(language.identifier);
 
-	const std::string baseLanguage = boost::algorithm::to_lower_copy(modConfig.Struct().count("language") ? modConfig["language"].String() : "english");
+	const std::string baseLanguage = modConfig.Struct().count("language") ? modConfig["language"].String() : "english";
 
 	std::vector<std::string> sections;
 	boost::algorithm::iter_split(sections, fullDescription, boost::algorithm::first_finder("\n# "));

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -28,68 +28,43 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 	std::set<std::string> knownLanguages;
 	for (const auto & language : Languages::getLanguageList())
 		knownLanguages.insert(boost::algorithm::to_lower_copy(language.identifier));
-	std::map<std::string, std::string> sections;
-	std::string currentLanguage;
-	std::string currentContent;
+
 	const std::string baseLanguage = boost::algorithm::to_lower_copy(modConfig.Struct().count("language") ? modConfig["language"].String() : "english");
 
-	auto flushCurrentSection = [&]()
+	std::vector<std::string> sections;
+	boost::algorithm::iter_split(sections, fullDescription, boost::algorithm::first_finder("\n# "));
+
+	for (auto & section : sections)
 	{
-		if (!currentLanguage.empty())
-			sections[currentLanguage] = currentContent;
-		currentLanguage.clear();
-		currentContent.clear();
-	};
+		if (boost::algorithm::starts_with(section, "# "))
+			section.erase(0, 2);
 
-	std::istringstream stream(fullDescription);
-	bool firstLine = true;
-	for (std::string line; std::getline(stream, line);)
-	{
-		boost::trim_right_if(line, boost::is_any_of("\r"));
-		if (firstLine)
-		{
-			boost::trim_left_if(line, boost::is_any_of("\xEF\xBB\xBF")); // UTF-8 BOM, if present
-			firstLine = false;
-		}
+		boost::trim_left_if(section, boost::is_any_of("\xEF\xBB\xBF")); // UTF-8 BOM, if present
 
-		if (boost::algorithm::starts_with(line, "#"))
-		{
-			std::string languageID = line.substr(1);
-			boost::trim(languageID);
-			boost::to_lower(languageID);
+		size_t endOfFirstLine = section.find('\n');
+		if (endOfFirstLine == std::string::npos)
+			continue;
 
-			if (knownLanguages.count(languageID) != 0)
-			{
-				flushCurrentSection();
-				currentLanguage = languageID;
-				continue;
-			}
-		}
+		std::string languageID = section.substr(0, endOfFirstLine);
+		boost::trim(languageID);
+		boost::to_lower(languageID);
 
-		if (!currentLanguage.empty())
-			currentContent += line + "\n";
+		if (knownLanguages.count(languageID) == 0)
+			continue;
+
+		if (languageID == baseLanguage)
+			modConfig["description"].String() = section.substr(endOfFirstLine + 1);
+		else
+			modConfig[languageID]["description"].String() = section.substr(endOfFirstLine + 1);
 	}
 
-	flushCurrentSection();
-
-	if (sections.empty())
+	if (modConfig["description"].isNull())
 	{
-		modConfig["description"].String() = fullDescription;
-		return;
+		if (!modConfig["english"]["description"].isNull())
+			modConfig["description"].String() = modConfig["english"]["description"].String();
+		else
+			modConfig["description"].String() = fullDescription;
 	}
-
-	for (const auto & [languageID, description] : sections)
-	{
-		if (languageID != baseLanguage)
-			modConfig[languageID]["description"].String() = description;
-	}
-
-	if (sections.count(baseLanguage) != 0)
-		modConfig["description"].String() = sections[baseLanguage];
-	else if (sections.count("english") != 0)
-		modConfig["description"].String() = sections["english"];
-	else
-		modConfig["description"].String() = sections.begin()->second;
 }
 
 ModDescription::ModDescription(const TModID & fullID, const JsonNode & localConfig, const JsonNode & repositoryConfig)

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -29,6 +29,12 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 	if (descriptionText.find('\n') == std::string::npos && descriptionText.find("\\n") != std::string::npos)
 		boost::replace_all(descriptionText, "\\n", "\n");
 
+	if (descriptionText.find('#') == std::string::npos)
+	{
+		modConfig["description"].String() = descriptionText;
+		return;
+	}
+
 	std::set<std::string> knownLanguages;
 	for (const auto & language : Languages::getLanguageList())
 		knownLanguages.insert(language.identifier);
@@ -37,6 +43,7 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 
 	std::vector<std::string> sections;
 	boost::algorithm::iter_split(sections, descriptionText, boost::algorithm::first_finder("\n# "));
+	bool hasKnownLanguageHeader = false;
 
 	for (auto & section : sections)
 	{
@@ -56,10 +63,18 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 		if (knownLanguages.count(languageID) == 0)
 			continue;
 
+		hasKnownLanguageHeader = true;
+
 		if (languageID == baseLanguage)
 			modConfig["description"].String() = section.substr(endOfFirstLine + 1);
 		else
 			modConfig[languageID]["description"].String() = section.substr(endOfFirstLine + 1);
+	}
+
+	if (!hasKnownLanguageHeader)
+	{
+		modConfig["description"].String() = descriptionText;
+		return;
 	}
 
 	if (modConfig["description"].isNull())

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -19,36 +19,77 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
+
 void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::string & fullDescription)
 {
-	std::vector<std::string> sections;
-	boost::algorithm::iter_split(sections, fullDescription, boost::algorithm::first_finder("\n# "));
+	if (fullDescription.empty())
+		return;
 
-	for (const auto & section : sections)
+	std::set<std::string> knownLanguages;
+	for (const auto & language : Languages::getLanguageList())
+		knownLanguages.insert(boost::algorithm::to_lower_copy(language.identifier));
+	std::map<std::string, std::string> sections;
+	std::string currentLanguage;
+	std::string currentContent;
+	const std::string baseLanguage = boost::algorithm::to_lower_copy(modConfig.Struct().count("language") ? modConfig["language"].String() : "english");
+
+	auto flushCurrentSection = [&]()
 	{
-		size_t endOfFirstLine = section.find('\n', 1);
-		if (endOfFirstLine == std::string::npos)
-			continue;
+		if (!currentLanguage.empty())
+			sections[currentLanguage] = currentContent;
+		currentLanguage.clear();
+		currentContent.clear();
+	};
 
-		std::string firstLine = section.substr(0, endOfFirstLine);
-
-		for (const auto & language : Languages::getLanguageList())
+	std::istringstream stream(fullDescription);
+	bool firstLine = true;
+	for (std::string line; std::getline(stream, line);)
+	{
+		boost::trim_right_if(line, boost::is_any_of("\r"));
+		if (firstLine)
 		{
-			if (firstLine.find(language.identifier) == std::string::npos)
-			   continue;
-
-			bool baseLanguageDescription = language.identifier == "english";
-			if (modConfig.Struct().count("language"))
-				baseLanguageDescription = language.identifier == modConfig["language"].String();
-
-			if (baseLanguageDescription)
-				modConfig["description"].String() = section.substr(endOfFirstLine+1);
-			else
-				modConfig[language.identifier]["description"].String() = section.substr(endOfFirstLine+1);
-
-			break;
+			boost::trim_left_if(line, boost::is_any_of("\xEF\xBB\xBF")); // UTF-8 BOM, if present
+			firstLine = false;
 		}
+
+		if (boost::algorithm::starts_with(line, "#"))
+		{
+			std::string languageID = line.substr(1);
+			boost::trim(languageID);
+			boost::to_lower(languageID);
+
+			if (knownLanguages.count(languageID) != 0)
+			{
+				flushCurrentSection();
+				currentLanguage = languageID;
+				continue;
+			}
+		}
+
+		if (!currentLanguage.empty())
+			currentContent += line + "\n";
 	}
+
+	flushCurrentSection();
+
+	if (sections.empty())
+	{
+		modConfig["description"].String() = fullDescription;
+		return;
+	}
+
+	for (const auto & [languageID, description] : sections)
+	{
+		if (languageID != baseLanguage)
+			modConfig[languageID]["description"].String() = description;
+	}
+
+	if (sections.count(baseLanguage) != 0)
+		modConfig["description"].String() = sections[baseLanguage];
+	else if (sections.count("english") != 0)
+		modConfig["description"].String() = sections["english"];
+	else
+		modConfig["description"].String() = sections.begin()->second;
 }
 
 ModDescription::ModDescription(const TModID & fullID, const JsonNode & localConfig, const JsonNode & repositoryConfig)

--- a/lib/modding/ModDescription.cpp
+++ b/lib/modding/ModDescription.cpp
@@ -25,6 +25,10 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 	if (fullDescription.empty())
 		return;
 
+	std::string descriptionText = fullDescription;
+	if (descriptionText.find('\n') == std::string::npos && descriptionText.find("\\n") != std::string::npos)
+		boost::replace_all(descriptionText, "\\n", "\n");
+
 	std::set<std::string> knownLanguages;
 	for (const auto & language : Languages::getLanguageList())
 		knownLanguages.insert(language.identifier);
@@ -32,7 +36,7 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 	const std::string baseLanguage = modConfig.Struct().count("language") ? modConfig["language"].String() : "english";
 
 	std::vector<std::string> sections;
-	boost::algorithm::iter_split(sections, fullDescription, boost::algorithm::first_finder("\n# "));
+	boost::algorithm::iter_split(sections, descriptionText, boost::algorithm::first_finder("\n# "));
 
 	for (auto & section : sections)
 	{
@@ -63,7 +67,7 @@ void ModDescription::mergeModDescriptions(JsonNode & modConfig, const std::strin
 		if (!modConfig["english"]["description"].isNull())
 			modConfig["description"].String() = modConfig["english"]["description"].String();
 		else
-			modConfig["description"].String() = fullDescription;
+			modConfig["description"].String() = descriptionText;
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Provide safer launcher-side rendering for legacy mod descriptions that may contain HTML by converting HTML to Markdown when appropriate.
- Robustly parse multi-language mod description blobs that use `# Language` section headers and correctly assign per-language descriptions.
- Handle edge cases such as empty descriptions and UTF-8 BOM at the start of description text.

### Description

- In the launcher view (`CModListView::genModInfoText`) capture the raw description in `rawDescription`, use it for the Markdown conversion, and add a fallback that detects HTML and converts it to Markdown via `QTextDocument::setHtml` when useful.
- Rewrote `ModDescription::mergeModDescriptions` to stream the full description line-by-line, detect section headers beginning with `#`, trim UTF-8 BOM, collect sections into a `std::map`, and maintain a `knownLanguages` set from `Languages::getLanguageList()` for robust identification.
- Populate `modConfig[

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d3259e38832dbe2281b2c646fa98)