### PR TITLE
Add Save dir UI and Windows directory relocation with config persistence

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -19,12 +19,14 @@
 #endif
 
 #include "../updatedialog_moc.h"
+#include "../main.h"
 #include "../helper.h"
 
 #include "../../lib/GameConstants.h"
 #include "../../lib/VCMIDirs.h"
 #include "../../lib/filesystem/CZipSaver.h"
 #include "../../lib/json/JsonUtils.h"
+#include "../../lib/json/JsonNode.h"
 #include "../../lib/filesystem/Filesystem.h"
 
 void AboutProjectView::hideAndStretchWidget(QGridLayout * layout, QWidget * toHide, QWidget * toStretch)
@@ -41,6 +43,133 @@ void AboutProjectView::hideAndStretchWidget(QGridLayout * layout, QWidget * toHi
 	layout->addWidget(toStretch, row, col, 1, -1);
 }
 
+namespace
+{
+#ifdef VCMI_WINDOWS
+QString windowsDirsConfigPath()
+{
+	return QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("config/dirs.json"));
+}
+
+int countDirectoryEntries(const QString & sourcePath, const QSet<QString> & skippedFiles)
+{
+	QDir sourceDir(sourcePath);
+	if (!sourceDir.exists())
+		return 0;
+
+	int count = 0;
+	for (const QFileInfo & entry : sourceDir.entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries))
+	{
+		if (!entry.isDir() && skippedFiles.contains(entry.fileName()))
+			continue;
+
+		++count;
+		if (entry.isDir())
+			count += countDirectoryEntries(entry.absoluteFilePath(), skippedFiles);
+	}
+	return count;
+}
+
+bool moveDirectoryContent(const QString & sourcePath, const QString & targetPath, int & processed, const QSet<QString> & skippedFiles, const std::function<void(int, const QString &)> & onProgress)
+{
+	QDir sourceDir(sourcePath);
+	if (!sourceDir.exists())
+		return true;
+
+	QDir targetDir(targetPath);
+	if (!targetDir.exists() && !QDir().mkpath(targetPath))
+		return false;
+
+	for (const QFileInfo & entry : sourceDir.entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries))
+	{
+		const QString sourceEntry = entry.absoluteFilePath();
+		const QString targetEntry = targetDir.filePath(entry.fileName());
+
+		if (entry.isDir())
+		{
+			if (!moveDirectoryContent(sourceEntry, targetEntry, processed, skippedFiles, onProgress))
+				return false;
+			QDir().rmdir(sourceEntry);
+			++processed;
+			onProgress(processed, sourceEntry);
+			continue;
+		}
+
+		if (skippedFiles.contains(entry.fileName()))
+			continue;
+
+		if (!QFile::exists(targetEntry))
+		{
+			if (!QFile::rename(sourceEntry, targetEntry))
+			{
+				if (!Helper::performNativeCopy(sourceEntry, targetEntry))
+					return false;
+				QFile::remove(sourceEntry);
+			}
+		}
+
+		++processed;
+		onProgress(processed, sourceEntry);
+	}
+
+	return true;
+}
+
+JsonNode currentWindowsDirsConfig()
+{
+	JsonNode dirsConfig;
+	dirsConfig.setType(JsonNode::JsonType::DATA_STRUCT);
+	dirsConfig["userDataPath"].String() = pathToQString(VCMIDirs::get().userDataPath()).toStdString();
+	dirsConfig["userCachePath"].String() = pathToQString(VCMIDirs::get().userCachePath()).toStdString();
+	dirsConfig["userConfigPath"].String() = pathToQString(VCMIDirs::get().userConfigPath()).toStdString();
+	dirsConfig["userLogsPath"].String() = pathToQString(VCMIDirs::get().userLogsPath()).toStdString();
+	dirsConfig["userSavePath"].String() = pathToQString(VCMIDirs::get().userSavePath()).toStdString();
+	return dirsConfig;
+}
+
+bool writeWindowsDirsConfig(const JsonNode & dirsConfig)
+{
+	QFile configFile(windowsDirsConfigPath());
+	QDir().mkpath(QFileInfo(configFile).absolutePath());
+	if (!configFile.open(QIODevice::WriteOnly | QIODevice::Truncate))
+		return false;
+
+	configFile.write(QString::fromStdString(dirsConfig.toString()).toUtf8());
+	configFile.close();
+	return true;
+}
+
+bool relocateDirectoryWithProgress(QWidget * parent, const QString & sourcePath, const QString & targetPath, const QString & title, const QSet<QString> & skippedFiles = {})
+{
+	if (!QDir().mkpath(targetPath))
+		return false;
+
+	const int totalEntries = std::max(1, countDirectoryEntries(sourcePath, skippedFiles));
+	QProgressDialog progressDialog(QObject::tr("Moving files..."), QString(), 0, totalEntries, parent);
+	progressDialog.setWindowTitle(title);
+	progressDialog.setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+	progressDialog.setWindowFlag(Qt::WindowCloseButtonHint, false);
+	progressDialog.setWindowModality(Qt::WindowModal);
+	progressDialog.setCancelButton(nullptr);
+	progressDialog.setMinimumDuration(0);
+	progressDialog.setValue(0);
+
+	int processed = 0;
+	const auto onProgress = [&](int value, const QString & path)
+	{
+		progressDialog.setLabelText(QObject::tr("Moving: %1").arg(QFileInfo(path).fileName()));
+		progressDialog.setValue(std::min(value, totalEntries));
+		QCoreApplication::processEvents();
+	};
+
+	const bool moved = moveDirectoryContent(sourcePath, targetPath, processed, skippedFiles, onProgress);
+	progressDialog.setValue(totalEntries);
+	QCoreApplication::processEvents();
+	return moved;
+}
+#endif
+}
+
 AboutProjectView::AboutProjectView(QWidget * parent)
 	: QWidget(parent)
 	, ui(std::make_unique<Ui::AboutProjectView>())
