### PR TITLE
Add support to export and import save files (zip archives)

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -150,6 +150,64 @@ static QString gatherDeviceInfo()
 	return info;
 }
 
+
+void AboutProjectView::on_pushButtonExportSaves_clicked()
+{
+	const QString defaultName = QDir::home().filePath("vcmi-saves.zip");
+	QString outPath = QFileDialog::getSaveFileName(this, tr("Save saves"), defaultName, tr("Zip archives (*.zip)"));
+	if (outPath.isEmpty())
+		return;
+
+	if (!outPath.endsWith(".zip", Qt::CaseInsensitive))
+		outPath += ".zip";
+
+	QDir savesDir(pathToQString(VCMIDirs::get().userSavePath()));
+	if(!savesDir.exists())
+	{
+		QMessageBox::warning(this, tr("Error"), tr("Saves directory does not exist"));
+		return;
+	}
+
+	QDirIterator it(savesDir.absolutePath(), QDir::Files, QDirIterator::Subdirectories);
+
+	try
+	{
+		std::shared_ptr<CIOApi> api = std::make_shared<CDefaultIOApi>();
+		boost::filesystem::path archivePath(outPath.toStdString());
+		CZipSaver saver(api, archivePath);
+
+		bool hasAnySave = false;
+		while (it.hasNext())
+		{
+			const QString savePath = it.next();
+			if(!savePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+				continue;
+			QFile saveFile(savePath);
+			if (!saveFile.open(QIODevice::ReadOnly))
+				continue;
+
+			hasAnySave = true;
+			QByteArray data = saveFile.readAll();
+			const QString relativePath = savesDir.relativeFilePath(savePath);
+			auto stream = saver.addFile(relativePath.toStdString());
+			stream->write(reinterpret_cast<const ui8 *>(data.constData()), data.size());
+		}
+
+		if(!hasAnySave)
+		{
+			QMessageBox::warning(this, tr("Error"), tr("No save files were found"));
+			return;
+		}
+	}
+	catch (const std::exception & e)
+	{
+		QMessageBox::critical(this, tr("Error"), tr("Failed to create archive: %1").arg(QString::fromUtf8(e.what())));
+		return;
+	}
+
+	QMessageBox::information(this, tr("Success"), tr("Saves saved to %1").arg(outPath));
+}
+
 void AboutProjectView::on_pushButtonExportLogs_clicked()
 {
 	QDir tempDir(ui->lineEditTempDir->text());

--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -168,7 +168,24 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 		return;
 	}
 
-	QDirIterator it(savesDir.absolutePath(), QDir::Files, QDirIterator::Subdirectories);
+	QStringList saveFiles;
+	QDirIterator scanner(savesDir.absolutePath(), QDir::Files, QDirIterator::Subdirectories);
+	while(scanner.hasNext())
+	{
+		const QString savePath = scanner.next();
+		if(savePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+			saveFiles.push_back(savePath);
+	}
+
+	if(saveFiles.empty())
+	{
+		QMessageBox::warning(this, tr("Error"), tr("No save files were found"));
+		return;
+	}
+
+	QProgressDialog progress(tr("Exporting saves..."), tr("Cancel"), 0, saveFiles.size(), this);
+	progress.setWindowModality(Qt::WindowModal);
+	progress.setMinimumDuration(0);
 
 	try
 	{
@@ -176,28 +193,31 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 		boost::filesystem::path archivePath(outPath.toStdString());
 		CZipSaver saver(api, archivePath);
 
-		bool hasAnySave = false;
-		while (it.hasNext())
+		for(int index = 0; index < saveFiles.size(); ++index)
 		{
-			const QString savePath = it.next();
-			if(!savePath.endsWith(".vsgm1", Qt::CaseInsensitive))
-				continue;
+			if(progress.wasCanceled())
+			{
+				QFile::remove(outPath);
+				return;
+			}
+
+			const QString savePath = saveFiles[index];
+			const QString relativePath = savesDir.relativeFilePath(savePath);
+			progress.setValue(index);
+			progress.setLabelText(tr("Exporting %1").arg(relativePath));
+			qApp->processEvents();
+
 			QFile saveFile(savePath);
 			if (!saveFile.open(QIODevice::ReadOnly))
 				continue;
 
-			hasAnySave = true;
 			QByteArray data = saveFile.readAll();
-			const QString relativePath = savesDir.relativeFilePath(savePath);
-			auto stream = saver.addFile(relativePath.toStdString());
+			QByteArray relativePathUtf8 = relativePath.toUtf8();
+			auto stream = saver.addFile(std::string(relativePathUtf8.constData(), relativePathUtf8.size()));
 			stream->write(reinterpret_cast<const ui8 *>(data.constData()), data.size());
 		}
 
-		if(!hasAnySave)
-		{
-			QMessageBox::warning(this, tr("Error"), tr("No save files were found"));
-			return;
-		}
+		progress.setValue(saveFiles.size());
 	}
 	catch (const std::exception & e)
 	{

--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -232,7 +232,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 {
 	QDir tempDir(ui->lineEditTempDir->text());
 
-#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
+#if defined(VCMI_MOBILE)
     // cleanup old temp archives from previous runs (delete now)
     {
         QDir tdir(QDir::tempPath());
@@ -351,7 +351,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 		return;
 	}
 	// On mobile platforms, send file via platform and remove temporary file afterwards.
-#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
+#if defined(VCMI_MOBILE)
 	QMessageBox::information(this, tr("Send logs"), tr("The archive will be sent via another application. Share your logs e.g. over discord to developers."));
 	Helper::sendFileToApp(outPath);
 #else

--- a/launcher/aboutProject/aboutproject_moc.h
+++ b/launcher/aboutProject/aboutproject_moc.h
@@ -49,6 +49,8 @@ private slots:
 
 	void on_pushButtonExportLogs_clicked();
 
+	void on_pushButtonExportSaves_clicked();
+
 	void on_openConfigDir_clicked();
 
 private:

--- a/launcher/aboutProject/aboutproject_moc.ui
+++ b/launcher/aboutProject/aboutproject_moc.ui
@@ -318,6 +318,19 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="pushButtonExportSaves">
+       <property name="minimumSize">
+        <size>
+         <width>180</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Export saves</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -242,7 +242,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
 {
 	if(event->mimeData()->hasUrls())
 		for(const auto & url : event->mimeData()->urls())
-			for(const auto & ending : QStringList({".zip", ".h3m", ".h3c", ".vmap", ".vcmp", ".json", ".exe"}))
+			for(const auto & ending : QStringList({".zip", ".vsgm1", ".h3m", ".h3c", ".vmap", ".vcmp", ".json", ".exe"}))
 				if(url.fileName().endsWith(ending, Qt::CaseInsensitive))
 				{
 					event->acceptProposedAction();

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -266,6 +266,7 @@ void MainWindow::manualInstallFile(QString filePath)
 {
 	QString realFilePath = Helper::getRealPath(filePath);
 
+
 	if(realFilePath.endsWith(".zip", Qt::CaseInsensitive) || realFilePath.endsWith(".exe", Qt::CaseInsensitive))
 		switchToModsTab();
 

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -77,6 +77,7 @@ public:
 	void dropEvent(QDropEvent *event) override;
 
 	void manualInstallFile(QString filePath);
+
 	ETranslationStatus getTranslationStatus();
 
 protected:

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -963,6 +963,7 @@ void CModListView::installFiles(QStringList files)
 	QStringList mods;
 	QStringList maps;
 	QStringList saves;
+	QStringList saveFiles;
 	QStringList images;
 	QStringList exe;
 	bool repositoryFilesEnqueued = false;
@@ -1016,6 +1017,8 @@ void CModListView::installFiles(QStringList files)
 		}
 		else if(realFilename.endsWith(".h3m", Qt::CaseInsensitive) || realFilename.endsWith(".h3c", Qt::CaseInsensitive) || realFilename.endsWith(".vmap", Qt::CaseInsensitive) || realFilename.endsWith(".vcmp", Qt::CaseInsensitive))
 			maps.push_back(filename);
+		else if(realFilename.endsWith(".vsgm1", Qt::CaseInsensitive))
+			saveFiles.push_back(filename);
 		if(realFilename.endsWith(".exe", Qt::CaseInsensitive))
 			exe.push_back(filename);
 		else if(realFilename.endsWith(".json", Qt::CaseInsensitive))
@@ -1101,6 +1104,13 @@ void CModListView::installFiles(QStringList files)
 		logGlobal->info("Installing maps: ended");
 	}
 
+	if(!saveFiles.empty())
+	{
+		logGlobal->info("Installing save files: started");
+		installSaveFiles(saveFiles);
+		logGlobal->info("Installing save files: ended");
+	}
+
 	if(!saves.empty())
 	{
 		logGlobal->info("Installing saves: started");
@@ -1148,6 +1158,55 @@ void CModListView::installFiles(QStringList files)
 
 	if(!images.empty())
 		loadScreenshots();
+}
+
+void CModListView::installSaveFiles(QStringList saves)
+{
+	const auto savesPath = VCMIDirs::get().userSavePath();
+	boost::filesystem::create_directories(savesPath);
+
+	QDir savesDir(pathToQString(savesPath));
+	const auto saveDestDir = savesDir.absolutePath() + QChar{'/'};
+
+	int importedCount = 0;
+	int conflictCount = 0;
+	for(const auto & save : saves)
+	{
+		QString realSavePath = Helper::getRealPath(save);
+		QString fileName = QFileInfo(realSavePath).fileName();
+		if(fileName.isEmpty())
+			continue;
+		if(QFile::exists(saveDestDir + fileName))
+			conflictCount++;
+	}
+
+	bool applyToAll = false;
+	bool overwriteAll = false;
+
+	for(const auto & save : saves)
+	{
+		QString realSavePath = Helper::getRealPath(save);
+		QString fileName = QFileInfo(realSavePath).fileName();
+		if(fileName.isEmpty())
+			continue;
+
+		const QString destinationPath = saveDestDir + fileName;
+		if(QFile::exists(destinationPath))
+		{
+			if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(fileName), conflictCount, applyToAll, overwriteAll))
+				continue;
+
+			QFile::remove(destinationPath);
+		}
+
+		if(Helper::performNativeCopy(realSavePath, destinationPath))
+			importedCount++;
+		else
+			QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save file %1").arg(realSavePath));
+	}
+
+	if(importedCount > 0)
+		QMessageBox::information(this, tr("Success"), tr("Imported %1 save files").arg(importedCount));
 }
 
 void CModListView::installSaveArchives(QStringList archives)

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -37,8 +37,6 @@
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/texts/Languages.h"
 
-#include "../vcmiqt/launcherdirs.h"
-
 #include <future>
 
 void CModListView::setupModModel()
@@ -901,6 +899,47 @@ void CModListView::hideProgressBar()
 	}
 }
 
+bool CModListView::askOverwriteDialog(const QString & windowTitle, const QString & message, int conflictCount, bool & applyToAll, bool & overwriteAll)
+{
+	if(applyToAll)
+		return overwriteAll;
+
+	QMessageBox msgBox(this);
+	msgBox.setIcon(QMessageBox::Question);
+	msgBox.setWindowTitle(windowTitle);
+	msgBox.setText(message);
+
+	QPushButton * yes = msgBox.addButton(QMessageBox::Yes);
+	msgBox.addButton(QMessageBox::No);
+
+	QPushButton * yesAll = nullptr;
+	QPushButton * noAll = nullptr;
+	if(conflictCount > 1)
+	{
+		yesAll = msgBox.addButton(tr("Yes to All"), QMessageBox::YesRole);
+		noAll = msgBox.addButton(tr("No to All"), QMessageBox::NoRole);
+	}
+
+	msgBox.exec();
+	QAbstractButton * clicked = msgBox.clickedButton();
+
+	if(clicked == yes)
+		return true;
+	if(clicked == yesAll)
+	{
+		applyToAll = true;
+		overwriteAll = true;
+		return true;
+	}
+	if(clicked == noAll)
+	{
+		applyToAll = true;
+		overwriteAll = false;
+		return false;
+	}
+	return false;
+}
+
 void CModListView::installFiles(QStringList files)
 {
 	QStringList mods;
@@ -1129,47 +1168,6 @@ void CModListView::installSaveArchives(QStringList archives)
 	bool applyToAll = false;
 	bool overwriteAll = false;
 
-	auto askOverwrite = [&](const QString & name) -> bool
-	{
-		if(applyToAll)
-			return overwriteAll;
-
-		QMessageBox msgBox(this);
-		msgBox.setIcon(QMessageBox::Question);
-		msgBox.setWindowTitle(tr("Save exists"));
-		msgBox.setText(tr("Save '%1' already exists. Do you want to overwrite it?").arg(name));
-
-		QPushButton * yes = msgBox.addButton(QMessageBox::Yes);
-		msgBox.addButton(QMessageBox::No);
-
-		QPushButton * yesAll = nullptr;
-		QPushButton * noAll = nullptr;
-		if(conflictCount > 1)
-		{
-			yesAll = msgBox.addButton(tr("Yes to All"), QMessageBox::YesRole);
-			noAll = msgBox.addButton(tr("No to All"), QMessageBox::NoRole);
-		}
-
-		msgBox.exec();
-		QAbstractButton * clicked = msgBox.clickedButton();
-
-		if(clicked == yes)
-			return true;
-		if(clicked == yesAll)
-		{
-			applyToAll = true;
-			overwriteAll = true;
-			return true;
-		}
-		if(clicked == noAll)
-		{
-			applyToAll = true;
-			overwriteAll = false;
-			return false;
-		}
-		return false;
-	};
-
 	for(const auto & archivePath : archives)
 	{
 		try
@@ -1186,7 +1184,7 @@ void CModListView::installSaveArchives(QStringList archives)
 				const QString destinationPath = saveDestDir + relativePath;
 				if(QFile::exists(destinationPath))
 				{
-					if(!askOverwrite(relativePath))
+					if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(relativePath), conflictCount, applyToAll, overwriteAll))
 						continue;
 
 					QFile::remove(destinationPath);
@@ -1318,46 +1316,6 @@ void CModListView::installMaps(QStringList maps)
 	bool applyToAll = false;
 	bool overwriteAll = false;
 
-	auto askOverwrite = [&](const QString& name) -> bool {
-		if (applyToAll)
-			return overwriteAll;
-
-		QMessageBox msgBox(this);
-		msgBox.setIcon(QMessageBox::Question);
-		msgBox.setWindowTitle(tr("Map exists"));
-		msgBox.setText(tr("Map '%1' already exists. Do you want to overwrite it?").arg(name));
-
-		QPushButton* yes = msgBox.addButton(QMessageBox::Yes);
-		msgBox.addButton(QMessageBox::No);
-
-		QPushButton* yesAll = nullptr;
-		QPushButton* noAll = nullptr;
-		if (conflictCount > 1)
-		{
-			yesAll = msgBox.addButton(tr("Yes to All"), QMessageBox::YesRole);
-			noAll = msgBox.addButton(tr("No to All"), QMessageBox::NoRole);
-		}
-
-		msgBox.exec();
-		QAbstractButton* clicked = msgBox.clickedButton();
-
-		if (clicked == yes)
-			return true;
-		if (clicked == yesAll)
-		{
-			applyToAll = true;
-			overwriteAll = true;
-			return true;
-		}
-		if (clicked == noAll)
-		{
-			applyToAll = true;
-			overwriteAll = false;
-			return false;
-		}
-		return false;
-	};
-
 	// Process each map file and archive
 	for (const QString& map : maps)
 	{
@@ -1377,7 +1335,7 @@ void CModListView::installMaps(QStringList maps)
 
 				if (QFile::exists(destFile))
 				{
-					if (!askOverwrite(name))
+					if (!askOverwriteDialog(tr("Map exists"), tr("Map '%1' already exists. Do you want to overwrite it?").arg(name), conflictCount, applyToAll, overwriteAll))
 					{
 						logGlobal->info("Skipped map '%s'", name.toStdString());
 						continue;

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1106,7 +1106,7 @@ void CModListView::installFiles(QStringList files)
 	if(!saves.empty())
 	{
 		logGlobal->info("Installing saves: started");
-		installSaveFiles(saves);
+		installSaves(saves);
 		logGlobal->info("Installing saves: ended");
 	}
 
@@ -1152,7 +1152,7 @@ void CModListView::installFiles(QStringList files)
 		loadScreenshots();
 }
 
-void CModListView::installSaveFiles(QStringList saves)
+void CModListView::installSaves(QStringList saves)
 {
 	const auto savesPath = VCMIDirs::get().userSavePath();
 	boost::filesystem::create_directories(savesPath);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1098,7 +1098,11 @@ void CModListView::installSaveArchives(QStringList archives)
 	const auto savesPath = VCMIDirs::get().userSavePath();
 	boost::filesystem::create_directories(savesPath);
 
+	QDir savesDir(pathToQString(savesPath));
+	const auto saveDestDir = savesDir.absolutePath() + QChar{'/'};
+
 	int importedCount = 0;
+	int conflictCount = 0;
 
 	for(const auto & archivePath : archives)
 	{
@@ -1107,23 +1111,92 @@ void CModListView::installSaveArchives(QStringList archives)
 			ZipArchive archive(qstringToPath(archivePath));
 			auto fileList = archive.listFiles();
 
-			std::vector<std::string> saveFiles;
 			for(const auto & file : fileList)
 			{
-				if(QString::fromStdString(file).endsWith(".vsgm1", Qt::CaseInsensitive))
-					saveFiles.push_back(file);
+				QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
+				if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+					continue;
+
+				if(QFile::exists(saveDestDir + relativePath))
+					conflictCount++;
 			}
+		}
+		catch(const std::exception &)
+		{
+		}
+	}
 
-			if(saveFiles.empty())
-				continue;
+	bool applyToAll = false;
+	bool overwriteAll = false;
 
-			if(!archive.extract(savesPath, saveFiles))
+	auto askOverwrite = [&](const QString & name) -> bool
+	{
+		if(applyToAll)
+			return overwriteAll;
+
+		QMessageBox msgBox(this);
+		msgBox.setIcon(QMessageBox::Question);
+		msgBox.setWindowTitle(tr("Save exists"));
+		msgBox.setText(tr("Save '%1' already exists. Do you want to overwrite it?").arg(name));
+
+		QPushButton * yes = msgBox.addButton(QMessageBox::Yes);
+		msgBox.addButton(QMessageBox::No);
+
+		QPushButton * yesAll = nullptr;
+		QPushButton * noAll = nullptr;
+		if(conflictCount > 1)
+		{
+			yesAll = msgBox.addButton(tr("Yes to All"), QMessageBox::YesRole);
+			noAll = msgBox.addButton(tr("No to All"), QMessageBox::NoRole);
+		}
+
+		msgBox.exec();
+		QAbstractButton * clicked = msgBox.clickedButton();
+
+		if(clicked == yes)
+			return true;
+		if(clicked == yesAll)
+		{
+			applyToAll = true;
+			overwriteAll = true;
+			return true;
+		}
+		if(clicked == noAll)
+		{
+			applyToAll = true;
+			overwriteAll = false;
+			return false;
+		}
+		return false;
+	};
+
+	for(const auto & archivePath : archives)
+	{
+		try
+		{
+			ZipArchive archive(qstringToPath(archivePath));
+			auto fileList = archive.listFiles();
+
+			for(const auto & file : fileList)
 			{
-				QMessageBox::warning(this, tr("Import failed"), tr("Failed to import saves from %1").arg(archivePath));
-				continue;
-			}
+				QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
+				if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+					continue;
 
-			importedCount += static_cast<int>(saveFiles.size());
+				const QString destinationPath = saveDestDir + relativePath;
+				if(QFile::exists(destinationPath))
+				{
+					if(!askOverwrite(relativePath))
+						continue;
+
+					QFile::remove(destinationPath);
+				}
+
+				if(archive.extract(savesPath, file))
+					importedCount++;
+				else
+					QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save %1 from %2").arg(relativePath, archivePath));
+			}
 		}
 		catch(const std::exception & e)
 		{

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -889,6 +889,24 @@ void CModListView::downloadFinished(QStringList savedFiles, QStringList failedFi
 	hideProgressBar();
 }
 
+void CModListView::showExternalProgress(const QString & format, int current, int max)
+{
+	ui->progressWidget->setVisible(true);
+	ui->progressBar->setFormat(format);
+	ui->progressBar->setMaximum(max);
+	ui->progressBar->setValue(current);
+}
+
+void CModListView::hideExternalProgress()
+{
+	if(dlManager == nullptr)
+	{
+		ui->progressWidget->setVisible(false);
+		ui->progressBar->setMaximum(0);
+		ui->progressBar->setValue(0);
+	}
+}
+
 void CModListView::hideProgressBar()
 {
 	if(dlManager == nullptr) // it was not recreated meanwhile

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -905,6 +905,7 @@ void CModListView::installFiles(QStringList files)
 {
 	QStringList mods;
 	QStringList maps;
+	QStringList saves;
 	QStringList images;
 	QStringList exe;
 	bool repositoryFilesEnqueued = false;
@@ -923,6 +924,7 @@ void CModListView::installFiles(QStringList files)
 
 			bool hasModJson = false;
 			bool hasMaps = false;
+			bool hasSaves = false;
 
 			for (const auto& file : fileList)
 			{
@@ -935,12 +937,17 @@ void CModListView::installFiles(QStringList files)
 				// Check for map files anywhere
 				if (lower.endsWith(".h3m") || lower.endsWith(".h3c") || lower.endsWith(".vmap") || lower.endsWith(".vcmp"))
 					hasMaps = true;
+
+				if (lower.endsWith(".vsgm1"))
+					hasSaves = true;
 			}
 
 			if (hasModJson)
 				mods.push_back(filename);
 			else if (hasMaps)
 				maps.push_back(filename);
+			else if (hasSaves)
+				saves.push_back(filename);
 			else
 				mods.push_back(filename);
 			}
@@ -1037,6 +1044,13 @@ void CModListView::installFiles(QStringList files)
 		logGlobal->info("Installing maps: ended");
 	}
 
+	if(!saves.empty())
+	{
+		logGlobal->info("Installing saves: started");
+		installSaveArchives(saves);
+		logGlobal->info("Installing saves: ended");
+	}
+
 	if(!exe.empty())
 	{
 		logGlobal->info("Installing chronicles: started");
@@ -1077,6 +1091,48 @@ void CModListView::installFiles(QStringList files)
 
 	if(!images.empty())
 		loadScreenshots();
+}
+
+void CModListView::installSaveArchives(QStringList archives)
+{
+	const auto savesPath = VCMIDirs::get().userSavePath();
+	boost::filesystem::create_directories(savesPath);
+
+	int importedCount = 0;
+
+	for(const auto & archivePath : archives)
+	{
+		try
+		{
+			ZipArchive archive(qstringToPath(archivePath));
+			auto fileList = archive.listFiles();
+
+			std::vector<std::string> saveFiles;
+			for(const auto & file : fileList)
+			{
+				if(QString::fromStdString(file).endsWith(".vsgm1", Qt::CaseInsensitive))
+					saveFiles.push_back(file);
+			}
+
+			if(saveFiles.empty())
+				continue;
+
+			if(!archive.extract(savesPath, saveFiles))
+			{
+				QMessageBox::warning(this, tr("Import failed"), tr("Failed to import saves from %1").arg(archivePath));
+				continue;
+			}
+
+			importedCount += static_cast<int>(saveFiles.size());
+		}
+		catch(const std::exception & e)
+		{
+			QMessageBox::warning(this, tr("Import failed"), tr("Failed to import saves from %1.\nReason: %2").arg(archivePath, QString::fromUtf8(e.what())));
+		}
+	}
+
+	if(importedCount > 0)
+		QMessageBox::information(this, tr("Success"), tr("Imported %1 save files").arg(importedCount));
 }
 
 void CModListView::installMods(QStringList archives)

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -963,7 +963,6 @@ void CModListView::installFiles(QStringList files)
 	QStringList mods;
 	QStringList maps;
 	QStringList saves;
-	QStringList saveFiles;
 	QStringList images;
 	QStringList exe;
 	bool repositoryFilesEnqueued = false;
@@ -1018,7 +1017,7 @@ void CModListView::installFiles(QStringList files)
 		else if(realFilename.endsWith(".h3m", Qt::CaseInsensitive) || realFilename.endsWith(".h3c", Qt::CaseInsensitive) || realFilename.endsWith(".vmap", Qt::CaseInsensitive) || realFilename.endsWith(".vcmp", Qt::CaseInsensitive))
 			maps.push_back(filename);
 		else if(realFilename.endsWith(".vsgm1", Qt::CaseInsensitive))
-			saveFiles.push_back(filename);
+			saves.push_back(filename);
 		if(realFilename.endsWith(".exe", Qt::CaseInsensitive))
 			exe.push_back(filename);
 		else if(realFilename.endsWith(".json", Qt::CaseInsensitive))
@@ -1104,17 +1103,10 @@ void CModListView::installFiles(QStringList files)
 		logGlobal->info("Installing maps: ended");
 	}
 
-	if(!saveFiles.empty())
-	{
-		logGlobal->info("Installing save files: started");
-		installSaveFiles(saveFiles);
-		logGlobal->info("Installing save files: ended");
-	}
-
 	if(!saves.empty())
 	{
 		logGlobal->info("Installing saves: started");
-		installSaveArchives(saves);
+		installSaveFiles(saves);
 		logGlobal->info("Installing saves: ended");
 	}
 
@@ -1170,9 +1162,33 @@ void CModListView::installSaveFiles(QStringList saves)
 
 	int importedCount = 0;
 	int conflictCount = 0;
+
 	for(const auto & save : saves)
 	{
 		QString realSavePath = Helper::getRealPath(save);
+		if(realSavePath.endsWith(".zip", Qt::CaseInsensitive))
+		{
+			try
+			{
+				ZipArchive archive(qstringToPath(realSavePath));
+				auto fileList = archive.listFiles();
+
+				for(const auto & file : fileList)
+				{
+					QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
+					if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+						continue;
+
+					if(QFile::exists(saveDestDir + relativePath))
+						conflictCount++;
+				}
+			}
+			catch(const std::exception &)
+			{
+			}
+			continue;
+		}
+
 		QString fileName = QFileInfo(realSavePath).fileName();
 		if(fileName.isEmpty())
 			continue;
@@ -1186,6 +1202,42 @@ void CModListView::installSaveFiles(QStringList saves)
 	for(const auto & save : saves)
 	{
 		QString realSavePath = Helper::getRealPath(save);
+
+		if(realSavePath.endsWith(".zip", Qt::CaseInsensitive))
+		{
+			try
+			{
+				ZipArchive archive(qstringToPath(realSavePath));
+				auto fileList = archive.listFiles();
+
+				for(const auto & file : fileList)
+				{
+					QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
+					if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+						continue;
+
+					const QString destinationPath = saveDestDir + relativePath;
+					if(QFile::exists(destinationPath))
+					{
+						if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(relativePath), conflictCount, applyToAll, overwriteAll))
+							continue;
+
+						QFile::remove(destinationPath);
+					}
+
+					if(archive.extract(savesPath, file))
+						importedCount++;
+					else
+						QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save %1 from %2").arg(relativePath, realSavePath));
+				}
+			}
+			catch(const std::exception & e)
+			{
+				QMessageBox::warning(this, tr("Import failed"), tr("Failed to import saves from %1.\nReason: %2").arg(realSavePath, QString::fromUtf8(e.what())));
+			}
+			continue;
+		}
+
 		QString fileName = QFileInfo(realSavePath).fileName();
 		if(fileName.isEmpty())
 			continue;
@@ -1203,80 +1255,6 @@ void CModListView::installSaveFiles(QStringList saves)
 			importedCount++;
 		else
 			QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save file %1").arg(realSavePath));
-	}
-
-	if(importedCount > 0)
-		QMessageBox::information(this, tr("Success"), tr("Imported %1 save files").arg(importedCount));
-}
-
-void CModListView::installSaveArchives(QStringList archives)
-{
-	const auto savesPath = VCMIDirs::get().userSavePath();
-	boost::filesystem::create_directories(savesPath);
-
-	QDir savesDir(pathToQString(savesPath));
-	const auto saveDestDir = savesDir.absolutePath() + QChar{'/'};
-
-	int importedCount = 0;
-	int conflictCount = 0;
-
-	for(const auto & archivePath : archives)
-	{
-		try
-		{
-			ZipArchive archive(qstringToPath(archivePath));
-			auto fileList = archive.listFiles();
-
-			for(const auto & file : fileList)
-			{
-				QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
-				if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
-					continue;
-
-				if(QFile::exists(saveDestDir + relativePath))
-					conflictCount++;
-			}
-		}
-		catch(const std::exception &)
-		{
-		}
-	}
-
-	bool applyToAll = false;
-	bool overwriteAll = false;
-
-	for(const auto & archivePath : archives)
-	{
-		try
-		{
-			ZipArchive archive(qstringToPath(archivePath));
-			auto fileList = archive.listFiles();
-
-			for(const auto & file : fileList)
-			{
-				QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
-				if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
-					continue;
-
-				const QString destinationPath = saveDestDir + relativePath;
-				if(QFile::exists(destinationPath))
-				{
-					if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(relativePath), conflictCount, applyToAll, overwriteAll))
-						continue;
-
-					QFile::remove(destinationPath);
-				}
-
-				if(archive.extract(savesPath, file))
-					importedCount++;
-				else
-					QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save %1 from %2").arg(relativePath, archivePath));
-			}
-		}
-		catch(const std::exception & e)
-		{
-			QMessageBox::warning(this, tr("Import failed"), tr("Failed to import saves from %1.\nReason: %2").arg(archivePath, QString::fromUtf8(e.what())));
-		}
 	}
 
 	if(importedCount > 0)

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -132,6 +132,9 @@ public:
 	void downloadFile(QString file, QUrl url, QString description, qint64 sizeBytes = 0);
 	void installFiles(QStringList mods);
 
+	void showExternalProgress(const QString & format, int current, int max);
+	void hideExternalProgress();
+
 public slots:
 	void enableModByName(QString modName);
 	void disableModByName(QString modName);

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -59,6 +59,7 @@ class CModListView : public QWidget
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);
 	void installSaveArchives(QStringList archives);
