### PR TITLE
Fix first-launch wizard navigation after page reordering

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -296,8 +296,9 @@ bool FirstLaunchView::heroesDataUpdate()
 
 void FirstLaunchView::heroesDataMissing()
 {
+	const bool demoDetected = isDemoDataDetected();
 	QPalette newPalette = palette();
-	newPalette.setColor(QPalette::Base, QColor(200, 50, 50));
+	newPalette.setColor(QPalette::Base, demoDetected ? QColor(220, 170, 50) : QColor(200, 50, 50));
 	ui->lineEditDataSystem->setPalette(newPalette);
 	ui->lineEditDataUser->setPalette(newPalette);
 
@@ -318,7 +319,8 @@ void FirstLaunchView::heroesDataMissing()
 #endif
 
 	ui->labelDataFound->setVisible(false);
-	ui->pushButtonDataNext->setEnabled(false);
+	ui->labelDataDemoInfo->setVisible(demoDetected);
+	ui->pushButtonDataNext->setEnabled(demoDetected);
 }
 
 void FirstLaunchView::heroesDataDetected()
@@ -343,6 +345,7 @@ void FirstLaunchView::heroesDataDetected()
 #endif
 
 	ui->labelDataFound->setVisible(true);
+	ui->labelDataDemoInfo->setVisible(false);
 	ui->pushButtonDataNext->setEnabled(true);
 
 	CGeneralTextHandler::detectInstallParameters();

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -36,6 +36,15 @@ static ProgressOverlay* createOverlay(QWidget *parent, const QString &title, boo
 	return overlay;
 }
 
+namespace
+{
+constexpr int TAB_LANGUAGE = 0;
+constexpr int TAB_DATA = 1;
+constexpr int TAB_MOD_PRESET = 2;
+constexpr int TAB_INFO = 3;
+constexpr int TAB_COUNT = 4;
+}
+
 FirstLaunchView::FirstLaunchView(QWidget * parent)
 	: QWidget(parent)
 	, ui(std::make_unique<Ui::FirstLaunchView>())
@@ -43,7 +52,7 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	ui->setupUi(this);
 
 	enterSetup();
-	activateTabLanguage();
+	activateTab(TAB_LANGUAGE);
 
 	ui->lineEditDataSystem->setText(pathToQString(boost::filesystem::absolute(VCMIDirs::get().dataPaths().front())));
 	ui->lineEditDataUser->setText(pathToQString(boost::filesystem::absolute(VCMIDirs::get().userDataPath())));
@@ -96,17 +105,17 @@ void FirstLaunchView::changeEvent(QEvent * event)
 
 void FirstLaunchView::on_pushButtonLanguageNext_clicked()
 {
-	activateTabHeroesData();
+	activateNextTab();
 }
 
 void FirstLaunchView::on_pushButtonDataNext_clicked()
 {
-	activateTabModPreset();
+	activateNextTab();
 }
 
 void FirstLaunchView::on_pushButtonDataBack_clicked()
 {
-	activateTabLanguage();
+	activatePreviousTab();
 }
 
 void FirstLaunchView::on_pushButtonDataSearch_clicked()