@@ -51,7 +180,14 @@ AboutProjectView::AboutProjectView(QWidget * parent)
 	ui->lineEditGameDir->setText(pathToQString(VCMIDirs::get().binaryPath()));
 	ui->lineEditTempDir->setText(pathToQString(VCMIDirs::get().userLogsPath()));
 	ui->lineEditConfigDir->setText(pathToQString(VCMIDirs::get().userConfigPath()));
+	ui->lineEditSaveDir->setText(pathToQString(VCMIDirs::get().userSavePath()));
 	ui->lineEditBuildVersion->setText(QString::fromStdString(GameConstants::VCMI_VERSION));
+
+#ifndef VCMI_WINDOWS
+	ui->relocateUserDataDir->hide();
+	ui->relocateTempDir->hide();
+	ui->relocateSaveDir->hide();
+#endif
 	ui->lineEditOperatingSystem->setText(QSysInfo::prettyProductName());
 
 #ifdef VCMI_MOBILE
@@ -62,6 +198,7 @@ AboutProjectView::AboutProjectView(QWidget * parent)
 	hideAndStretchWidget(ui->gridLayout, ui->openUserDataDir, ui->lineEditUserDataDir);
 	hideAndStretchWidget(ui->gridLayout, ui->openTempDir, ui->lineEditTempDir);
 	hideAndStretchWidget(ui->gridLayout, ui->openConfigDir, ui->lineEditConfigDir);
+	hideAndStretchWidget(ui->gridLayout, ui->openSaveDir, ui->lineEditSaveDir);
 #endif
 #endif
 }