+	bool askOverwriteDialog(const QString & windowTitle, const QString & message, int conflictCount, bool & applyToAll, bool & overwriteAll);
 
 	QString genChangelogText(const ModState & mod);
 	QString genModInfoText(const ModState & mod);

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -58,7 +58,7 @@ class CModListView : public QWidget
 
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);
-	void installSaveFiles(QStringList saves);
+	void installSaves(QStringList saves);
 	bool askOverwriteDialog(const QString & windowTitle, const QString & message, int conflictCount, bool & applyToAll, bool & overwriteAll);
 
 	QString genChangelogText(const ModState & mod);

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -59,7 +59,6 @@ class CModListView : public QWidget
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);
 	void installSaveFiles(QStringList saves);
-	void installSaveArchives(QStringList archives);
 	bool askOverwriteDialog(const QString & windowTitle, const QString & message, int conflictCount, bool & applyToAll, bool & overwriteAll);
 
 	QString genChangelogText(const ModState & mod);

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -58,6 +58,7 @@ class CModListView : public QWidget
 
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);
+	void installSaveFiles(QStringList saves);
 	void installSaveArchives(QStringList archives);
 	bool askOverwriteDialog(const QString & windowTitle, const QString & message, int conflictCount, bool & applyToAll, bool & overwriteAll);
 

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -58,6 +58,7 @@ class CModListView : public QWidget
 
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);
+	void installSaveArchives(QStringList archives);
 
 	QString genChangelogText(const ModState & mod);
 	QString genModInfoText(const ModState & mod);

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -253,9 +253,52 @@ void StartGameTab::on_buttonImportFiles_clicked()
 		//Workaround for sometimes incorrect mime for some extensions (e.g. for exe)
 		QString filter = tr("All files (*.*)");
 #endif