@@ -140,52 +149,123 @@ void FirstLaunchView::enterSetup()
 
 void FirstLaunchView::setSetupProgress(int progress)
 {
-	ui->buttonTabLanguage->setDisabled(progress < 1);
-	ui->buttonTabHeroesData->setDisabled(progress < 2);
-	ui->buttonTabModPreset->setDisabled(progress < 3);
+	Q_UNUSED(progress);
+}
+
+bool FirstLaunchView::isDemoDataDetected() const
+{
+	QDir userRoot = pathToQString(VCMIDirs::get().userDataPath());
+	QDir dataDir(userRoot.filePath(QStringLiteral("Data")));
+	QDir mapsDir(userRoot.filePath(QStringLiteral("Maps")));
+
+	bool hasDemoMap = false;
+	const QStringList mapFiles = mapsDir.entryList(QDir::Files | QDir::Readable);
+	for(const QString &name : mapFiles)
+	{
+		if(name.compare(QStringLiteral("h3demo.h3m"), Qt::CaseInsensitive) == 0)
+		{
+			hasDemoMap = true;
+			break;
+		}
+	}
+
+	if(!hasDemoMap)
+		return false;
+
+	const QStringList files = dataDir.entryList(QDir::Files | QDir::Readable);
+	for(const QString &name : files)
+	{
+		if(name.compare(QStringLiteral("H3ab_spr.lod"), Qt::CaseInsensitive) == 0)
+		{
+			QFileInfo lodInfo(dataDir.filePath(name));
+			const quint64 fileSize = static_cast<quint64>(lodInfo.size());
+			logGlobal->trace("H3ab_spr.lod size: %llu", fileSize);
+			if(fileSize < 8000000) // 8 MB + Demo map = Merged Windows and MacOS Demo
+				return true;
+		}
+	}
+
+	return false;
+}
+
+bool FirstLaunchView::shouldShowTab(int tabIndex) const
+{
+	if(tabIndex == TAB_DATA)
+		return !heroesDataDetect() || isDemoDataDetected();
+
+	return tabIndex >= TAB_LANGUAGE && tabIndex < TAB_COUNT;
+}
+
+void FirstLaunchView::activateTab(int tabIndex)
+{
+	if(tabIndex < TAB_LANGUAGE || tabIndex >= TAB_COUNT)
+		return;
+
+	if(!shouldShowTab(tabIndex))
+	{
+		activateNextTab();
+		return;
+	}
+
+	setSetupProgress(tabIndex + 1);
+	ui->installerTabs->setCurrentIndex(tabIndex);
+
+	if(tabIndex == TAB_DATA)
+	{
+		if(heroesDataUpdate())
+			return;
+
+		QString installPath = getHeroesInstallDir();
+		if(!installPath.isEmpty())
+		{
+			auto reply = QMessageBox::question(this, tr("Heroes III installation found!"), tr("Copy data to VCMI folder?"), QMessageBox::Yes | QMessageBox::No);
+			if(reply == QMessageBox::Yes)
+				copyHeroesData(installPath, false);
+		}
+	}
+
+	if(tabIndex == TAB_MOD_PRESET)
+		modPresetUpdate();
+}
+
+void FirstLaunchView::activateNextTab()
+{
+	int nextTab = ui->installerTabs->currentIndex() + 1;
+	while(nextTab < TAB_COUNT && !shouldShowTab(nextTab))
+		++nextTab;
+
+	if(nextTab < TAB_COUNT)
+		activateTab(nextTab);
+}
+
+void FirstLaunchView::activatePreviousTab()
+{
+	int previousTab = ui->installerTabs->currentIndex() - 1;
+	while(previousTab >= TAB_LANGUAGE && !shouldShowTab(previousTab))
+		--previousTab;
+
+	if(previousTab >= TAB_LANGUAGE)
+		activateTab(previousTab);
 }
 
 void FirstLaunchView::activateTabLanguage()
 {
-	setSetupProgress(1);
-	ui->installerTabs->setCurrentIndex(0);
-	ui->buttonTabLanguage->setChecked(true);
-	ui->buttonTabHeroesData->setChecked(false);
-	ui->buttonTabModPreset->setChecked(false);
+	activateTab(TAB_LANGUAGE);
 }
 
 void FirstLaunchView::activateTabHeroesData()
 {
-	setSetupProgress(2);
-	ui->installerTabs->setCurrentIndex(1);
-	ui->buttonTabLanguage->setChecked(false);
-	ui->buttonTabHeroesData->setChecked(true);
-	ui->buttonTabModPreset->setChecked(false);
-
-	if(heroesDataUpdate())
-	{
-		activateTabModPreset();
-		return;
-	}
-
-	QString installPath = getHeroesInstallDir();
-	if(!installPath.isEmpty())
-	{
-		auto reply = QMessageBox::question(this, tr("Heroes III installation found!"), tr("Copy data to VCMI folder?"), QMessageBox::Yes | QMessageBox::No);
-		if(reply == QMessageBox::Yes)
-			copyHeroesData(installPath, false);
-	}
+	activateTab(TAB_DATA);
 }
 
 void FirstLaunchView::activateTabModPreset()
 {
-	setSetupProgress(3);
-	ui->installerTabs->setCurrentIndex(2);
-	ui->buttonTabLanguage->setChecked(false);
-	ui->buttonTabHeroesData->setChecked(false);
-	ui->buttonTabModPreset->setChecked(true);
+	activateTab(TAB_MOD_PRESET);
+}
 