@@ -99,6 +236,169 @@ void AboutProjectView::on_openTempDir_clicked()
 void AboutProjectView::on_openConfigDir_clicked()
 {
 	Helper::revealDirectoryInFileBrowser(ui->lineEditConfigDir->text());
+}
+
+void AboutProjectView::on_openSaveDir_clicked()
+{
+	Helper::revealDirectoryInFileBrowser(ui->lineEditSaveDir->text());
+}
+
+void AboutProjectView::on_relocateUserDataDir_clicked()
+{
+#ifndef VCMI_WINDOWS
+	return;
+#else
+	const QString currentUserDataPath = ui->lineEditUserDataDir->text();
+	const QString currentLogsPath = ui->lineEditTempDir->text();
+
+	const QString targetPath = QFileDialog::getExistingDirectory(this, tr("Select new user data directory"), currentUserDataPath);
+	if (targetPath.isEmpty())
+		return;
+
+	auto normalize = [](const QString & path)
+	{
+		QString result = QDir::fromNativeSeparators(QDir(path).absolutePath());
+		while (result.endsWith(QLatin1Char('/')))
+			result.chop(1);
+		return result;
+	};
+
+	const QString normalizedOldRoot = normalize(currentUserDataPath);
+	const QString normalizedNewRoot = normalize(targetPath);
+	const QString normalizedLogsPath = normalize(currentLogsPath);
+	const bool logsAffected = normalizedLogsPath.startsWith(normalizedOldRoot + QLatin1Char('/'), Qt::CaseInsensitive) || normalizedLogsPath.compare(normalizedOldRoot, Qt::CaseInsensitive) == 0;
+
+	if (logsAffected && QMessageBox::warning(this,
+		tr("Restart required"),
+		tr("User data relocation also includes logs and requires launcher restart after migration. Do you want to continue?"),
+		QMessageBox::Ok | QMessageBox::Cancel,
+		QMessageBox::Cancel) != QMessageBox::Ok)
+	{
+		return;
+	}
+
+	QSet<QString> skippedFiles;
+	if (logsAffected)
+		skippedFiles.insert(QStringLiteral("VCMI_Launcher_log.txt"));
+
+	if (!relocateDirectoryWithProgress(this, currentUserDataPath, targetPath, tr("Relocating user data"), skippedFiles))
+	{
+		QMessageBox::critical(this, tr("Failed to relocate"), tr("Unable to move existing files to the new directory."));
+		return;
+	}
+
+	JsonNode dirsConfig = currentWindowsDirsConfig();
+	dirsConfig["userDataPath"].String() = QDir::toNativeSeparators(targetPath).toStdString();
+
+	auto remapIfInsideOldRoot = [&](const char * key)
+	{
+		QString currentPath = QString::fromStdString(dirsConfig[key].String());
+		QString normalizedCurrent = normalize(currentPath);
+		if (normalizedCurrent.startsWith(normalizedOldRoot + QLatin1Char('/'), Qt::CaseInsensitive))
+		{
+			const QString suffix = normalizedCurrent.mid(normalizedOldRoot.size());
+			dirsConfig[key].String() = QDir::toNativeSeparators(normalizedNewRoot + suffix).toStdString();
+		}
+	};
+
+	remapIfInsideOldRoot("userCachePath");
+	remapIfInsideOldRoot("userConfigPath");
+	remapIfInsideOldRoot("userLogsPath");
+	remapIfInsideOldRoot("userSavePath");
+
+	if (!writeWindowsDirsConfig(dirsConfig))
+	{
+		QMessageBox::critical(this, tr("Failed to relocate"), tr("Unable to write %1").arg(windowsDirsConfigPath()));
+		return;
+	}
+
+	VCMIDirs::reload();
+	ui->lineEditUserDataDir->setText(pathToQString(VCMIDirs::get().userDataPath()));
+	ui->lineEditTempDir->setText(pathToQString(VCMIDirs::get().userLogsPath()));
+	ui->lineEditConfigDir->setText(pathToQString(VCMIDirs::get().userConfigPath()));
+	ui->lineEditSaveDir->setText(pathToQString(VCMIDirs::get().userSavePath()));
+
+	if (logsAffected)
+	{
+		QMessageBox::information(this, tr("Restarting launcher"), tr("User data (including logs) was moved. Launcher will now restart to apply logging path changes."));
+		startExecutable(QCoreApplication::applicationFilePath(), QCoreApplication::arguments().mid(1));
+	}
+#endif
+}
+
+void AboutProjectView::on_relocateTempDir_clicked()
+{
+#ifndef VCMI_WINDOWS
+	return;
+#else
+	const QString targetPath = QFileDialog::getExistingDirectory(this, tr("Select new logs directory"), ui->lineEditTempDir->text());
+	if (targetPath.isEmpty())
+		return;
+
+	if (QMessageBox::warning(this,
+		tr("Restart required"),
+		tr("Log directory relocation requires launcher restart after migration. Do you want to continue?"),
+		QMessageBox::Ok | QMessageBox::Cancel,
+		QMessageBox::Cancel) != QMessageBox::Ok)
+	{
+		return;
+	}
+
+	if (!relocateDirectoryWithProgress(this, ui->lineEditTempDir->text(), targetPath, tr("Relocating logs"), {QStringLiteral("VCMI_Launcher_log.txt")}))
+	{
+		QMessageBox::critical(this, tr("Failed to relocate"), tr("Unable to move existing files to the new directory."));
+		return;
+	}
+
+	JsonNode dirsConfig = currentWindowsDirsConfig();
+	dirsConfig["userLogsPath"].String() = QDir::toNativeSeparators(targetPath).toStdString();
+	if (!writeWindowsDirsConfig(dirsConfig))
+	{
+		QMessageBox::critical(this, tr("Failed to relocate"), tr("Unable to write %1").arg(windowsDirsConfigPath()));
+		return;
+	}
+
+	VCMIDirs::reload();
+
+	ui->lineEditUserDataDir->setText(pathToQString(VCMIDirs::get().userDataPath()));
+	ui->lineEditTempDir->setText(pathToQString(VCMIDirs::get().userLogsPath()));
+	ui->lineEditConfigDir->setText(pathToQString(VCMIDirs::get().userConfigPath()));
+	ui->lineEditSaveDir->setText(pathToQString(VCMIDirs::get().userSavePath()));
+
+	QMessageBox::information(this, tr("Restarting launcher"), tr("Log directory was moved. Launcher will now restart to apply logging path changes."));
+	startExecutable(QCoreApplication::applicationFilePath(), QCoreApplication::arguments().mid(1));
+#endif
+}
+
+void AboutProjectView::on_relocateSaveDir_clicked()
+{
+#ifndef VCMI_WINDOWS
+	return;
+#else
+	const QString targetPath = QFileDialog::getExistingDirectory(this, tr("Select new save directory"), ui->lineEditSaveDir->text());
+	if (targetPath.isEmpty())
+		return;
+
+	if (!relocateDirectoryWithProgress(this, ui->lineEditSaveDir->text(), targetPath, tr("Relocating saves")))
+	{
+		QMessageBox::critical(this, tr("Failed to relocate"), tr("Unable to move existing files to the new directory."));
+		return;
+	}
+
+	JsonNode dirsConfig = currentWindowsDirsConfig();
+	dirsConfig["userSavePath"].String() = QDir::toNativeSeparators(targetPath).toStdString();
+	if (!writeWindowsDirsConfig(dirsConfig))
+	{
+		QMessageBox::critical(this, tr("Failed to relocate"), tr("Unable to write %1").arg(windowsDirsConfigPath()));
+		return;
+	}
+
+	VCMIDirs::reload();
+	ui->lineEditUserDataDir->setText(pathToQString(VCMIDirs::get().userDataPath()));
+	ui->lineEditTempDir->setText(pathToQString(VCMIDirs::get().userLogsPath()));
+	ui->lineEditConfigDir->setText(pathToQString(VCMIDirs::get().userConfigPath()));
+	ui->lineEditSaveDir->setText(pathToQString(VCMIDirs::get().userSavePath()));
+#endif
 }
 
 void AboutProjectView::on_pushButtonDiscord_clicked()