-		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, save archives, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
+		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
+		if(files.isEmpty())
+			return;
 
-		for(const auto & file : files)
+		QStringList preparedFiles;
+		preparedFiles.reserve(files.size());
+
+		QDir importCacheDir(pathToQString(VCMIDirs::get().userDataPath()));
+		importCacheDir.mkpath("tmp/import-cache");
+		importCacheDir.cd("tmp/import-cache");
+
+		auto * modView = Helper::getMainWindow()->getModView();
+		modView->showExternalProgress(tr("Preparing selected files for import..."), 0, files.size());
+
+		for(int index = 0; index < files.size(); ++index)
+		{
+			const QString file = files[index];
+			modView->showExternalProgress(tr("Preparing selected files for import... %1/%2").arg(index + 1).arg(files.size()), index, files.size());
+			qApp->processEvents();
+
+			QString importPath = file;
+
+			// Some exotic systems allows read after copy
+			QFile sourceFile(file);
+			if(!sourceFile.open(QIODevice::ReadOnly))
+			{
+				QString baseName = QFileInfo(Helper::getRealPath(file)).fileName();
+				if(baseName.isEmpty())
+					baseName = QStringLiteral("import_%1.bin").arg(index + 1);
+
+				const QString stagedPath = importCacheDir.filePath(QString::number(QDateTime::currentMSecsSinceEpoch()) + "_" + baseName);
+				if(!Helper::performNativeCopy(file, stagedPath))
+				{
+					QMessageBox::warning(this, tr("Import failed"), tr("Failed to prepare file for import: %1").arg(Helper::getRealPath(file)));
+					continue;
+				}
+				importPath = stagedPath;
+			}
+
+			preparedFiles << importPath;
+		}
+
+		modView->showExternalProgress(tr("Preparing selected files for import..."), files.size(), files.size());
+		modView->hideExternalProgress();
+
+		for(const auto & file : preparedFiles)
 		{
 			logGlobal->info("Importing file %s", file.toStdString());
 			Helper::getMainWindow()->manualInstallFile(file);

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -243,9 +243,10 @@ void StartGameTab::on_buttonImportFiles_clicked()
 	{
 #ifndef VCMI_MOBILE
 		QString filter =
-			tr("All supported files") + " (*.h3m *.vmap *.h3c *.vcmp *.zip *.json *.exe);;" +
+			tr("All supported files") + " (*.h3m *.vmap *.h3c *.vcmp *.vsgm1 *.zip *.json *.exe);;" +
 			tr("Maps") + " (*.h3m *.vmap);;" +
 			tr("Campaigns") + " (*.h3c *.vcmp);;" +
+			tr("Saves") + " (*.vsgm1);;" +
 			tr("Configs") + " (*.json);;" +
 			tr("Mods") + " (*.zip);;" +
 			tr("Gog files") + " (*.exe)";
@@ -253,7 +254,7 @@ void StartGameTab::on_buttonImportFiles_clicked()
 		//Workaround for sometimes incorrect mime for some extensions (e.g. for exe)
 		QString filter = tr("All files (*.*)");
 #endif
-		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
+		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, saves, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
 		if(files.isEmpty())
 			return;
 
@@ -347,6 +348,7 @@ void StartGameTab::on_buttonHelpImportFiles_clicked()
 		" - Heroes III Chronicles using offline backup installer from GOG.com (.exe).\n"
 		" - VCMI mods in zip format (.zip)\n"
 		" - VCMI saves archive in zip format (.zip)\n"
+		" - VCMI save files (.vsgm1)\n"
 		" - VCMI configuration files (.json)\n"
 	);
 

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -253,7 +253,7 @@ void StartGameTab::on_buttonImportFiles_clicked()
 		//Workaround for sometimes incorrect mime for some extensions (e.g. for exe)
 		QString filter = tr("All files (*.*)");
 #endif
-		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
+		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, save archives, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
 
 		for(const auto & file : files)
 		{
@@ -303,6 +303,7 @@ void StartGameTab::on_buttonHelpImportFiles_clicked()
 		" - Heroes III Campaigns (.h3c or .vcmp).\n"
 		" - Heroes III Chronicles using offline backup installer from GOG.com (.exe).\n"
 		" - VCMI mods in zip format (.zip)\n"
+		" - VCMI saves archive in zip format (.zip)\n"
 		" - VCMI configuration files (.json)\n"
 	);
 


### PR DESCRIPTION
### Motivation
- Provide users a way to export local save files as a zip archive from the About dialog. 
- Allow the launcher to detect and import save archives dropped or selected for installation alongside mods/maps. 
- Update UI and import flows so save archives are advertised and handled like other supported file types.

### Description
- Added an `Export saves` button to the About dialog UI and a new slot `AboutProjectView::on_pushButtonExportSaves_clicked()` that collects `*.vsgm1` files from the user save directory and writes them into a zip using `CZipSaver`.
- Extended the import pipeline in `CModListView` to detect `*.vsgm1` inside zip archives, added a `saves` queue, and implemented `CModListView::installSaveArchives(QStringList)` to extract save files into `VCMIDirs::get().userSavePath()`.
- Updated `StartGameTab` import dialog text to advertise save archives in the file picker and wired the new slot in `aboutproject_moc.h` and `cmodlistview_moc.h` headers.
- Minor integration changes: adjusted file type handling in `manualInstallFile` and added UI resource entry for the new button (`aboutproject_moc.ui`).

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4513a8c54832da3ee5f089dcfeef6)