### PR TITLE
Launcher: support Folder/ZIP option for first-launch data import

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -412,9 +412,13 @@ void FirstLaunchView::updateDataOptionState(bool dataDetected)
 void FirstLaunchView::updateDataOptionDetails()
 {
 	const bool manualSelected = ui->radioButtonDataManual->isChecked();
+	const bool copySelected = ui->radioButtonDataCopy->isChecked();
+	const bool canUseDataCopy = Helper::canUseFolderPicker();
 	ui->labelDataFiles->setVisible(manualSelected);
 	ui->lineEditDataUser->setVisible(manualSelected);
 	ui->lineEditDataSystem->setVisible(manualSelected);
+	ui->radioButtonFolder->setVisible(copySelected && canUseDataCopy);
+	ui->radioButtonZIP->setVisible(copySelected && canUseDataCopy);
 
 	if(ui->radioButtonDataDetected->isChecked())
 	{
@@ -435,7 +439,11 @@ void FirstLaunchView::updateDataOptionDetails()
 	}
 	else
 	{
-		ui->textBrowserDataOptionDetails->setText(tr("Choose your GOG offline installer files (.exe and -1.bin), then VCMI will extract and import game data automatically."));
+		ui->textBrowserDataOptionDetails->setHtml(tr(R"(
+<p>Pokud již víte o co jde a máte stažený Heroes III Complete z gog.com offline backup installer, pokračujte výběrem souborů stiskem tlačítka <b>Select installer</b>.</p>
+<p>Pokud hru ještě nevlastníte, je třeba si ji koupit na gog.com: <a href="https://www.gog.com/en/game/heroes_of_might_and_magic_3_complete_edition">Heroes of Might and Magic 3 Complete Edition</a>.</p>
+<p>Pokud ji už máte a jen si ji potřebujete stáhnout, stačí se přihlásit do svého účtu a potom stáhnout offline backup game installer EXE: <a href="https://www.gog.com/downloads/heroes_of_might_and_magic_3_complete_edition/en1installer0">en1installer0</a> a BIN: <a href="https://www.gog.com/downloads/heroes_of_might_and_magic_3_complete_edition/en1installer1">en1installer1</a>.</p>
+)"));
 		ui->pushButtonSelect->setText(tr("Select installer"));
 #ifdef ENABLE_INNOEXTRACT
 		ui->pushButtonSelect->setVisible(true);

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -19,6 +19,7 @@
 #include "../../lib/texts/Languages.h"
 #include "../../lib/VCMIDirs.h"
 #include "../../lib/filesystem/Filesystem.h"
+#include "../../lib/filesystem/CZipLoader.h"
 #include "../../vcmiqt/MessageBox.h"
 #include "../helper.h"
 #include "../languages.h"
@@ -149,14 +150,23 @@ void FirstLaunchView::on_pushButtonSelect_clicked()
 
 	if(ui->radioButtonDataCopy->isChecked())
 	{
-		// iOS can't display modal dialogs when called directly on button press
-		// https://bugreports.qt.io/browse/QTBUG-98651
-		MessageBoxCustom::showDialog(this, [this]{
-			Helper::nativeFolderPicker(this, [this](const QString &picked){
-				if(!picked.isEmpty())
-					copyHeroesData(picked, false);
+		if(ui->radioButtonZIP->isChecked())
+		{
+			const QString zipPath = QFileDialog::getOpenFileName(this, tr("Select ZIP archive"), defaultStartDirForOpen(), tr("Zip archives (*.zip)"));
+			if(!zipPath.isEmpty())
+				copyHeroesDataFromArchive(zipPath);
+		}
+		else
+		{
+			// iOS can't display modal dialogs when called directly on button press
+			// https://bugreports.qt.io/browse/QTBUG-98651
+			MessageBoxCustom::showDialog(this, [this]{
+				Helper::nativeFolderPicker(this, [this](const QString &picked){
+					if(!picked.isEmpty())
+						copyHeroesData(picked, false);
+				});
 			});
-		});
+		}
 		return;
 	}
 
@@ -186,6 +196,18 @@ void FirstLaunchView::on_radioButtonDataCopy_toggled(bool checked)
 void FirstLaunchView::on_radioButtonDataManual_toggled(bool checked)
 {
 	if(checked)
+		updateDataOptionDetails();
+}
+
+void FirstLaunchView::on_radioButtonFolder_toggled(bool checked)
+{
+	if(checked && ui->radioButtonDataCopy->isChecked())
+		updateDataOptionDetails();
+}
+
+void FirstLaunchView::on_radioButtonZIP_toggled(bool checked)
+{
+	if(checked && ui->radioButtonDataCopy->isChecked())
 		updateDataOptionDetails();
 }
 
@@ -372,6 +394,10 @@ void FirstLaunchView::updateDataOptionState(bool dataDetected)
 
 	const bool canUseDataCopy = Helper::canUseFolderPicker();
 	ui->radioButtonDataCopy->setVisible(canUseDataCopy);
+	ui->radioButtonFolder->setVisible(canUseDataCopy);
+	ui->radioButtonZIP->setVisible(canUseDataCopy);
+	if(canUseDataCopy && !ui->radioButtonFolder->isChecked() && !ui->radioButtonZIP->isChecked())
+		ui->radioButtonFolder->setChecked(true);
 	if(!canUseDataCopy && ui->radioButtonDataCopy->isChecked())
 		ui->radioButtonDataGog->setChecked(true);
 
@@ -392,24 +418,24 @@ void FirstLaunchView::updateDataOptionDetails()
 
 	if(ui->radioButtonDataDetected->isChecked())
 	{
-		ui->labelDataOptionDetails->setText(tr("VCMI found an existing Heroes III installation on this system. No additional action is required."));
+		ui->textBrowserDataOptionDetails->setText(tr("VCMI found an existing Heroes III installation on this system. No additional action is required."));
 		ui->pushButtonSelect->setVisible(false);
 	}
 	else if(ui->radioButtonDataCopy->isChecked())
 	{
-		ui->labelDataOptionDetails->setText(tr("Pick the folder with your existing Heroes III files and VCMI will copy all required data automatically."));
-		ui->pushButtonSelect->setText(tr("Select folder"));
+		ui->textBrowserDataOptionDetails->setText(ui->radioButtonZIP->isChecked() ? tr("Pick a ZIP archive with Heroes III files and VCMI will import all required data automatically.") : tr("Pick the folder with your existing Heroes III files and VCMI will copy all required data automatically."));
+		ui->pushButtonSelect->setText(ui->radioButtonZIP->isChecked() ? tr("Select ZIP") : tr("Select folder"));
 		ui->pushButtonSelect->setVisible(true);
 	}
 	else if(manualSelected)
 	{
-		ui->labelDataOptionDetails->setText(tr("Copy Heroes III files manually into the folders shown below, then press Scan again to verify installation."));
+		ui->textBrowserDataOptionDetails->setText(tr("Copy Heroes III files manually into the folders shown below, then press Scan again to verify installation."));
 		ui->pushButtonSelect->setText(tr("Scan again"));
 		ui->pushButtonSelect->setVisible(true);
 	}
 	else
 	{
-		ui->labelDataOptionDetails->setText(tr("Choose your GOG offline installer files (.exe and -1.bin), then VCMI will extract and import game data automatically."));
+		ui->textBrowserDataOptionDetails->setText(tr("Choose your GOG offline installer files (.exe and -1.bin), then VCMI will extract and import game data automatically."));
 		ui->pushButtonSelect->setText(tr("Select installer"));
 #ifdef ENABLE_INNOEXTRACT
 		ui->pushButtonSelect->setVisible(true);
@@ -842,6 +868,42 @@ void FirstLaunchView::extractGogDataAsync(QString filePathBin, QString filePathE
 				activateTabModPreset();
 	});
 #endif
+}
+
+void FirstLaunchView::copyHeroesDataFromArchive(const QString &archivePath)
+{
+	QTemporaryDir tempDir;
+	if(!tempDir.isValid())
+	{
+		QMessageBox::critical(this, tr("Extraction error"), tr("Failed to create temporary directory for ZIP extraction."));
+		return;
+	}
+
+	bool extracted = false;
+	try
+	{
+		ZipArchive archive(qstringToPath(archivePath));
+		const auto files = archive.listFiles();
+		extracted = archive.extract(qstringToPath(tempDir.path()), files);
+	}
+	catch(const std::exception &e)
+	{
+		QMessageBox::critical(this, tr("Extraction error"), tr("Failed to read ZIP archive: %1").arg(QString::fromUtf8(e.what())));
+		return;
+	}
+
+	if(!extracted)
+	{
+		QMessageBox::critical(this, tr("Extraction error"), tr("Failed to extract ZIP archive."));
+		return;
+	}
+
+	QPointer<ProgressOverlay> overlay = createOverlay(this, tr("Scanning selected folder..."), true);
+	overlay->raise();
+	if(performCopyFlow(tempDir.path(), overlay, false))
+		if(heroesDataUpdate())
+			activateTabModPreset();
+	overlay->deleteLater();
 }
 
 void FirstLaunchView::copyHeroesData(const QString &path, bool removeSource)

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -152,7 +152,7 @@ void FirstLaunchView::on_pushButtonSelect_clicked()
 	{
 		if(ui->radioButtonZIP->isChecked())
 		{
-			const QString zipPath = QFileDialog::getOpenFileName(this, tr("Select ZIP archive"), defaultStartDirForOpen(), tr("Zip archives (*.zip)"));
+			const QString zipPath = QFileDialog::getOpenFileName(this, tr("Select ZIP archive"), {}, tr("Zip archives (*.zip)"));
 			if(!zipPath.isEmpty())
 				copyHeroesDataFromArchive(zipPath);
 		}

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -422,27 +422,27 @@ void FirstLaunchView::updateDataOptionDetails()
 
 	if(ui->radioButtonDataDetected->isChecked())
 	{
-		ui->textBrowserDataOptionDetails->setText(tr("VCMI found an existing Heroes III installation on this system. No additional action is required."));
+		ui->textBrowserDataOptionDetails->setPlainText(tr("VCMI found an existing Heroes III installation on this system. No additional action is required."));
 		ui->pushButtonSelect->setVisible(false);
 	}
 	else if(ui->radioButtonDataCopy->isChecked())
 	{
-		ui->textBrowserDataOptionDetails->setText(ui->radioButtonZIP->isChecked() ? tr("Pick a ZIP archive with Heroes III files and VCMI will import all required data automatically.") : tr("Pick the folder with your existing Heroes III files and VCMI will copy all required data automatically."));
+		ui->textBrowserDataOptionDetails->setPlainText(ui->radioButtonZIP->isChecked() ? tr("Pick a ZIP archive with Heroes III files and VCMI will import all required data automatically.") : tr("Pick the folder with your existing Heroes III files and VCMI will copy all required data automatically."));
 		ui->pushButtonSelect->setText(ui->radioButtonZIP->isChecked() ? tr("Select ZIP") : tr("Select folder"));
 		ui->pushButtonSelect->setVisible(true);
 	}
 	else if(manualSelected)
 	{
-		ui->textBrowserDataOptionDetails->setText(tr("Copy Heroes III files manually into the folders shown below, then press Scan again to verify installation."));
+		ui->textBrowserDataOptionDetails->setPlainText(tr("Copy Heroes III files manually into the folders shown below, then press Scan again to verify installation."));
 		ui->pushButtonSelect->setText(tr("Scan again"));
 		ui->pushButtonSelect->setVisible(true);
 	}
 	else
 	{
 		ui->textBrowserDataOptionDetails->setHtml(tr(R"(
-<p>Pokud již víte o co jde a máte stažený Heroes III Complete z gog.com offline backup installer, pokračujte výběrem souborů stiskem tlačítka <b>Select installer</b>.</p>
-<p>Pokud hru ještě nevlastníte, je třeba si ji koupit na gog.com: <a href="https://www.gog.com/en/game/heroes_of_might_and_magic_3_complete_edition">Heroes of Might and Magic 3 Complete Edition</a>.</p>
-<p>Pokud ji už máte a jen si ji potřebujete stáhnout, stačí se přihlásit do svého účtu a potom stáhnout offline backup game installer EXE: <a href="https://www.gog.com/downloads/heroes_of_might_and_magic_3_complete_edition/en1installer0">en1installer0</a> a BIN: <a href="https://www.gog.com/downloads/heroes_of_might_and_magic_3_complete_edition/en1installer1">en1installer1</a>.</p>
+<p>If you already know this flow and have the Heroes III Complete offline backup installer from gog.com, continue by pressing <b>Select installer</b> and selecting the files.</p>
+<p>If you do not own the game yet, buy it on gog.com: <a href="https://www.gog.com/en/game/heroes_of_might_and_magic_3_complete_edition">Heroes of Might and Magic 3 Complete Edition</a>.</p>
+<p>If you already own it and only need to download it, sign in to your account and download the offline backup game installer EXE: <a href="https://www.gog.com/downloads/heroes_of_might_and_magic_3_complete_edition/en1installer0">en1installer0</a> and BIN: <a href="https://www.gog.com/downloads/heroes_of_might_and_magic_3_complete_edition/en1installer1">en1installer1</a>.</p>
 )"));
 		ui->pushButtonSelect->setText(tr("Select installer"));
 #ifdef ENABLE_INNOEXTRACT

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -54,6 +54,7 @@ class FirstLaunchView : public QWidget
 	void extractGogDataAsync(QString filePathBin, QString filePathExe);
 	bool performCopyFlow(const QString& path, ProgressOverlay* overlay, bool removeSource);
 	void copyHeroesData(const QString & path = {}, bool removeSource = false);
+	void copyHeroesDataFromArchive(const QString & archivePath);
 
 	// Tab Mod Preset
 	void modPresetUpdate();
@@ -103,6 +104,8 @@ private slots:
 	void on_radioButtonDataGog_toggled(bool checked);
 	void on_radioButtonDataCopy_toggled(bool checked);
 	void on_radioButtonDataManual_toggled(bool checked);
+	void on_radioButtonFolder_toggled(bool checked);
+	void on_radioButtonZIP_toggled(bool checked);
 
 	void on_pushButtonPresetBack_clicked();
 

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -198,6 +198,7 @@
          </property>
          <item row="4" column="0" colspan="4">
           <widget class="QRadioButton" name="radioButtonDataManual">
+           <attribute name="buttonGroup">mainDataSourceGroup</attribute>
            <property name="text">
             <string>Manual installation</string>
            </property>
@@ -208,6 +209,7 @@
          </item>
          <item row="3" column="0">
           <widget class="QRadioButton" name="radioButtonDataCopy">
+           <attribute name="buttonGroup">mainDataSourceGroup</attribute>
            <property name="text">
             <string>Copy existing files from selected</string>
            </property>
@@ -215,6 +217,7 @@
          </item>
          <item row="3" column="2">
           <widget class="QRadioButton" name="radioButtonFolder">
+           <attribute name="buttonGroup">copySourceGroup</attribute>
            <property name="text">
             <string>Folder</string>
            </property>
@@ -301,6 +304,7 @@
          </item>
          <item row="1" column="0" colspan="4">
           <widget class="QRadioButton" name="radioButtonDataDetected">
+           <attribute name="buttonGroup">mainDataSourceGroup</attribute>
            <property name="text">
             <string>Detected Heroes III installation</string>
            </property>
@@ -308,6 +312,7 @@
          </item>
          <item row="3" column="3">
           <widget class="QRadioButton" name="radioButtonZIP">
+           <attribute name="buttonGroup">copySourceGroup</attribute>
            <property name="text">
             <string>ZIP</string>
            </property>
@@ -347,6 +352,7 @@
          </item>
          <item row="2" column="0" colspan="3">
           <widget class="QRadioButton" name="radioButtonDataGog">
+           <attribute name="buttonGroup">mainDataSourceGroup</attribute>
            <property name="text">
             <string>Offline backup installer from https://www.gog.com/en/game/heroes_of_might_and_magic_3_complete_edition</string>
            </property>
@@ -1111,6 +1117,10 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
    </item>
   </layout>
  </widget>
+ <buttongroups>
+  <buttongroup name="mainDataSourceGroup"/>
+  <buttongroup name="copySourceGroup"/>
+ </buttongroups>
  <resources>
   <include location="../resources.qrc"/>
  </resources>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -218,6 +218,9 @@
            <property name="text">
             <string>Folder</string>
            </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
           </widget>
          </item>
          <item row="9" column="0" colspan="3">
@@ -237,7 +240,17 @@
           </widget>
          </item>
          <item row="6" column="0" colspan="4">
-          <widget class="QTextBrowser" name="textBrowserDataOptionDetails"/>
+          <widget class="QTextBrowser" name="textBrowserDataOptionDetails">
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="openExternalLinks">
+            <bool>true</bool>
+           </property>
+          </widget>
          </item>
          <item row="8" column="1" colspan="3">
           <widget class="QLineEdit" name="lineEditDataSystem">


### PR DESCRIPTION
### Motivation
- Improve first-launch data import UX by allowing users to provide Heroes III data either from a folder or from a ZIP archive and enable clickable links in the descriptive text.
- Reuse existing copy/validation pipeline for ZIP imports to avoid duplicating logic.

### Description
- Added UI and code to present Folder / ZIP sub-options for the "Copy existing files" data import path and default the sub-option to Folder when available (`firstlaunch_moc.ui`, `firstlaunch_moc.cpp`, `firstlaunch_moc.h`).
- Replaced the previous label with a `QTextBrowser` for the data option details and enabled `openExternalLinks` so the text can include clickable links (`textBrowserDataOptionDetails` in `firstlaunch_moc.ui` and corresponding code updates).
- Implemented `copyHeroesDataFromArchive` which extracts a selected ZIP via `ZipArchive` into a temporary directory and then calls the existing `performCopyFlow` to validate/copy files into the VCMI data tree (`firstlaunch_moc.cpp`), and added slots to react to the Folder/ZIP radio toggles.
- Kept existing folder-picker and GOG installer flows intact and reused the validated copy pipeline to avoid behavioral regressions.

### Testing
- Ran `git diff --check` to ensure no whitespace issues and it passed.
- Verified repository status and committed changes; diff shows updated UI and implementation (`firstlaunch_moc.ui`, `firstlaunch_moc.cpp`, `firstlaunch_moc.h`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a453466338832d97aee6875dc6017b)