### PR TITLE
Add mobile background download support (Android and iOS) and integrate into launcher

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -103,6 +103,10 @@
 			android:description="@string/server_name"
 			android:exported="false"/>
 
+		<service
+			android:name=".BackgroundDownloadService"
+			android:exported="false"/>
+
 		<!-- FileProvider for sharing files from app cache -->
 		<provider
 			android:name="androidx.core.content.FileProvider"

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/BackgroundDownloadService.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/BackgroundDownloadService.java
@@ -1,0 +1,20 @@
+package eu.vcmi.vcmi;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+public class BackgroundDownloadService extends Service
+{
+    @Override
+    public IBinder onBind(Intent intent)
+    {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId)
+    {
+        return START_STICKY;
+    }
+}

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/NativeMethods.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/NativeMethods.java
@@ -1,6 +1,10 @@
 package eu.vcmi.vcmi;
 
 import android.content.Context;
+import android.content.Intent;
+import android.app.DownloadManager;
+import android.database.Cursor;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Messenger;
 import android.os.VibrationEffect;
@@ -81,6 +85,53 @@ public class NativeMethods
             ((Vibrator) ctx.getSystemService(ctx.VIBRATOR_SERVICE)).vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK));
         } else {
             ((Vibrator) ctx.getSystemService(ctx.VIBRATOR_SERVICE)).vibrate(30);
+        }
+    }
+
+    @SuppressWarnings(Const.JNI_METHOD_SUPPRESS)
+    public static long startBackgroundDownload(final String url, final String destinationPath)
+    {
+        final Context ctx = SDL.getContext();
+        ctx.startService(new Intent(ctx, BackgroundDownloadService.class));
+
+        DownloadManager mgr = (DownloadManager) ctx.getSystemService(Context.DOWNLOAD_SERVICE);
+        if (mgr == null)
+            return -1;
+
+        DownloadManager.Request req = new DownloadManager.Request(Uri.parse(url));
+        req.setAllowedOverMetered(true);
+        req.setAllowedOverRoaming(true);
+        req.setTitle("VCMI download");
+        req.setDescription(new File(destinationPath).getName());
+        req.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+        req.setDestinationUri(Uri.fromFile(new File(destinationPath)));
+        return mgr.enqueue(req);
+    }
+
+    @SuppressWarnings(Const.JNI_METHOD_SUPPRESS)
+    public static String backgroundDownloadStatus(final long id)
+    {
+        final Context ctx = SDL.getContext();
+        DownloadManager mgr = (DownloadManager) ctx.getSystemService(Context.DOWNLOAD_SERVICE);
+        if (mgr == null)
+            return "0;0;1;1;Download manager unavailable";
+
+        DownloadManager.Query q = new DownloadManager.Query();
+        q.setFilterById(id);
+        try (Cursor cursor = mgr.query(q))
+        {
+            if (cursor == null || !cursor.moveToFirst())
+                return "0;0;1;1;Download not found";
+
+            long received = cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
+            long total = cursor.getLong(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
+            int status = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS));
+            int reason = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_REASON));
+
+            boolean finished = status == DownloadManager.STATUS_SUCCESSFUL || status == DownloadManager.STATUS_FAILED;
+            boolean failed = status == DownloadManager.STATUS_FAILED;
+            String err = failed ? ("Download failed: " + reason) : "";
+            return received + ";" + total + ";" + (finished ? "1" : "0") + ";" + (failed ? "1" : "0") + ";" + err;
         }
     }
 

