### PR TITLE
Improve first-launch Heroes III data page with radio-based flow

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -69,6 +69,8 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	ui->labelDataGogTitle->hide();
 	ui->labelDataGogDescr->hide();
 #endif
+
+	updateDataOptionDetails();
 }
 
 FirstLaunchView::~FirstLaunchView() = default;
@@ -123,10 +125,40 @@ void FirstLaunchView::on_pushButtonDataSearch_clicked()
 	heroesDataUpdate();
 }
 
+void FirstLaunchView::on_radioButtonDataDetected_toggled(bool checked)
+{
+	if(checked)
+		updateDataOptionDetails();
+}
+
+void FirstLaunchView::on_radioButtonDataGog_toggled(bool checked)
+{
+	if(checked)
+		updateDataOptionDetails();
+}
+
+void FirstLaunchView::on_radioButtonDataCopy_toggled(bool checked)
+{
+	if(checked)
+		updateDataOptionDetails();
+}
+
+void FirstLaunchView::on_radioButtonDataManual_toggled(bool checked)
+{
+	if(checked)
+		updateDataOptionDetails();
+}
+
 void FirstLaunchView::on_pushButtonDataCopy_clicked()
 {
 	// iOS can't display modal dialogs when called directly on button press
 	// https://bugreports.qt.io/browse/QTBUG-98651
+	if(ui->radioButtonDataDetected->isVisible() && ui->radioButtonDataDetected->isChecked() && !detectedInstallPath.isEmpty())
+	{
+		copyHeroesData(detectedInstallPath, false);
+		return;
+	}
+
 	MessageBoxCustom::showDialog(this, [this]{
 		Helper::nativeFolderPicker(this, [this](const QString &picked){
 			if(!picked.isEmpty())
@@ -215,13 +247,8 @@ void FirstLaunchView::activateTab(int tabIndex)
 		if(heroesDataUpdate())
 			return;
 
-		QString installPath = getHeroesInstallDir();
-		if(!installPath.isEmpty())
-		{
-			auto reply = QMessageBox::question(this, tr("Heroes III installation found!"), tr("Copy data to VCMI folder?"), QMessageBox::Yes | QMessageBox::No);
-			if(reply == QMessageBox::Yes)
-				copyHeroesData(installPath, false);
-		}
+		setDetectedInstallPath(getHeroesInstallDir());
+		updateDataOptionDetails();
 	}
 
 	if(tabIndex == TAB_MOD_PRESET)
@@ -294,6 +321,58 @@ bool FirstLaunchView::heroesDataUpdate()
 	return detected;
 }
 
+void FirstLaunchView::setDetectedInstallPath(const QString & path)
+{
+	detectedInstallPath = path;
+	const bool hasDetectedPath = !detectedInstallPath.isEmpty();
+	ui->radioButtonDataDetected->setVisible(hasDetectedPath);
+	ui->radioButtonDataDetected->setEnabled(hasDetectedPath);
+	ui->radioButtonDataDetected->setText(tr("VCMI detected your Heroes III Installation at: %1").arg(detectedInstallPath));
+
+	if(!hasDetectedPath && ui->radioButtonDataDetected->isChecked())
+		ui->radioButtonDataManual->setChecked(true);
+}
+
+void FirstLaunchView::updateDataOptionDetails()
+{
+	QString details;
+
+	if(ui->radioButtonDataDetected->isVisible() && ui->radioButtonDataDetected->isChecked())
+		details = tr("VCMI found your Heroes III installation path. Click 'Copy existing data' to import files automatically from this location.");
+	else if(ui->radioButtonDataGog->isChecked())
+		details = tr("If you own Heroes III on gog.com, download the backup offline installer and select both files: '.exe' and '-1.bin'. Then click 'Install gog.com files'.");
+	else if(ui->radioButtonDataCopy->isChecked())
+		details = tr("If Heroes III files are already on your device, select the game folder and VCMI will copy required data automatically.");
+	else
+		details = tr("You can manually copy directories Maps, Data, and Mp3 from the original game directory to the VCMI data directory shown below.");
+
+	ui->labelDataOptionDetails->setText(details);
+
+	const bool canUseDataCopy = Helper::canUseFolderPicker();
+	const bool useDetected = ui->radioButtonDataDetected->isVisible() && ui->radioButtonDataDetected->isChecked();
+	const bool useGog = ui->radioButtonDataGog->isChecked();
+	const bool useCopy = ui->radioButtonDataCopy->isChecked() || useDetected;
+
+	ui->pushButtonDataSearch->setVisible(ui->radioButtonDataManual->isChecked());
+	ui->pushButtonDataCopy->setVisible(canUseDataCopy && useCopy);
+	ui->pushButtonDataCopy->setEnabled(canUseDataCopy && (ui->radioButtonDataCopy->isChecked() || useDetected));
+	ui->pushButtonDataCopy->setText(useDetected ? tr("Copy detected data") : tr("Copy existing data"));
+
+#ifdef ENABLE_INNOEXTRACT
+	ui->pushButtonGogInstall->setVisible(useGog);
+	ui->pushButtonGogInstall->setEnabled(useGog);
+	ui->labelDataGogTitle->setVisible(useGog);
+	ui->labelDataGogDescr->setVisible(useGog);
+#else
+	Q_UNUSED(useGog);
+#endif
+
+	ui->labelDataCopyTitle->setVisible(canUseDataCopy && useCopy);
+	ui->labelDataCopyDescr->setVisible(canUseDataCopy && useCopy);
+	ui->labelDataManualTitle->setVisible(ui->radioButtonDataManual->isChecked());
+	ui->labelDataManualDescr->setVisible(ui->radioButtonDataManual->isChecked());
+}
+
 void FirstLaunchView::heroesDataMissing()
 {
 	const bool demoDetected = isDemoDataDetected();
@@ -302,21 +381,13 @@ void FirstLaunchView::heroesDataMissing()
 	ui->lineEditDataSystem->setPalette(newPalette);
 	ui->lineEditDataUser->setPalette(newPalette);
 
-	ui->labelDataManualTitle->setVisible(true);
-	ui->labelDataManualDescr->setVisible(true);
-	ui->pushButtonDataSearch->setVisible(true);
+	ui->radioButtonDataGog->setVisible(true);
+	ui->radioButtonDataCopy->setVisible(true);
+	ui->radioButtonDataManual->setVisible(true);
+	ui->labelDataOptionDetails->setVisible(true);
 
-	const bool canUseDataCopy = Helper::canUseFolderPicker();
-
-	ui->labelDataCopyTitle->setVisible(canUseDataCopy);
-	ui->labelDataCopyDescr->setVisible(canUseDataCopy);
-	ui->pushButtonDataCopy->setVisible(canUseDataCopy);
-
-#ifdef ENABLE_INNOEXTRACT
-	ui->pushButtonGogInstall->setVisible(true);
-	ui->labelDataGogTitle->setVisible(true);
-	ui->labelDataGogDescr->setVisible(true);
-#endif
+	setDetectedInstallPath(getHeroesInstallDir());
+	updateDataOptionDetails();
 
 	ui->labelDataFound->setVisible(false);
 	ui->labelDataDemoInfo->setVisible(demoDetected);
@@ -332,17 +403,20 @@ void FirstLaunchView::heroesDataDetected()
 
 	ui->pushButtonDataSearch->setVisible(false);
 	ui->pushButtonDataCopy->setVisible(false);
+	ui->pushButtonGogInstall->setVisible(false);
+
+	ui->radioButtonDataDetected->setVisible(false);
+	ui->radioButtonDataGog->setVisible(false);
+	ui->radioButtonDataCopy->setVisible(false);
+	ui->radioButtonDataManual->setVisible(false);
+	ui->labelDataOptionDetails->setVisible(false);
 
 	ui->labelDataManualTitle->setVisible(false);
 	ui->labelDataManualDescr->setVisible(false);
 	ui->labelDataCopyTitle->setVisible(false);
 	ui->labelDataCopyDescr->setVisible(false);
-
-#ifdef ENABLE_INNOEXTRACT
-	ui->pushButtonGogInstall->setVisible(false);
 	ui->labelDataGogTitle->setVisible(false);
 	ui->labelDataGogDescr->setVisible(false);
-#endif
 
 	ui->labelDataFound->setVisible(true);
 	ui->labelDataDemoInfo->setVisible(false);

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -52,6 +52,8 @@ class FirstLaunchView : public QWidget
 	void extractGogDataAsync(QString filePathBin, QString filePathExe);
 	bool performCopyFlow(const QString& path, ProgressOverlay* overlay, bool removeSource);
 	void copyHeroesData(const QString & path = {}, bool removeSource = false);
+	void updateDataOptionDetails();
+	void setDetectedInstallPath(const QString & path);
 
 	// Tab Mod Preset
 	void modPresetUpdate();
@@ -93,6 +95,11 @@ private slots:
 
 	void on_pushButtonDataSearch_clicked();
 
+	void on_radioButtonDataDetected_toggled(bool checked);
+	void on_radioButtonDataGog_toggled(bool checked);
+	void on_radioButtonDataCopy_toggled(bool checked);
+	void on_radioButtonDataManual_toggled(bool checked);
+
 	void on_pushButtonDataCopy_clicked();
 
 	void on_pushButtonGogInstall_clicked();
@@ -111,4 +118,5 @@ private slots:
 
 private:
 	std::unique_ptr<Ui::FirstLaunchView> ui;
+	QString detectedInstallPath;
 };

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -165,6 +165,19 @@
         </widget>
        </item>
        <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <widget class="QLabel" name="labelDataIntro">
          <property name="text">
           <string>Choose how you want to import Heroes III data files. Detailed instructions for the selected option are shown below.</string>
@@ -180,7 +193,7 @@
           <bool>false</bool>
          </property>
          <property name="text">
-          <string>Use detected Heroes III installation</string>
+          <string>Detected Heroes III installation</string>
          </property>
         </widget>
        </item>
@@ -188,6 +201,9 @@
         <widget class="QRadioButton" name="radioButtonDataGog">
          <property name="text">
           <string>Use offline installer from gog.com</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -201,7 +217,7 @@
        <item>
         <widget class="QRadioButton" name="radioButtonDataManual">
          <property name="checked">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="text">
           <string>Manual installation</string>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -144,7 +144,7 @@
         <number>12</number>
        </property>
        <item>
-        <widget class="QLabel" name="labelDataTitle">
+       <widget class="QLabel" name="labelDataTitle">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -161,6 +161,69 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelDataIntro">
+         <property name="text">
+          <string>Choose how you want to import Heroes III data files. Detailed instructions for the selected option are shown below.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="radioButtonDataDetected">
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Use detected Heroes III installation</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="radioButtonDataGog">
+         <property name="text">
+          <string>Use offline installer from gog.com</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="radioButtonDataCopy">
+         <property name="text">
+          <string>Copy existing files from local folder</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="radioButtonDataManual">
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>Manual installation</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelDataOptionDetails">
+         <property name="frameShape">
+          <enum>QFrame::Shape::StyledPanel</enum>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="margin">
+          <number>8</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
### Motivation

- Make the first-launch "Heroes III data" page clearer by consolidating multiple options into a single set of mutually exclusive choices with a single dynamic instruction area.
- Replace the blocking confirmation popup for a detected Heroes III installation with an inline radio option that is shown only when a detection path is available and can be used directly.

### Description

- Added radio buttons and a single dynamic details panel in the data page UI by modifying `launcher/firstLaunch/firstlaunch_moc.ui` to present options: detected install / GOG installer / copy from folder / manual, plus `labelDataOptionDetails` for contextual text.
- Declared new helpers, slots and storage (`detectedInstallPath`, `updateDataOptionDetails`, `setDetectedInstallPath`, and radio toggle slots) in `launcher/firstLaunch/firstlaunch_moc.h`.
- Implemented the new flow and UI-reactive logic in `launcher/firstLaunch/firstlaunch_moc.cpp`, including `setDetectedInstallPath`, `updateDataOptionDetails`, radio toggle handlers, replacing the startup `QMessageBox` popup with the detected-install radio option, and wiring `on_pushButtonDataCopy` to copy from the detected path when that radio is selected.
- Updated visibility and enable/disable logic so controls (`pushButtonDataCopy`, `pushButtonGogInstall`, labels) reflect the current radio selection and detection state.

### Testing

- Ran `git diff --check` which reported no whitespace/patch issues.
- Attempted `cmake --build build --target launcher -j2` but the build failed in this environment because `/workspace/vcmi/build` does not exist, so a full compile could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a438ed16c0832db44b38f019f09365)