--- a/launcher/aboutProject/aboutproject_moc.h
+++ b/launcher/aboutProject/aboutproject_moc.h
@@ -51,6 +51,14 @@ private slots:
 
 	void on_openConfigDir_clicked();
 
+	void on_openSaveDir_clicked();
+
+	void on_relocateUserDataDir_clicked();
+
+	void on_relocateTempDir_clicked();
+
+	void on_relocateSaveDir_clicked();
+
 private:
 	std::unique_ptr<Ui::AboutProjectView> ui;
 };

--- a/launcher/aboutProject/aboutproject_moc.ui
+++ b/launcher/aboutProject/aboutproject_moc.ui
@@ -71,7 +71,7 @@
     </spacer>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout" columnstretch="2,4,1">
+    <layout class="QGridLayout" name="gridLayout" columnstretch="2,4,1,1">
      <item row="2" column="1">
       <widget class="QLineEdit" name="lineEditOperatingSystem">
        <property name="text">
@@ -93,6 +93,13 @@
       <widget class="QPushButton" name="openUserDataDir">
        <property name="text">
         <string>Open</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="3">
+      <widget class="QPushButton" name="relocateUserDataDir">
+       <property name="text">
+        <string>Relocate...</string>
        </property>
       </widget>
      </item>
@@ -159,6 +166,13 @@
       <widget class="QPushButton" name="openTempDir">
        <property name="text">
         <string>Open</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="3">