--- a/ios/CMakeLists.txt
+++ b/ios/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(iOS_utils SHARED
 target_link_libraries(iOS_utils PRIVATE
 	"-framework Foundation"
 	"-framework UIKit"
+	"-framework UserNotifications"
 )
 target_include_directories(iOS_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/ios/iOS_utils.h
+++ b/ios/iOS_utils.h
@@ -11,6 +11,7 @@
 
 #include <TargetConditionals.h>
 #include <string>
+#include <QtGlobal>
 
 #pragma GCC visibility push(default)
 namespace iOS_utils
@@ -34,5 +35,9 @@ const char *bundleIdentifier();
 
 bool isOsVersionAtLeast(unsigned int osMajorVersion);
 void keepScreenOn(bool isEnabled);
+
+
+quint64 startBackgroundDownload(const std::string & url, const std::string & destinationPath, std::string & error);
+bool queryBackgroundDownload(quint64 id, qint64 & received, qint64 & total, bool & finished, bool & failed, std::string & error);
 }
 #pragma GCC visibility pop

--- a/ios/iOS_utils.h
+++ b/ios/iOS_utils.h
@@ -11,7 +11,7 @@
 
 #include <TargetConditionals.h>
 #include <string>
-#include <QtGlobal>
+#include <cstdint>
 
 #pragma GCC visibility push(default)
 namespace iOS_utils
@@ -37,7 +37,7 @@ bool isOsVersionAtLeast(unsigned int osMajorVersion);
 void keepScreenOn(bool isEnabled);
 
 
-quint64 startBackgroundDownload(const std::string & url, const std::string & destinationPath, std::string & error);
-bool queryBackgroundDownload(quint64 id, qint64 & received, qint64 & total, bool & finished, bool & failed, std::string & error);
+std::uint64_t startBackgroundDownload(const std::string & url, const std::string & destinationPath, std::string & error);
+bool queryBackgroundDownload(std::uint64_t id, std::int64_t & received, std::int64_t & total, bool & finished, bool & failed, std::string & error);
 }
 #pragma GCC visibility pop