-	modPresetUpdate();
+void FirstLaunchView::activateTabInfo()
+{
+	activateTab(TAB_INFO);
 }
 
 void FirstLaunchView::exitSetup(bool goToMods)
@@ -784,32 +864,7 @@ bool FirstLaunchView::checkCanInstallDemo()
 	if(!checkCanInstallMod("demo-support"))
 		return false;
 
-	QDir userRoot = pathToQString(VCMIDirs::get().userDataPath());
-	QDir dataDir(userRoot.filePath(QStringLiteral("Data")));
-	QDir mapsDir(userRoot.filePath(QStringLiteral("Maps")));
-
-	bool hasDemoMap = false;
-	QStringList mapFiles = mapsDir.entryList(QDir::Files | QDir::Readable);
-	for(const QString &name : mapFiles)
-		if(name.compare(QStringLiteral("h3demo.h3m"), Qt::CaseInsensitive) == 0)
-		{
-			hasDemoMap = true;
-			break;
-		}
-	
-	QStringList files = dataDir.entryList(QDir::Files | QDir::Readable);
-	for(const QString &name : files)
-	{
-		if(name.compare(QStringLiteral("H3ab_spr.lod"), Qt::CaseInsensitive) == 0)
-		{
-			QFileInfo lodInfo(dataDir.filePath(name));
-			quint64 fileSize = static_cast<quint64>(lodInfo.size());
-			logGlobal->trace("H3ab_spr.lod size: %llu", fileSize);
-			if(fileSize < 8000000 && hasDemoMap) // 8 MB + Demo map = Merged Windows and MacOS Demo
-				return true;
-		}
-	}
-	return false;
+	return isDemoDataDetected();
 }
 
 bool FirstLaunchView::checkCanInstallHota()
@@ -850,10 +905,20 @@ bool FirstLaunchView::checkCanInstallMod(const QString & modID)
 
 void FirstLaunchView::on_pushButtonPresetBack_clicked()
 {
-	activateTabHeroesData();
+	activatePreviousTab();
 }
 
 void FirstLaunchView::on_pushButtonPresetNext_clicked()
+{
+	activateNextTab();
+}
+
+void FirstLaunchView::on_pushButtonInfoBack_clicked()
+{
+	activatePreviousTab();
+}
+
+void FirstLaunchView::on_pushButtonFinish_clicked()
 {
 	QStringList modsToInstall;
 

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -349,7 +349,7 @@ void FirstLaunchView::heroesDataDetected()
 }
 
 // Tab Heroes III Data