+      <widget class="QPushButton" name="relocateTempDir">
+       <property name="text">
+        <string>Relocate...</string>
        </property>
       </widget>
      </item>
@@ -245,6 +259,40 @@
       <widget class="QPushButton" name="openConfigDir">
        <property name="text">
         <string>Open</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelSaveDir">
+       <property name="text">
+        <string>Save files directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLineEdit" name="lineEditSaveDir">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string notr="true">/home/user/.vcmi/Saves</string>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="2">
+      <widget class="QPushButton" name="openSaveDir">
+       <property name="text">
+        <string>Open</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="3">
+      <widget class="QPushButton" name="relocateSaveDir">
+       <property name="text">
+        <string>Relocate...</string>
        </property>
       </widget>
      </item>

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -102,6 +102,7 @@ class VCMIDirsWIN32 final : public IVCMIDirs
 		std::unique_ptr<JsonNode> dirsConfig;
 
 		bfs::path getPathFromConfigOrDefault(const std::string& key, const std::function<bfs::path()>& fallbackFunc) const;
+		bool isPathValueValid(const std::string & value) const;
 		bfs::path getDefaultUserDataPath() const;
 
 		std::wstring utf8ToWstring(const std::string& str) const;
@@ -130,7 +131,14 @@ void VCMIDirsWIN32::reloadConfig()
 		return;
 
 	std::string buffer((std::istreambuf_iterator<char>(in)), {});
-	dirsConfig = std::make_unique<JsonNode>(reinterpret_cast<const std::byte*>(buffer.data()), buffer.size(), pathToUtf8(configPath));
+	try
+	{
+		dirsConfig = std::make_unique<JsonNode>(reinterpret_cast<const std::byte*>(buffer.data()), buffer.size(), pathToUtf8(configPath));
+	}
+	catch(const std::exception &)
+	{
+		dirsConfig.reset();
+	}
 }
 
 std::string VCMIDirsWIN32::pathToUtf8(const bfs::path& path) const
@@ -154,6 +162,16 @@ std::wstring VCMIDirsWIN32::utf8ToWstring(const std::string& str) const
 	return result;
 }
 
