### PR TITLE
Improve IME handling and window insets for VcmiSDLActivity

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -95,7 +95,8 @@
 			android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
 			android:label="@string/app_name"
 			android:launchMode="singleTop"
-			android:screenOrientation="fullSensor" />
+			android:screenOrientation="fullSensor"
+			android:windowSoftInputMode="adjustResize|stateHidden" />
 
 		<service
 			android:name=".ServerService"

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -10,9 +10,13 @@ import android.os.IBinder;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
+import android.view.inputmethod.InputMethodManager;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import org.libsdl.app.SDLActivity;
 
@@ -115,6 +119,23 @@ public class VcmiSDLActivity extends SDLActivity
         setContentView(outerLayout);
 
         VcmiSDLActivity.this.setWindowStyle(true); // set fullscreen
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+
+        configureImeInsets(layout);
+    }
+
+    private void configureImeInsets(final View gameLayout)
+    {
+        ViewCompat.setOnApplyWindowInsetsListener(gameLayout, (view, windowInsets) -> {
+            final int imeBottomInset = windowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            final int navigationBottomInset = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+            final int bottomInset = Math.max(imeBottomInset, navigationBottomInset);
+
+            view.setPadding(view.getPaddingLeft(), view.getPaddingTop(), view.getPaddingRight(), bottomInset);
+            return windowInsets;
+        });
+
+        ViewCompat.requestApplyInsets(gameLayout);
     }
 
     @Override
@@ -166,8 +187,20 @@ public class VcmiSDLActivity extends SDLActivity
         mSurface.setFocusable(true);
         mSurface.setFocusableInTouchMode(true);
         mSurface.requestFocus();
+        hideSoftKeyboard();
 
         notifySdlFocusChanged();
+    }
+
+    private void hideSoftKeyboard()
+    {
+        final InputMethodManager inputManager = getSystemService(InputMethodManager.class);
+        if (inputManager == null)
+            return;
+
+        final View focusedView = getCurrentFocus() != null ? getCurrentFocus() : mSurface;
+        if (focusedView != null)
+            inputManager.hideSoftInputFromWindow(focusedView.getWindowToken(), 0);
     }
 
     private void notifySdlFocusChanged()

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -181,6 +181,9 @@ public class VcmiSDLActivity extends SDLActivity
         if (mSurface == null)
             return;
 
+        if (shouldKeepTextInputFocus())
+            return;
+
         VcmiSDLActivity.this.setWindowStyle(true);
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
 
@@ -190,6 +193,12 @@ public class VcmiSDLActivity extends SDLActivity
         hideSoftKeyboard();
 
         notifySdlFocusChanged();
+    }
+
+    private boolean shouldKeepTextInputFocus()
+    {
+        final View focusedView = getCurrentFocus();
+        return focusedView != null && focusedView != mSurface && focusedView.onCheckIsTextEditor();
     }
 
     private void hideSoftKeyboard()


### PR DESCRIPTION
### Motivation
- Ensure the SDL game surface behaves correctly when the soft keyboard appears and when focus is restored.
- Prevent the IME from covering or misplacing the game UI by adjusting layout when IME or navigation insets change.
- Hide the soft keyboard when restoring focus so the SDL surface receives input without the keyboard unexpectedly staying open.

### Description
- Added `android:windowSoftInputMode="adjustResize|stateHidden"` to the `VcmiSDLActivity` entry in `AndroidManifest.xml`.
- In `VcmiSDLActivity`, set the soft input mode via `getWindow().setSoftInputMode(...)` in `onCreate` and added `configureImeInsets(View)` that uses `ViewCompat.setOnApplyWindowInsetsListener` and `WindowInsetsCompat.Type` to update bottom padding based on IME and navigation bar insets.
- Implemented `hideSoftKeyboard()` which uses `InputMethodManager` to dismiss the IME and invoked it from `ensureInputFocusNow()` to ensure the surface receives focus cleanly, and added the necessary imports and `ViewCompat.requestApplyInsets` call.

### Testing
- Built the Android debug APK with `./gradlew assembleDebug` which completed successfully.
- Executed project unit tests with `./gradlew test` and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0556dd17c832da291f285b11d91ca)