-bool FirstLaunchView::heroesDataDetect()
+bool FirstLaunchView::heroesDataDetect() const
 {
 	// user might have copied files to one of our data path.
 	// perform full reinitialization of virtual filesystem

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -30,6 +30,12 @@ class FirstLaunchView : public QWidget
 	void activateTabLanguage();
 	void activateTabHeroesData();
 	void activateTabModPreset();
+	void activateTabInfo();
+	void activateTab(int tabIndex);
+	void activateNextTab();
+	void activatePreviousTab();
+	bool shouldShowTab(int tabIndex) const;
+	bool isDemoDataDetected() const;
 	void exitSetup(bool goToMods);
 	
 	// Tab Language
@@ -94,6 +100,10 @@ private slots:
 	void on_pushButtonPresetBack_clicked();
 
 	void on_pushButtonPresetNext_clicked();
+
+	void on_pushButtonInfoBack_clicked();
+
+	void on_pushButtonFinish_clicked();
 
 	void on_pushButtonDiscord_clicked();
 

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -42,7 +42,7 @@ class FirstLaunchView : public QWidget
 	void languageSelected(const QString & languageCode);
 
 	// Tab Heroes III Data
-	bool heroesDataDetect();
+	bool heroesDataDetect() const;
 
 	void heroesDataMissing();
 	void heroesDataDetected();

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -20,124 +20,128 @@
       <number>0</number>
      </property>
      <widget class="QWidget" name="pageLanguage">
-      <widget class="QWidget" name="verticalLayoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>2</x>
-         <y>40</y>
-         <width>721</width>
-         <height>271</height>
-        </rect>
+      <layout class="QVBoxLayout" name="verticalLayoutLanguagePage">
+       <property name="leftMargin">
+        <number>12</number>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QListWidget" name="listWidgetLanguage">
-          <property name="spacing">
-           <number>5</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_6">
-          <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="layoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>2</x>
-         <y>330</y>
-         <width>721</width>
-         <height>31</height>
-        </rect>
+       <property name="topMargin">
+        <number>12</number>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Orientation::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonLanguageNext">
-          <property name="text">
-           <string>Next</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QLabel" name="labelLanguageTitle">
-       <property name="geometry">
-        <rect>
-         <x>5</x>
-         <y>0</y>
-         <width>721</width>
-         <height>20</height>
-        </rect>
+       <property name="rightMargin">
+        <number>12</number>
        </property>
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
+       <property name="bottomMargin">
+        <number>12</number>
        </property>
-       <property name="text">
-        <string>Select your language</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignCenter</set>
-       </property>
-      </widget>
+       <item>
+        <widget class="QLabel" name="labelLanguageTitle">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Select your language</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayoutLanguageContent">
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QListWidget" name="listWidgetLanguage">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>220</height>
+            </size>
+           </property>
+           <property name="spacing">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonLanguageNext">
+           <property name="text">
+            <string>Next</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="pageDataFiles">
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <property name="spacing">
-        <number>0</number>
+        <number>8</number>
        </property>
        <property name="leftMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="topMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="rightMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="bottomMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <item>
         <widget class="QLabel" name="labelDataTitle">
@@ -159,10 +163,13 @@
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Fixed</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>0</height>
+           <height>12</height>
           </size>
          </property>
         </spacer>
@@ -397,6 +404,25 @@
            </property>
           </widget>
          </item>
+         <item row="11" column="0" colspan="3">
+          <widget class="QLabel" name="labelDataDemoInfo">
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>100</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Detected Heroes III demo files only. You can continue with demo support, but importing full game data is recommended for the best experience.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
          <item row="3" column="0" colspan="3">
           <widget class="QLabel" name="labelDataGogDescr">
            <property name="sizePolicy">
@@ -508,6 +534,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Fixed</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -537,7 +566,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <item row="1" column="0">
           <widget class="QToolButton" name="buttonPresetLanguage">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -610,7 +639,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <item row="4" column="0">
           <widget class="QToolButton" name="buttonPresetHota">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -648,7 +677,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <item row="3" column="0">
           <widget class="QToolButton" name="buttonPresetExtras">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -769,7 +798,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <item row="5" column="0">
           <widget class="QToolButton" name="buttonPresetWog">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -807,7 +836,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <item row="6" column="0">
           <widget class="QToolButton" name="buttonPresetTow">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -845,7 +874,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <item row="7" column="0">
           <widget class="QToolButton" name="buttonPresetFod">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -883,7 +912,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <item row="2" column="0">
           <widget class="QToolButton" name="buttonPresetDemo">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -164,22 +164,7 @@
          </property>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer_8">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>12</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
+       
        <item>
         <layout class="QGridLayout" name="gridLayout" columnstretch="1,2,1">
          <property name="spacing">
@@ -560,22 +545,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          </property>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
+       
        <item>
         <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,0">
          <item row="0" column="1">
@@ -1073,22 +1043,7 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
          </property>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacerInfoTop">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
+       
        <item>
         <layout class="QVBoxLayout" name="verticalLayoutInfoLinks">
          <item>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -164,7 +164,7 @@
           <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Policy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -453,6 +453,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Expanding</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -503,16 +506,16 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
      <widget class="QWidget" name="pageModPreset">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="leftMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="topMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="rightMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="bottomMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <item>
         <widget class="QLabel" name="labelPresetTitle">
@@ -535,7 +538,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
           <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Policy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -957,6 +960,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Expanding</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -999,61 +1005,51 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
       </layout>
      </widget>
      <widget class="QWidget" name="pageInfo">
-      <layout class="QGridLayout" name="gridLayout_3">
+      <layout class="QVBoxLayout" name="verticalLayoutInfoPage">
        <property name="leftMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="topMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="rightMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
        <property name="bottomMargin">
-        <number>0</number>
+        <number>12</number>
        </property>
-       <property name="horizontalSpacing">
-        <number>6</number>
-       </property>
-       <item row="1" column="0">
-        <spacer name="verticalSpacer">
+       <item>
+        <widget class="QLabel" name="labelInfoTitle">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Final information</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacerInfoTop">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>8</height>
+           <height>20</height>
           </size>
          </property>
         </spacer>
        </item>
-       <item row="2" column="0" colspan="2">
-        <layout class="QGridLayout" name="gridLayout_5">
-         <item row="2" column="0">
-          <widget class="QPushButton" name="pushButtonGithub">
-           <property name="text">
-            <string>VCMI on Github</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="pushButtonDiscord">
-           <property name="text">
-            <string>VCMI on Discord</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="QLabel" name="labelLanguageSocial">
-           <property name="text">
-            <string>Have a question? Found a bug? Want to help? Join us!</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="0" column="0" colspan="2">
+       <item>
         <widget class="QLabel" name="labelLanguageWelcome">
          <property name="text">
           <string>Thank you for installing VCMI!
@@ -1069,7 +1065,48 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0" colspan="2">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayoutInfoLinks">
+         <item>
+          <widget class="QLabel" name="labelLanguageSocial">
+           <property name="text">
+            <string>Have a question? Found a bug? Want to help? Join us!</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonDiscord">
+           <property name="text">
+            <string>VCMI on Discord</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonGithub">
+           <property name="text">
+            <string>VCMI on Github</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacerInfoBottom">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="spacing">
           <number>6</number>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -195,7 +195,7 @@
          <item row="2" column="0" colspan="2">
           <widget class="QLabel" name="labelDataGogTitle">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>50</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -213,7 +213,7 @@
          <item row="7" column="0" colspan="3">
           <widget class="QLabel" name="labelDataManualDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -245,7 +245,7 @@
          <item row="6" column="0" colspan="2">
           <widget class="QLabel" name="labelDataManualTitle">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>50</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -320,7 +320,7 @@
          <item row="5" column="0" colspan="3">
           <widget class="QLabel" name="labelDataCopyDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -339,7 +339,7 @@
          <item row="8" column="0">
           <widget class="QLabel" name="labelDataFiles">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>50</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -357,7 +357,7 @@
          <item row="4" column="0" colspan="2">
           <widget class="QLabel" name="labelDataCopyTitle">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>50</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -391,7 +391,7 @@
          <item row="10" column="0" colspan="3">
           <widget class="QLabel" name="labelDataFound">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -410,7 +410,7 @@
             <bool>false</bool>
            </property>
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -426,7 +426,7 @@
          <item row="3" column="0" colspan="3">
           <widget class="QLabel" name="labelDataGogDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -533,6 +533,22 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="labelPresetDescription">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>100</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Optionally, you can install additional mods either now, or at any point later, using the VCMI Launcher</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_5">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -550,10 +566,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
        </item>
        <item>
         <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,0">
-         <item row="1" column="1">
+         <item row="0" column="1">
           <widget class="QLabel" name="labelPresetLanguageDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -566,7 +582,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="0" column="0">
           <widget class="QToolButton" name="buttonPresetLanguage">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -607,10 +623,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="3" column="1">
           <widget class="QLabel" name="labelPresetHotaDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -623,23 +639,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="QLabel" name="labelPresetDescription">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Optionally, you can install additional mods either now, or at any point later, using the VCMI Launcher</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
+         <item row="3" column="0">
           <widget class="QToolButton" name="buttonPresetHota">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -677,7 +677,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="2" column="0">
           <widget class="QToolButton" name="buttonPresetExtras">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -718,10 +718,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="4" column="1">
           <widget class="QLabel" name="labelPresetWogDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -734,10 +734,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="5" column="1">
           <widget class="QLabel" name="labelPresetTowDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -750,10 +750,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="6" column="1">
           <widget class="QLabel" name="labelPresetFodDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -766,10 +766,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="1" column="1">
           <widget class="QLabel" name="labelPresetDemoDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -782,10 +782,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="2" column="1">
           <widget class="QLabel" name="labelPresetExtrasDescr">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>100</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -798,7 +798,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="4" column="0">
           <widget class="QToolButton" name="buttonPresetWog">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -836,7 +836,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="5" column="0">
           <widget class="QToolButton" name="buttonPresetTow">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -874,7 +874,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="6" column="0">
           <widget class="QToolButton" name="buttonPresetFod">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -912,7 +912,7 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="1" column="0">
           <widget class="QToolButton" name="buttonPresetDemo">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1034,6 +1034,28 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="labelLanguageWelcome">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Thank you for installing VCMI!
+
+Before you can start playing, there are a few more steps to complete.
+
+Please remember that to use VCMI, you must own the original data files for Heroes® of Might and Magic® III: Complete or The Shadow of Death.
+
+Heroes® of Might and Magic® III HD is currently not supported!</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacerInfoTop">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -1050,25 +1072,15 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
         </spacer>
        </item>
        <item>
-        <widget class="QLabel" name="labelLanguageWelcome">
-         <property name="text">
-          <string>Thank you for installing VCMI!
-
-Before you can start playing, there are a few more steps to complete.
-
-Please remember that to use VCMI, you must own the original data files for Heroes® of Might and Magic® III: Complete or The Shadow of Death.
-
-Heroes® of Might and Magic® III HD is currently not supported!</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
         <layout class="QVBoxLayout" name="verticalLayoutInfoLinks">
          <item>
           <widget class="QLabel" name="labelLanguageSocial">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
            <property name="text">
             <string>Have a question? Found a bug? Want to help? Join us!</string>
            </property>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -145,6 +145,12 @@
        </property>
        <item>
         <widget class="QLabel" name="labelDataTitle">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="font">
           <font>
            <bold>true</bold>
@@ -519,6 +525,12 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
        </property>
        <item>
         <widget class="QLabel" name="labelPresetTitle">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="font">
           <font>
            <bold>true</bold>
@@ -1020,6 +1032,12 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
        </property>
        <item>
         <widget class="QLabel" name="labelInfoTitle">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="font">
           <font>
            <bold>true</bold>


### PR DESCRIPTION
### Motivation

- The first-launch UI was reordered (Language → Data → Mod Preset → Info) and existing hardcoded Next/Back flows broke navigation and page-skipping logic.
- The Data page should be skipped when full game data is already present but still shown for demo-data installs, and the flow should be easier to extend with new pages.

### Description

- Added a tab abstraction and navigation helpers: `activateTab(int)`, `activateNextTab()`, `activatePreviousTab()`, and tab constants for clarity (`TAB_LANGUAGE`, `TAB_DATA`, `TAB_MOD_PRESET`, `TAB_INFO`).
- Implemented conditional visibility via `shouldShowTab(...)` and centralized demo detection in `isDemoDataDetected()` so Data page is skipped when appropriate and demo logic is reused for `demo-support` eligibility.
- Rewired button handlers to use the new navigation helpers so `Next`/`Back`/`Finish` now follow the visible-page flow and `Finish` performs final mod installation.
- Changes made in `launcher/firstLaunch/firstlaunch_moc.cpp` and `launcher/firstLaunch/firstlaunch_moc.h` to add the new functions, replace hardcoded transitions, and reuse demo detection.

### Testing

- Ran `cmake -S . -B build -G Ninja` to sanity-check the project configuration; configure ran but failed due to missing Boost development components (`date_time filesystem locale program_options iostreams`).
- No full build/test run was possible in this environment because required system dependencies (Boost dev) are missing, so behavior verification was limited to code inspection and local static checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f17a20f0832da76a4fd10f35b0b2)