+bool VCMIDirsWIN32::isPathValueValid(const std::string & value) const
+{
+	for (unsigned char ch : value)
+	{
+		if (ch < 0x20)
+			return false;
+	}
+	return !value.empty();
+}
+
 bfs::path VCMIDirsWIN32::getPathFromConfigOrDefault(const std::string& key, const std::function<bfs::path()>& fallbackFunc) const
 {
 	if (!dirsConfig || !dirsConfig->isStruct())
@@ -161,6 +179,9 @@ bfs::path VCMIDirsWIN32::getPathFromConfigOrDefault(const std::string& key, cons
 
 	const JsonNode& node = (*dirsConfig)[key];
 	if (!node.isString())
+		return fallbackFunc();
+
+	if (!isPathValueValid(node.String()))
 		return fallbackFunc();
 
 	std::wstring raw = utf8ToWstring(node.String());

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -80,6 +80,7 @@ class VCMIDirsWIN32 final : public IVCMIDirs
 {
 	public:
 		VCMIDirsWIN32();
+		void reloadConfig();
 		bfs::path userDataPath() const override;
 		bfs::path userCachePath() const override;
 		bfs::path userConfigPath() const override;
@@ -110,6 +111,13 @@ class VCMIDirsWIN32 final : public IVCMIDirs
 
 VCMIDirsWIN32::VCMIDirsWIN32()
 {
+	reloadConfig();
+}
+
+void VCMIDirsWIN32::reloadConfig()
+{
+	dirsConfig.reset();
+
 	wchar_t currentPath[MAX_PATH];
 	GetModuleFileNameW(nullptr, currentPath, MAX_PATH);
 	auto configPath = bfs::path(currentPath).parent_path() / "config" / "dirs.json";
@@ -635,6 +643,15 @@ std::string VCMIDirsXDG::libraryName(const std::string& basename) const { return
 #endif // VCMI_WINDOWS, VCMI_UNIX
 
 // Getters for interfaces are separated for clarity.
+namespace
+{
+	std::once_flag & vcmiDirsInitFlag()
+	{
+		static std::once_flag flag;
+		return flag;
+	}
+}
+
 namespace VCMIDirs
 {
 	const IVCMIDirs& get()
@@ -653,9 +670,17 @@ namespace VCMIDirs
 			static VCMIDirsIOS singleton;
 		#endif
 
-		static std::once_flag flag;
-		std::call_once(flag, [] { singleton.init(); });
+		std::call_once(vcmiDirsInitFlag(), [] { singleton.init(); });
 		return singleton;
+	}
+
+	void reload()
+	{
+		auto & singleton = const_cast<IVCMIDirs &>(get());
+#ifdef VCMI_WINDOWS
+		static_cast<VCMIDirsWIN32 &>(singleton).reloadConfig();
+#endif
+		singleton.init();
 	}
 }
 

--- a/lib/VCMIDirs.h
+++ b/lib/VCMIDirs.h
@@ -71,6 +71,7 @@ public:
 namespace VCMIDirs
 {
 	extern DLL_LINKAGE const IVCMIDirs & get();
+	extern DLL_LINKAGE void reload();
 }
 
 VCMI_LIB_NAMESPACE_END


### PR DESCRIPTION
### Motivation

- Expose the save files directory in the About dialog and allow users to relocate data, logs and saves on Windows while preserving existing files and updating the launcher configuration.

### Description

- Added `lineEditSaveDir`, `openSaveDir` and `relocate*` buttons to the About dialog UI and corresponding slots (`on_openSaveDir_clicked`, `on_relocateUserDataDir_clicked`, `on_relocateTempDir_clicked`, `on_relocateSaveDir_clicked`).
- Implemented Windows-only relocation helpers in `aboutproject_moc.cpp` including `countDirectoryEntries`, `moveDirectoryContent`, `relocateDirectoryWithProgress`, and functions to read/write `config/dirs.json` using `JsonNode` to persist new paths.
- Updated `VCMIDirs` to expose a `reload()` function and added `VCMIDirsWIN32::reloadConfig()` so runtime changes to `dirs.json` are reloaded and `init()` is reapplied; replaced local `once_flag` with a shared one to ensure proper initialization.
- Minor wiring: added includes (`main.h`, `JsonNode.h`), UI grid adjustments, and ensured platform-specific hiding of relocation controls on non-Windows platforms.

### Testing

- Built the desktop launcher and verified the About dialog compiles with the new UI additions on Windows and non-Windows builds.
- Exercised the relocation flows on Windows: relocation progress dialog runs and `config/dirs.json` is updated; launcher restart is triggered when logs path changes.
- No new automated tests were added for this change; existing automated test-suite and project builds were executed and passed during verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e9572138832d89ecf704f89995b0)