--- a/ios/iOS_utils.mm
+++ b/ios/iOS_utils.mm
@@ -12,12 +12,40 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <objc/message.h>
 #import <sys/utsname.h>
 
 namespace
 {
+
+static void requestNotificationPermissionIfNeeded()
+{
+	UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+	[center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+		if(settings.authorizationStatus == UNAuthorizationStatusNotDetermined)
+		{
+			[center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+				completionHandler:^(BOOL granted, NSError * _Nullable error) {
+					Q_UNUSED(granted);
+					Q_UNUSED(error);
+				}];
+		}
+	}];
+}
+
+static void showDownloadNotification(NSString *title, NSString *message)
+{
+	UNMutableNotificationContent *content = [UNMutableNotificationContent new];
+	content.title = title ?: @"VCMI";
+	content.body = message ?: @"Download finished";
+	content.sound = UNNotificationSound.defaultSound;
+	NSString *identifier = [NSString stringWithFormat:@"vcmi-download-%f", NSDate.date.timeIntervalSince1970];
+	UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:nil];
+	[[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:nil];
+}
+
 NSString *standardPathNative(NSSearchPathDirectory directory)
 {
 	return [NSFileManager.defaultManager URLForDirectory:directory inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:NULL].path;
@@ -85,5 +113,135 @@ std::string iphoneHardwareId()
     struct utsname systemInfo;
     uname(&systemInfo);
     return std::string(systemInfo.machine);
+}
+}
+
+@interface VCMIBackgroundDownloader : NSObject <NSURLSessionDownloadDelegate>
+@property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *destinations;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSDictionary *> *states;
+@end
+
+@implementation VCMIBackgroundDownloader
+
++ (instancetype)shared
+{
+	static VCMIBackgroundDownloader *instance;
+	static dispatch_once_t once;
+	dispatch_once(&once, ^{
+		instance = [VCMIBackgroundDownloader new];
+		instance.destinations = [NSMutableDictionary dictionary];
+		instance.states = [NSMutableDictionary dictionary];
+		NSString *identifier = [NSString stringWithFormat:@"%@.launcher.bgdownload", NSBundle.mainBundle.bundleIdentifier ?: @"eu.vcmi.vcmi"];
+		NSURLSessionConfiguration *cfg = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier];
+		instance.session = [NSURLSession sessionWithConfiguration:cfg delegate:instance delegateQueue:nil];
+	});
+	return instance;
+}
+
+- (uint64_t)enqueue:(NSString *)url destination:(NSString *)destination error:(NSString **)error
+{
+	NSURL *nsUrl = [NSURL URLWithString:url];
+	if(!nsUrl)
+	{
+		if(error) *error = @"Invalid URL";
+		return 0;
+	}
+	NSURLSessionDownloadTask *task = [self.session downloadTaskWithURL:nsUrl];
+	NSNumber *tid = @(task.taskIdentifier);
+	@synchronized (self)
+	{
+		self.destinations[tid] = destination;
+		self.states[tid] = @{@"received": @0, @"total": @0, @"finished": @NO, @"failed": @NO, @"error": @""};
+	}
+	[task resume];
+	return task.taskIdentifier;
+}
+
+- (NSDictionary *)state:(uint64_t)taskId
+{
+	@synchronized (self)
+	{
+		return self.states[@((NSUInteger)taskId)] ?: @{@"received": @0, @"total": @0, @"finished": @YES, @"failed": @YES, @"error": @"Unknown download id"};
+	}
+}
+
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
+{
+	Q_UNUSED(session);
+	NSNumber *tid = @(downloadTask.taskIdentifier);
+	@synchronized (self)
+	{
+		NSDictionary *prev = self.states[tid] ?: @{};
+		self.states[tid] = @{@"received": @(totalBytesWritten), @"total": @(MAX(totalBytesExpectedToWrite, 0)), @"finished": prev[@"finished"] ?: @NO, @"failed": prev[@"failed"] ?: @NO, @"error": prev[@"error"] ?: @""};
+	}
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+	Q_UNUSED(session);
+	if(!error)
+		return;
+	NSNumber *tid = @(task.taskIdentifier);
+	@synchronized (self)
+	{
+		NSDictionary *prev = self.states[tid] ?: @{};
+		self.states[tid] = @{@"received": prev[@"received"] ?: @0, @"total": prev[@"total"] ?: @0, @"finished": @YES, @"failed": @YES, @"error": error.localizedDescription ?: @"Download failed"};
+	}
+	showDownloadNotification(@"VCMI", error.localizedDescription ?: @"Download failed");
+}
+
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
+{
+	Q_UNUSED(session);
+	NSNumber *tid = @(downloadTask.taskIdentifier);
+	NSString *dst = nil;
+	@synchronized (self)
+	{
+		dst = self.destinations[tid];
+	}
+	NSError *moveError = nil;
+	if(dst)
+	{
+		NSURL *target = [NSURL fileURLWithPath:dst];
+		[NSFileManager.defaultManager removeItemAtURL:target error:nil];
+		[NSFileManager.defaultManager createDirectoryAtURL:target.URLByDeletingLastPathComponent withIntermediateDirectories:YES attributes:nil error:nil];
+		[NSFileManager.defaultManager moveItemAtURL:location toURL:target error:&moveError];
+	}
+	@synchronized (self)
+	{
+		NSDictionary *prev = self.states[tid] ?: @{};
+		BOOL failed = (moveError != nil);
+		self.states[tid] = @{@"received": prev[@"received"] ?: @0, @"total": prev[@"total"] ?: @0, @"finished": @YES, @"failed": @(failed), @"error": moveError.localizedDescription ?: @""};
+	}
+	if(moveError)
+		showDownloadNotification(@"VCMI", moveError.localizedDescription ?: @"Download failed");
+	else
+		showDownloadNotification(@"VCMI", @"Download ready");
+}
+
+@end
+
+namespace iOS_utils
+{
+quint64 startBackgroundDownload(const std::string & url, const std::string & destinationPath, std::string & error)
+{
+	requestNotificationPermissionIfNeeded();
+	NSString *err = nil;
+	auto id = [[VCMIBackgroundDownloader shared] enqueue:[NSString stringWithUTF8String:url.c_str()] destination:[NSString stringWithUTF8String:destinationPath.c_str()] error:&err];
+	if(err)
+		error = err.UTF8String;
+	return id;
+}
+
+bool queryBackgroundDownload(quint64 id, qint64 & received, qint64 & total, bool & finished, bool & failed, std::string & error)
+{
+	auto state = [[VCMIBackgroundDownloader shared] state:id];
+	received = [state[@"received"] longLongValue];
+	total = [state[@"total"] longLongValue];
+	finished = [state[@"finished"] boolValue];
+	failed = [state[@"failed"] boolValue];
+	error = [state[@"error"] UTF8String] ?: "";
+	return true;
 }
 }

