### PR TITLE
Launcher: Improve first-launch data option tiles

### DIFF
--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -54,6 +54,7 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	, ui(std::make_unique<Ui::FirstLaunchView>())
 {
 	ui->setupUi(this);
+	applyDataOptionIcons();
 	applyResponsiveUiScale();
 
 	enterSetup();
@@ -731,6 +732,20 @@ void FirstLaunchView::layoutDataOptionWidgets(bool hasDetectedInstall, bool canU
 	updateDataOptionTileVisuals();
 }
 
+void FirstLaunchView::applyDataOptionIcons()
+{
+	ui->commandLinkButtonDataDetected->setIcon(style()->standardIcon(QStyle::SP_DialogApplyButton));
+	ui->commandLinkButtonDataGog->setIcon(style()->standardIcon(QStyle::SP_ArrowDown));
+	ui->commandLinkButtonDataCopy->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
+	ui->commandLinkButtonDataManual->setIcon(style()->standardIcon(QStyle::SP_FileDialogDetailedView));
+
+	const QSize iconSize(24, 24);
+	ui->commandLinkButtonDataDetected->setIconSize(iconSize);
+	ui->commandLinkButtonDataGog->setIconSize(iconSize);
+	ui->commandLinkButtonDataCopy->setIconSize(iconSize);
+	ui->commandLinkButtonDataManual->setIconSize(iconSize);
+}
+
 void FirstLaunchView::updateDataOptionTileVisuals()
 {
 	const QVector<QPair<QString, QCommandLinkButton *>> tiles = {
@@ -752,8 +767,9 @@ void FirstLaunchView::updateDataOptionTileVisuals()
 		container->style()->polish(container);
 		container->setStyleSheet(QStringLiteral(R"(
 			QWidget[tileEnabled="true"] { border: 1px solid palette(mid); border-radius: 8px; background: palette(base); }
-			QWidget[tileEnabled="true"][tileHovered="true"] { border: 1px solid palette(highlight); background: palette(alternate-base); }
-			QWidget[tileEnabled="true"][tileChecked="true"] { border: 2px solid palette(highlight); background: palette(alternate-base); }
+			QWidget[tileEnabled="true"][tileHovered="true"] { border: 2px solid palette(highlight); background: palette(alternate-base); }
+			QWidget[tileEnabled="true"][tileChecked="true"] { border: 3px solid palette(highlight); background: palette(alternate-base); }
+			QWidget[tileEnabled="true"][tileChecked="true"][tileHovered="true"] { background: palette(light); }
 			QWidget[tileEnabled="false"] { border: 1px solid palette(dark); border-radius: 8px; background: palette(window); }
 		)"));
 	}

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -53,6 +53,7 @@ class FirstLaunchView : public QWidget
 	void updateDataOptionDetails();
 	void layoutDataOptionWidgets(bool hasDetectedInstall, bool canUseGogInstall, bool canUseDataCopy);
 	void updateDataOptionTileVisuals();
+	void applyDataOptionIcons();
 
 	QString getHeroesInstallDir();
 	void extractGogData();


### PR DESCRIPTION
### Motivation
- Make the first-launch Heroes III data source tiles easier to distinguish by adding unique icons to each tile so users can quickly identify the option they want.
- Improve visual feedback for hover and selection so the active choice is more apparent.

### Description
- Added a new helper `FirstLaunchView::applyDataOptionIcons()` and declared it in `firstlaunch_moc.h` to assign distinct icons and sizes to the four data option `QCommandLinkButton`s (`Detected`, `GOG`, `Copy`, `Manual`).
- Call `applyDataOptionIcons()` during `FirstLaunchView` initialization so icons appear immediately after UI setup.
- Strengthened the tile stylesheet in `updateDataOptionTileVisuals()` by increasing border emphasis for hover/selected states and adding a special `selected+hovered` background state.

### Testing
- Ran `git diff --check` to ensure no whitespace/format issues and it passed.
- Verified working tree status with `git status --short` to confirm the intended files were modified.
- Created a commit (`Launcher: improve first-launch data option tiles`) successfully to record the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff7d69be0832dbdf3388506996abc)