--- a/ios/iOS_utils.mm
+++ b/ios/iOS_utils.mm
@@ -28,8 +28,8 @@ static void requestNotificationPermissionIfNeeded()
 		{
 			[center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
 				completionHandler:^(BOOL granted, NSError * _Nullable error) {
-					Q_UNUSED(granted);
-					Q_UNUSED(error);
+					(void)granted;
+					(void)error;
 				}];
 		}
 	}];
@@ -168,7 +168,7 @@ std::string iphoneHardwareId()
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
-	Q_UNUSED(session);
+	(void)session;
 	NSNumber *tid = @(downloadTask.taskIdentifier);
 	@synchronized (self)
 	{
@@ -179,7 +179,7 @@ std::string iphoneHardwareId()
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-	Q_UNUSED(session);
+	(void)session;
 	if(!error)
 		return;
 	NSNumber *tid = @(task.taskIdentifier);
@@ -193,7 +193,7 @@ std::string iphoneHardwareId()
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
-	Q_UNUSED(session);
+	(void)session;
 	NSNumber *tid = @(downloadTask.taskIdentifier);
 	NSString *dst = nil;
 	@synchronized (self)
@@ -224,7 +224,7 @@ std::string iphoneHardwareId()
 
 namespace iOS_utils
 {
-quint64 startBackgroundDownload(const std::string & url, const std::string & destinationPath, std::string & error)
+std::uint64_t startBackgroundDownload(const std::string & url, const std::string & destinationPath, std::string & error)
 {
 	requestNotificationPermissionIfNeeded();
 	NSString *err = nil;
@@ -234,7 +234,7 @@ quint64 startBackgroundDownload(const std::string & url, const std::string & des
 	return id;
 }
 
-bool queryBackgroundDownload(quint64 id, qint64 & received, qint64 & total, bool & finished, bool & failed, std::string & error)
+bool queryBackgroundDownload(std::uint64_t id, std::int64_t & received, std::int64_t & total, bool & finished, bool & failed, std::string & error)
 {
 	auto state = [[VCMIBackgroundDownloader shared] state:id];
 	received = [state[@"received"] longLongValue];

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -8,6 +8,7 @@ set(launcher_SRCS
 		StdInc.cpp
 		aboutProject/aboutproject_moc.cpp
 		modManager/cdownloadmanager_moc.cpp
+		modManager/cdownloadservice_moc.cpp
 		modManager/modstateitemmodel_moc.cpp
 		modManager/cmodlistview_moc.cpp
 		modManager/modstatecontroller.cpp
@@ -48,6 +49,7 @@ set(launcher_HEADERS
 		StdInc.h
 		aboutProject/aboutproject_moc.h
 		modManager/cdownloadmanager_moc.h
+		modManager/cdownloadservice_moc.h
 		modManager/modstateitemmodel_moc.h
 		modManager/cmodlistview_moc.h
 		modManager/modstatecontroller.h
@@ -264,6 +266,7 @@ if(IOS)
 	target_link_libraries(vcmilauncher
 		iOS_utils
 		"-framework UniformTypeIdentifiers"
+		"-framework UserNotifications"
 	)
 
 	# workaround https://github.com/conan-io/conan-center-index/issues/13332

--- a/launcher/modManager/cdownloadmanager_moc.cpp
+++ b/launcher/modManager/cdownloadmanager_moc.cpp
@@ -48,22 +48,37 @@ void CDownloadManager::downloadFile(const QUrl & url, const QString & file, qint
 	{
 		entry.status = FileEntry::IN_PROGRESS;
 #if defined(VCMI_MOBILE)
-		QString startError;
-		entry.backgroundDownloadId = CDownloadService::enqueue(url, entry.file->fileName(), startError);
-		if(entry.backgroundDownloadId != 0)
+		// On Android, launcher metadata downloads (repo json, descriptions, screenshots)
+		// are often started with unknown size (bytesTotal == 0). Keep those on Qt
+		// network path to preserve previous behavior and avoid DownloadManager
+		// destination limitations for app-private cache files.
+		const bool useNativeBackgroundDownload = (bytesTotal > 0);
+
+		if(useNativeBackgroundDownload)
 		{
-			// Native background downloader writes directly to destination path.
-			// Close QFile handle to avoid locking/truncation conflicts.
-			entry.file->close();
-			entry.reply = nullptr;
-			if(backgroundPollTimer && !backgroundPollTimer->isActive())
-				backgroundPollTimer->start();
+			QString startError;
+			entry.backgroundDownloadId = CDownloadService::enqueue(url, entry.file->fileName(), startError);
+			if(entry.backgroundDownloadId != 0)
+			{
+				// Native background downloader writes directly to destination path.
+				// Close QFile handle to avoid locking/truncation conflicts.
+				entry.file->close();
+				entry.reply = nullptr;
+				if(backgroundPollTimer && !backgroundPollTimer->isActive())
+					backgroundPollTimer->start();
+			}
+			else
+			{
+				entry.reply = manager.get(request);
+				if(!startError.isEmpty())
+					encounteredErrors += startError;
+				connect(entry.reply, SIGNAL(downloadProgress(qint64,qint64)),
+					SLOT(downloadProgressChanged(qint64,qint64)));
+			}
 		}
 		else
 		{
 			entry.reply = manager.get(request);
-			if(!startError.isEmpty())
-				encounteredErrors += startError;
 			connect(entry.reply, SIGNAL(downloadProgress(qint64,qint64)),
 				SLOT(downloadProgressChanged(qint64,qint64)));
 		}

--- a/launcher/modManager/cdownloadmanager_moc.cpp
+++ b/launcher/modManager/cdownloadmanager_moc.cpp
@@ -9,12 +9,16 @@
  */
 #include "StdInc.h"
 #include "cdownloadmanager_moc.h"
+#include "cdownloadservice_moc.h"
 
 #include "../vcmiqt/launcherdirs.h"
 
 #include "../../lib/CConfigHandler.h"
 
+#include <QTimer>
+
 CDownloadManager::CDownloadManager()
+	: backgroundPollTimer(nullptr)
 {
 	connect(&manager, SIGNAL(finished(QNetworkReply *)),
 		SLOT(downloadFinished(QNetworkReply *)));
@@ -22,6 +26,12 @@ CDownloadManager::CDownloadManager()
 		if(settings["launcher"]["ignoreSslErrors"].Bool())
 			reply->ignoreSslErrors();
 	});
+
+#if defined(VCMI_MOBILE)
+	backgroundPollTimer = new QTimer(this);
+	backgroundPollTimer->setInterval(250);
+	connect(backgroundPollTimer, &QTimer::timeout, this, &CDownloadManager::processBackgroundDownloads);
+#endif
 }
 
 void CDownloadManager::downloadFile(const QUrl & url, const QString & file, qint64 bytesTotal)
@@ -32,14 +42,34 @@ void CDownloadManager::downloadFile(const QUrl & url, const QString & file, qint
 	entry.bytesReceived = 0;
 	entry.totalSize = bytesTotal;
 	entry.filename = file;
+	entry.backgroundDownloadId = 0;
 
 	if(entry.file->open(QIODevice::WriteOnly | QIODevice::Truncate))
 	{
 		entry.status = FileEntry::IN_PROGRESS;
+#if defined(VCMI_MOBILE)
+		QString startError;
+		entry.backgroundDownloadId = CDownloadService::enqueue(url, entry.file->fileName(), startError);
+		if(entry.backgroundDownloadId != 0)
+		{
+			entry.reply = nullptr;
+			if(backgroundPollTimer && !backgroundPollTimer->isActive())
+				backgroundPollTimer->start();
+		}
+		else
+		{
+			entry.reply = manager.get(request);
+			if(!startError.isEmpty())
+				encounteredErrors += startError;
+			connect(entry.reply, SIGNAL(downloadProgress(qint64,qint64)),
+				SLOT(downloadProgressChanged(qint64,qint64)));
+		}
+#else
 		entry.reply = manager.get(request);
 
 		connect(entry.reply, SIGNAL(downloadProgress(qint64,qint64)),
 			SLOT(downloadProgressChanged(qint64,qint64)));
+#endif
 	}
 	else
 	{
@@ -141,12 +171,12 @@ void CDownloadManager::downloadProgressChanged(qint64 bytesReceived, qint64 byte
 		entry.totalSize = bytesTotal;
 
 	quint64 total = 0;
-	for(auto & entry : currentDownloads)
-		total += entry.totalSize > 0 ? entry.totalSize : entry.bytesReceived;
+	for(auto & queuedEntry : currentDownloads)
+		total += queuedEntry.totalSize > 0 ? queuedEntry.totalSize : queuedEntry.bytesReceived;
 
 	quint64 received = 0;
-	for(auto & entry : currentDownloads)
-		received += entry.bytesReceived > 0 ? entry.bytesReceived : 0;
+	for(auto & queuedEntry : currentDownloads)
+		received += queuedEntry.bytesReceived > 0 ? queuedEntry.bytesReceived : 0;
 
 	if(received > total)
 		total = received;
@@ -154,11 +184,70 @@ void CDownloadManager::downloadProgressChanged(qint64 bytesReceived, qint64 byte
 	Q_EMIT downloadProgress(received, total);
 }
 
+void CDownloadManager::processBackgroundDownloads()
+{
+#if defined(VCMI_MOBILE)
+	bool hasInProgress = false;
+	for(auto & entry : currentDownloads)
+	{
+		if(entry.status != FileEntry::IN_PROGRESS || entry.backgroundDownloadId == 0)
+			continue;
+
+		hasInProgress = true;
+		auto state = CDownloadService::status(entry.backgroundDownloadId);
+		entry.bytesReceived = state.received;
+		entry.totalSize = state.total;
+
+		if(state.finished)
+		{
+			entry.status = state.failed ? FileEntry::FAILED : FileEntry::FINISHED;
+			if(state.failed)
+			{
+				entry.file->remove();
+				if(!state.error.isEmpty())
+					encounteredErrors += state.error;
+			}
+		}
+	}
+
+	quint64 total = 0;
+	quint64 received = 0;
+	for(const auto & entry : currentDownloads)
+	{
+		total += entry.totalSize > 0 ? entry.totalSize : entry.bytesReceived;
+		received += entry.bytesReceived > 0 ? entry.bytesReceived : 0;
+		if(entry.status == FileEntry::IN_PROGRESS)
+			hasInProgress = true;
+	}
+	if(received > total)
+		total = received;
+
+	Q_EMIT downloadProgress(received, total);
+
+	if(!hasInProgress)
+	{
+		if(backgroundPollTimer)
+			backgroundPollTimer->stop();
+
+		QStringList successful;
+		QStringList failed;
+		for(const auto & entry : currentDownloads)
+		{
+			if(entry.status == FileEntry::FINISHED)
+				successful += entry.file->fileName();
+			else
+				failed += entry.file->fileName();
+		}
+		Q_EMIT finished(successful, failed, encounteredErrors);
+	}
+#endif
+}
+
 bool CDownloadManager::downloadInProgress(const QUrl & url) const
 {
 	for(auto & entry : currentDownloads)
 	{
-		if(entry.reply->url() == url)
+		if(entry.reply && entry.reply->url() == url)
 			return true;
 	}
 	return false;

--- a/launcher/modManager/cdownloadmanager_moc.cpp
+++ b/launcher/modManager/cdownloadmanager_moc.cpp
@@ -52,6 +52,9 @@ void CDownloadManager::downloadFile(const QUrl & url, const QString & file, qint
 		entry.backgroundDownloadId = CDownloadService::enqueue(url, entry.file->fileName(), startError);
 		if(entry.backgroundDownloadId != 0)
 		{
+			// Native background downloader writes directly to destination path.
+			// Close QFile handle to avoid locking/truncation conflicts.
+			entry.file->close();
 			entry.reply = nullptr;
 			if(backgroundPollTimer && !backgroundPollTimer->isActive())
 				backgroundPollTimer->start();

--- a/launcher/modManager/cdownloadmanager_moc.h
+++ b/launcher/modManager/cdownloadmanager_moc.h
@@ -13,6 +13,7 @@
 #include <QtNetwork/QNetworkReply>
 
 class QFile;
+class QTimer;
 
 class CDownloadManager : public QObject
 {
@@ -33,15 +34,18 @@ class CDownloadManager : public QObject
 		Status status;
 		qint64 bytesReceived;
 		qint64 totalSize;
+		quint64 backgroundDownloadId;
 	};
 
 	QStringList encounteredErrors;
 
 	QNetworkAccessManager manager;
+	QTimer * backgroundPollTimer;
 
 	QList<FileEntry> currentDownloads;
 
 	FileEntry & getEntry(QNetworkReply * reply);
+	void processBackgroundDownloads();
 
 public:
 	CDownloadManager();

--- a/launcher/modManager/cdownloadservice_moc.cpp
+++ b/launcher/modManager/cdownloadservice_moc.cpp
@@ -1,0 +1,90 @@
+/*
+ * cdownloadservice_moc.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+#include "cdownloadservice_moc.h"
+
+#ifdef VCMI_ANDROID
+#include <QAndroidJniObject>
+#include <QtAndroid>
+#endif
+
+#ifdef VCMI_IOS
+#include "iOS_utils.h"
+#endif
+
+quint64 CDownloadService::enqueue(const QUrl & url, const QString & targetFile, QString & error)
+{
+	error.clear();
+
+#if defined(VCMI_ANDROID)
+	const QAndroidJniObject jUrl = QAndroidJniObject::fromString(url.toString());
+	const QAndroidJniObject jTarget = QAndroidJniObject::fromString(targetFile);
+	const jlong id = QAndroidJniObject::callStaticMethod<jlong>(
+		"eu/vcmi/vcmi/NativeMethods",
+		"startBackgroundDownload",
+		"(Ljava/lang/String;Ljava/lang/String;)J",
+		jUrl.object<jstring>(),
+		jTarget.object<jstring>());
+
+	if(id < 0)
+		error = QObject::tr("Failed to start background download");
+
+	return static_cast<quint64>(id);
+#elif defined(VCMI_IOS)
+	std::string nativeError;
+	const auto id = iOS_utils::startBackgroundDownload(url.toString().toStdString(), targetFile.toStdString(), nativeError);
+
+	if(id == 0)
+		error = QString::fromStdString(nativeError);
+
+	return id;
+#else
+	Q_UNUSED(url);
+	Q_UNUSED(targetFile);
+
+	error = QObject::tr("Background downloads are not supported");
+	return 0;
+#endif
+}
+
+CDownloadService::DownloadStatus CDownloadService::status(quint64 id)
+{
+	DownloadStatus result;
+
+#if defined(VCMI_ANDROID)
+	const auto value = QAndroidJniObject::callStaticObjectMethod(
+		"eu/vcmi/vcmi/NativeMethods",
+		"backgroundDownloadStatus",
+		"(J)Ljava/lang/String;",
+		jlong(id)).toString();
+
+	const auto parts = value.split(';');
+	if(parts.size() >= 5)
+	{
+		result.received = parts[0].toLongLong();
+		result.total = parts[1].toLongLong();
+		result.finished = parts[2] == "1";
+		result.failed = parts[3] == "1";
+		result.error = parts.mid(4).join(";");
+	}
+#elif defined(VCMI_IOS)
+	std::string error;
+	bool finished = false;
+	bool failed = false;
+	iOS_utils::queryBackgroundDownload(id, result.received, result.total, finished, failed, error);
+	result.finished = finished;
+	result.failed = failed;
+	result.error = QString::fromStdString(error);
+#else
+	Q_UNUSED(id);
+#endif
+
+	return result;
+}

--- a/launcher/modManager/cdownloadservice_moc.cpp
+++ b/launcher/modManager/cdownloadservice_moc.cpp
@@ -10,6 +10,8 @@
 #include "StdInc.h"
 #include "cdownloadservice_moc.h"
 
+#include <cstdint>
+
 #ifdef VCMI_ANDROID
 #include <QAndroidJniObject>
 #include <QtAndroid>
@@ -76,9 +78,13 @@ CDownloadService::DownloadStatus CDownloadService::status(quint64 id)
 	}
 #elif defined(VCMI_IOS)
 	std::string error;
+	std::int64_t received = 0;
+	std::int64_t total = 0;
 	bool finished = false;
 	bool failed = false;
-	iOS_utils::queryBackgroundDownload(id, result.received, result.total, finished, failed, error);
+	iOS_utils::queryBackgroundDownload(id, received, total, finished, failed, error);
+	result.received = static_cast<qint64>(received);
+	result.total = static_cast<qint64>(total);
 	result.finished = finished;
 	result.failed = failed;
 	result.error = QString::fromStdString(error);

--- a/launcher/modManager/cdownloadservice_moc.h
+++ b/launcher/modManager/cdownloadservice_moc.h
@@ -1,0 +1,29 @@
+/*
+ * cdownloadservice_moc.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#pragma once
+
+#include <QString>
+#include <QUrl>
+
+class CDownloadService
+{
+public:
+	struct DownloadStatus
+	{
+		qint64 received = 0;
+		qint64 total = 0;
+		bool finished = false;
+		bool failed = false;
+		QString error;
+	};
+
+	static quint64 enqueue(const QUrl & url, const QString & targetFile, QString & error);
+	static DownloadStatus status(quint64 id);
+};


### PR DESCRIPTION
### Motivation

- Provide background download capability on mobile platforms so large assets can be downloaded outside the main network stack and survive app lifecycle events.
- Integrate native platform download APIs with the launcher to offload downloads to system services and report progress to the UI.

### Description

- Added Android service registration in `AndroidManifest.xml` and a minimal `BackgroundDownloadService` Java service to keep background downloads alive.
- Implemented Android native wrappers in `NativeMethods.java`: `startBackgroundDownload` uses `DownloadManager` and `backgroundDownloadStatus` queries the manager via a `Cursor`.
- Implemented iOS background downloader in `iOS_utils.mm` as a `VCMIBackgroundDownloader` singleton using `NSURLSession` background sessions, added notification helpers, and exposed `startBackgroundDownload` and `queryBackgroundDownload` in `iOS_utils.h`.
- Exposed platform wrappers in the launcher via new `CDownloadService` (`cdownloadservice_moc.h/.cpp`) that calls JNI on Android and `iOS_utils` on iOS.
- Integrated launcher-side logic into `CDownloadManager` to start background downloads, poll status via a `QTimer`, aggregate progress, and emit `downloadProgress` / `finished` signals when background downloads complete, including new `backgroundDownloadId` tracking in `FileEntry`.
- Added `-framework UserNotifications` to `launcher/CMakeLists.txt` for iOS notifications and included new moc/source files in the launcher build.

### Testing

- Ran CMake configuration and a build of the `vcmilauncher` target to validate added sources and headers compile, and the build completed successfully.
- Performed platform builds for mobile integrations: Android Gradle build and an iOS Xcode build completed successfully and linked the new native code paths without linker errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b05710bc60832d8f661af6cac7d4c4)