### PR TITLE
Add save import/export support and improve import UX

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -186,6 +186,8 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 	QProgressDialog progress(tr("Exporting saves..."), tr("Cancel"), 0, saveFiles.size(), this);
 	progress.setWindowModality(Qt::WindowModal);
 	progress.setMinimumDuration(0);
+	progress.setWindowFlag(Qt::WindowCloseButtonHint, false);
+	progress.setWindowFlag(Qt::WindowContextHelpButtonHint, false);
 
 	try
 	{
@@ -204,7 +206,7 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 			const QString savePath = saveFiles[index];
 			const QString relativePath = savesDir.relativeFilePath(savePath);
 			progress.setValue(index);
-			progress.setLabelText(tr("Exporting %1").arg(relativePath));
+			progress.setLabelText(tr("Exporting saves... %1 / %2").arg(index + 1).arg(saveFiles.size()));
 			qApp->processEvents();
 
 			QFile saveFile(savePath);

--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -150,11 +150,89 @@ static QString gatherDeviceInfo()
 	return info;
 }
 
+
+void AboutProjectView::on_pushButtonExportSaves_clicked()
+{
+	const QString defaultName = QDir::home().filePath("vcmi-saves.zip");
+	QString outPath = QFileDialog::getSaveFileName(this, tr("Save saves"), defaultName, tr("Zip archives (*.zip)"));
+	if (outPath.isEmpty())
+		return;
+
+	if (!outPath.endsWith(".zip", Qt::CaseInsensitive))
+		outPath += ".zip";
+
+	QDir savesDir(pathToQString(VCMIDirs::get().userSavePath()));
+	if(!savesDir.exists())
+	{
+		QMessageBox::warning(this, tr("Error"), tr("Saves directory does not exist"));
+		return;
+	}
+
+	QStringList saveFiles;
+	QDirIterator scanner(savesDir.absolutePath(), QDir::Files, QDirIterator::Subdirectories);
+	while(scanner.hasNext())
+	{
+		const QString savePath = scanner.next();
+		if(savePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+			saveFiles.push_back(savePath);
+	}
+
+	if(saveFiles.empty())
+	{
+		QMessageBox::warning(this, tr("Error"), tr("No save files were found"));
+		return;
+	}
+
+	QProgressDialog progress(tr("Exporting saves..."), tr("Cancel"), 0, saveFiles.size(), this);
+	progress.setWindowModality(Qt::WindowModal);
+	progress.setMinimumDuration(0);
+
+	try
+	{
+		std::shared_ptr<CIOApi> api = std::make_shared<CDefaultIOApi>();
+		boost::filesystem::path archivePath(outPath.toStdString());
+		CZipSaver saver(api, archivePath);
+
+		for(int index = 0; index < saveFiles.size(); ++index)
+		{
+			if(progress.wasCanceled())
+			{
+				QFile::remove(outPath);
+				return;
+			}
+
+			const QString savePath = saveFiles[index];
+			const QString relativePath = savesDir.relativeFilePath(savePath);
+			progress.setValue(index);
+			progress.setLabelText(tr("Exporting %1").arg(relativePath));
+			qApp->processEvents();
+
+			QFile saveFile(savePath);
+			if (!saveFile.open(QIODevice::ReadOnly))
+				continue;
+
+			QByteArray data = saveFile.readAll();
+			QByteArray relativePathUtf8 = relativePath.toUtf8();
+			auto stream = saver.addFile(std::string(relativePathUtf8.constData(), relativePathUtf8.size()));
+			stream->write(reinterpret_cast<const ui8 *>(data.constData()), data.size());
+		}
+
+		progress.setValue(saveFiles.size());
+	}
+	catch (const std::exception & e)
+	{
+		QMessageBox::critical(this, tr("Error"), tr("Failed to create archive: %1").arg(QString::fromUtf8(e.what())));
+		return;
+	}
+
+	QMessageBox::information(this, tr("Success"), tr("Saves saved to %1").arg(outPath));
+}
+
 void AboutProjectView::on_pushButtonExportLogs_clicked()
 {
 	QDir tempDir(ui->lineEditTempDir->text());
 
-#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
+#if defined(VCMI_MOBILE)
     // cleanup old temp archives from previous runs (delete now)
     {
         QDir tdir(QDir::tempPath());
@@ -273,7 +351,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 		return;
 	}
 	// On mobile platforms, send file via platform and remove temporary file afterwards.
-#if defined(VCMI_ANDROID) || defined(VCMI_IOS)
+#if defined(VCMI_MOBILE)
 	QMessageBox::information(this, tr("Send logs"), tr("The archive will be sent via another application. Share your logs e.g. over discord to developers."));
 	Helper::sendFileToApp(outPath);
 #else

--- a/launcher/aboutProject/aboutproject_moc.h
+++ b/launcher/aboutProject/aboutproject_moc.h
@@ -49,6 +49,8 @@ private slots:
 
 	void on_pushButtonExportLogs_clicked();
 
+	void on_pushButtonExportSaves_clicked();
+
 	void on_openConfigDir_clicked();
 
 private:

--- a/launcher/aboutProject/aboutproject_moc.ui
+++ b/launcher/aboutProject/aboutproject_moc.ui
@@ -318,6 +318,19 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="pushButtonExportSaves">
+       <property name="minimumSize">
+        <size>
+         <width>180</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Export saves</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -242,7 +242,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent* event)
 {
 	if(event->mimeData()->hasUrls())
 		for(const auto & url : event->mimeData()->urls())
-			for(const auto & ending : QStringList({".zip", ".h3m", ".h3c", ".vmap", ".vcmp", ".json", ".exe"}))
+			for(const auto & ending : QStringList({".zip", ".vsgm1", ".h3m", ".h3c", ".vmap", ".vcmp", ".json", ".exe"}))
 				if(url.fileName().endsWith(ending, Qt::CaseInsensitive))
 				{
 					event->acceptProposedAction();
@@ -265,6 +265,7 @@ void MainWindow::dropEvent(QDropEvent* event)
 void MainWindow::manualInstallFile(QString filePath)
 {
 	QString realFilePath = Helper::getRealPath(filePath);
+
 
 	if(realFilePath.endsWith(".zip", Qt::CaseInsensitive) || realFilePath.endsWith(".exe", Qt::CaseInsensitive))
 		switchToModsTab();

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -77,6 +77,7 @@ public:
 	void dropEvent(QDropEvent *event) override;
 
 	void manualInstallFile(QString filePath);
+
 	ETranslationStatus getTranslationStatus();
 
 protected:

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -37,8 +37,6 @@
 #include "../../lib/texts/CGeneralTextHandler.h"
 #include "../../lib/texts/Languages.h"
 
-#include "../vcmiqt/launcherdirs.h"
-
 #include <future>
 
 void CModListView::setupModModel()
@@ -891,6 +889,24 @@ void CModListView::downloadFinished(QStringList savedFiles, QStringList failedFi
 	hideProgressBar();
 }
 
+void CModListView::showExternalProgress(const QString & format, int current, int max)
+{
+	ui->progressWidget->setVisible(true);
+	ui->progressBar->setFormat(format);
+	ui->progressBar->setMaximum(max);
+	ui->progressBar->setValue(current);
+}
+
+void CModListView::hideExternalProgress()
+{
+	if(dlManager == nullptr)
+	{
+		ui->progressWidget->setVisible(false);
+		ui->progressBar->setMaximum(0);
+		ui->progressBar->setValue(0);
+	}
+}
+
 void CModListView::hideProgressBar()
 {
 	if(dlManager == nullptr) // it was not recreated meanwhile
@@ -901,10 +917,52 @@ void CModListView::hideProgressBar()
 	}
 }
 
+bool CModListView::askOverwriteDialog(const QString & windowTitle, const QString & message, int conflictCount, bool & applyToAll, bool & overwriteAll)
+{
+	if(applyToAll)
+		return overwriteAll;
+
+	QMessageBox msgBox(this);
+	msgBox.setIcon(QMessageBox::Question);
+	msgBox.setWindowTitle(windowTitle);
+	msgBox.setText(message);
+
+	QPushButton * yes = msgBox.addButton(QMessageBox::Yes);
+	msgBox.addButton(QMessageBox::No);
+
+	QPushButton * yesAll = nullptr;
+	QPushButton * noAll = nullptr;
+	if(conflictCount > 1)
+	{
+		yesAll = msgBox.addButton(tr("Yes to All"), QMessageBox::YesRole);
+		noAll = msgBox.addButton(tr("No to All"), QMessageBox::NoRole);
+	}
+
+	msgBox.exec();
+	QAbstractButton * clicked = msgBox.clickedButton();
+
+	if(clicked == yes)
+		return true;
+	if(clicked == yesAll)
+	{
+		applyToAll = true;
+		overwriteAll = true;
+		return true;
+	}
+	if(clicked == noAll)
+	{
+		applyToAll = true;
+		overwriteAll = false;
+		return false;
+	}
+	return false;
+}
+
 void CModListView::installFiles(QStringList files)
 {
 	QStringList mods;
 	QStringList maps;
+	QStringList saves;
 	QStringList images;
 	QStringList exe;
 	bool repositoryFilesEnqueued = false;
@@ -923,6 +981,7 @@ void CModListView::installFiles(QStringList files)
 
 			bool hasModJson = false;
 			bool hasMaps = false;
+			bool hasSaves = false;
 
 			for (const auto& file : fileList)
 			{
@@ -935,12 +994,17 @@ void CModListView::installFiles(QStringList files)
 				// Check for map files anywhere
 				if (lower.endsWith(".h3m") || lower.endsWith(".h3c") || lower.endsWith(".vmap") || lower.endsWith(".vcmp"))
 					hasMaps = true;
+
+				if (lower.endsWith(".vsgm1"))
+					hasSaves = true;
 			}
 
 			if (hasModJson)
 				mods.push_back(filename);
 			else if (hasMaps)
 				maps.push_back(filename);
+			else if (hasSaves)
+				saves.push_back(filename);
 			else
 				mods.push_back(filename);
 			}
@@ -952,6 +1016,8 @@ void CModListView::installFiles(QStringList files)
 		}
 		else if(realFilename.endsWith(".h3m", Qt::CaseInsensitive) || realFilename.endsWith(".h3c", Qt::CaseInsensitive) || realFilename.endsWith(".vmap", Qt::CaseInsensitive) || realFilename.endsWith(".vcmp", Qt::CaseInsensitive))
 			maps.push_back(filename);
+		else if(realFilename.endsWith(".vsgm1", Qt::CaseInsensitive))
+			saves.push_back(filename);
 		if(realFilename.endsWith(".exe", Qt::CaseInsensitive))
 			exe.push_back(filename);
 		else if(realFilename.endsWith(".json", Qt::CaseInsensitive))
@@ -1037,6 +1103,13 @@ void CModListView::installFiles(QStringList files)
 		logGlobal->info("Installing maps: ended");
 	}
 
+	if(!saves.empty())
+	{
+		logGlobal->info("Installing saves: started");
+		installSaves(saves);
+		logGlobal->info("Installing saves: ended");
+	}
+
 	if(!exe.empty())
 	{
 		logGlobal->info("Installing chronicles: started");
@@ -1077,6 +1150,115 @@ void CModListView::installFiles(QStringList files)
 
 	if(!images.empty())
 		loadScreenshots();
+}
+
+void CModListView::installSaves(QStringList saves)
+{
+	const auto savesPath = VCMIDirs::get().userSavePath();
+	boost::filesystem::create_directories(savesPath);
+
+	QDir savesDir(pathToQString(savesPath));
+	const auto saveDestDir = savesDir.absolutePath() + QChar{'/'};
+
+	int importedCount = 0;
+	int conflictCount = 0;
+
+	for(const auto & save : saves)
+	{
+		QString realSavePath = Helper::getRealPath(save);
+		if(realSavePath.endsWith(".zip", Qt::CaseInsensitive))
+		{
+			try
+			{
+				ZipArchive archive(qstringToPath(realSavePath));
+				auto fileList = archive.listFiles();
+
+				for(const auto & file : fileList)
+				{
+					QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
+					if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+						continue;
+
+					if(QFile::exists(saveDestDir + relativePath))
+						conflictCount++;
+				}
+			}
+			catch(const std::exception &)
+			{
+			}
+			continue;
+		}
+
+		QString fileName = QFileInfo(realSavePath).fileName();
+		if(fileName.isEmpty())
+			continue;
+		if(QFile::exists(saveDestDir + fileName))
+			conflictCount++;
+	}
+
+	bool applyToAll = false;
+	bool overwriteAll = false;
+
+	for(const auto & save : saves)
+	{
+		QString realSavePath = Helper::getRealPath(save);
+
+		if(realSavePath.endsWith(".zip", Qt::CaseInsensitive))
+		{
+			try
+			{
+				ZipArchive archive(qstringToPath(realSavePath));
+				auto fileList = archive.listFiles();
+
+				for(const auto & file : fileList)
+				{
+					QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
+					if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+						continue;
+
+					const QString destinationPath = saveDestDir + relativePath;
+					if(QFile::exists(destinationPath))
+					{
+						if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(relativePath), conflictCount, applyToAll, overwriteAll))
+							continue;
+
+						QFile::remove(destinationPath);
+					}
+
+					if(archive.extract(savesPath, file))
+						importedCount++;
+					else
+						QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save %1 from %2").arg(relativePath, realSavePath));
+				}
+			}
+			catch(const std::exception & e)
+			{
+				QMessageBox::warning(this, tr("Import failed"), tr("Failed to import saves from %1.\nReason: %2").arg(realSavePath, QString::fromUtf8(e.what())));
+			}
+			continue;
+		}
+
+		QString fileName = QFileInfo(realSavePath).fileName();
+		if(fileName.isEmpty())
+			continue;
+
+		const QString destinationPath = saveDestDir + fileName;
+		if(QFile::exists(destinationPath))
+		{
+			if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(fileName), conflictCount, applyToAll, overwriteAll))
+				continue;
+
+			QFile::remove(destinationPath);
+		}
+
+		if(Helper::performNativeCopy(realSavePath, destinationPath))
+			importedCount++;
+		else
+			QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save file %1").arg(realSavePath));
+	}
+
+	if(importedCount > 0)
+		QMessageBox::information(this, tr("Success"), tr("Imported %1 save files").arg(importedCount));
 }
 
 void CModListView::installMods(QStringList archives)
@@ -1189,46 +1371,6 @@ void CModListView::installMaps(QStringList maps)
 	bool applyToAll = false;
 	bool overwriteAll = false;
 
-	auto askOverwrite = [&](const QString& name) -> bool {
-		if (applyToAll)
-			return overwriteAll;
-
-		QMessageBox msgBox(this);
-		msgBox.setIcon(QMessageBox::Question);
-		msgBox.setWindowTitle(tr("Map exists"));
-		msgBox.setText(tr("Map '%1' already exists. Do you want to overwrite it?").arg(name));
-
-		QPushButton* yes = msgBox.addButton(QMessageBox::Yes);
-		msgBox.addButton(QMessageBox::No);
-
-		QPushButton* yesAll = nullptr;
-		QPushButton* noAll = nullptr;
-		if (conflictCount > 1)
-		{
-			yesAll = msgBox.addButton(tr("Yes to All"), QMessageBox::YesRole);
-			noAll = msgBox.addButton(tr("No to All"), QMessageBox::NoRole);
-		}
-
-		msgBox.exec();
-		QAbstractButton* clicked = msgBox.clickedButton();
-
-		if (clicked == yes)
-			return true;
-		if (clicked == yesAll)
-		{
-			applyToAll = true;
-			overwriteAll = true;
-			return true;
-		}
-		if (clicked == noAll)
-		{
-			applyToAll = true;
-			overwriteAll = false;
-			return false;
-		}
-		return false;
-	};
-
 	// Process each map file and archive
 	for (const QString& map : maps)
 	{
@@ -1248,7 +1390,7 @@ void CModListView::installMaps(QStringList maps)
 
 				if (QFile::exists(destFile))
 				{
-					if (!askOverwrite(name))
+					if (!askOverwriteDialog(tr("Map exists"), tr("Map '%1' already exists. Do you want to overwrite it?").arg(name), conflictCount, applyToAll, overwriteAll))
 					{
 						logGlobal->info("Skipped map '%s'", name.toStdString());
 						continue;
@@ -1276,7 +1418,7 @@ void CModListView::installMaps(QStringList maps)
 
 			if (QFile::exists(destFile))
 			{
-				if (!askOverwrite(fileName))
+				if (!askOverwriteDialog(tr("Map exists"), tr("Map '%1' already exists. Do you want to overwrite it?").arg(fileName), conflictCount, applyToAll, overwriteAll))
 				{
 					logGlobal->info("Skipped map '%s'", fileName.toStdString());
 					continue;

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -58,6 +58,8 @@ class CModListView : public QWidget
 
 	void installMods(QStringList archives);
 	void installMaps(QStringList maps);
+	void installSaves(QStringList saves);
+	bool askOverwriteDialog(const QString & windowTitle, const QString & message, int conflictCount, bool & applyToAll, bool & overwriteAll);
 
 	QString genChangelogText(const ModState & mod);
 	QString genModInfoText(const ModState & mod);
@@ -129,6 +131,9 @@ public:
 	void downloadMod(const ModState & mod);
 	void downloadFile(QString file, QUrl url, QString description, qint64 sizeBytes = 0);
 	void installFiles(QStringList mods);
+
+	void showExternalProgress(const QString & format, int current, int max);
+	void hideExternalProgress();
 
 public slots:
 	void enableModByName(QString modName);

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -243,9 +243,10 @@ void StartGameTab::on_buttonImportFiles_clicked()
 	{
 #ifndef VCMI_MOBILE
 		QString filter =
-			tr("All supported files") + " (*.h3m *.vmap *.h3c *.vcmp *.zip *.json *.exe);;" +
+			tr("All supported files") + " (*.h3m *.vmap *.h3c *.vcmp *.vsgm1 *.zip *.json *.exe);;" +
 			tr("Maps") + " (*.h3m *.vmap);;" +
 			tr("Campaigns") + " (*.h3c *.vcmp);;" +
+			tr("Saves") + " (*.vsgm1);;" +
 			tr("Configs") + " (*.json);;" +
 			tr("Mods") + " (*.zip);;" +
 			tr("Gog files") + " (*.exe)";
@@ -253,9 +254,52 @@ void StartGameTab::on_buttonImportFiles_clicked()
 		//Workaround for sometimes incorrect mime for some extensions (e.g. for exe)
 		QString filter = tr("All files (*.*)");
 #endif
-		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
+		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, saves, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
+		if(files.isEmpty())
+			return;
 
-		for(const auto & file : files)
+		QStringList preparedFiles;
+		preparedFiles.reserve(files.size());
+
+		QDir importCacheDir(pathToQString(VCMIDirs::get().userDataPath()));
+		importCacheDir.mkpath("tmp/import-cache");
+		importCacheDir.cd("tmp/import-cache");
+
+		auto * modView = Helper::getMainWindow()->getModView();
+		modView->showExternalProgress(tr("Preparing selected files for import..."), 0, files.size());
+
+		for(int index = 0; index < files.size(); ++index)
+		{
+			const QString file = files[index];
+			modView->showExternalProgress(tr("Preparing selected files for import... %1/%2").arg(index + 1).arg(files.size()), index, files.size());
+			qApp->processEvents();
+
+			QString importPath = file;
+
+			// Some exotic systems allows read after copy
+			QFile sourceFile(file);
+			if(!sourceFile.open(QIODevice::ReadOnly))
+			{
+				QString baseName = QFileInfo(Helper::getRealPath(file)).fileName();
+				if(baseName.isEmpty())
+					baseName = QStringLiteral("import_%1.bin").arg(index + 1);
+
+				const QString stagedPath = importCacheDir.filePath(QString::number(QDateTime::currentMSecsSinceEpoch()) + "_" + baseName);
+				if(!Helper::performNativeCopy(file, stagedPath))
+				{
+					QMessageBox::warning(this, tr("Import failed"), tr("Failed to prepare file for import: %1").arg(Helper::getRealPath(file)));
+					continue;
+				}
+				importPath = stagedPath;
+			}
+
+			preparedFiles << importPath;
+		}
+
+		modView->showExternalProgress(tr("Preparing selected files for import..."), files.size(), files.size());
+		modView->hideExternalProgress();
+
+		for(const auto & file : preparedFiles)
 		{
 			logGlobal->info("Importing file %s", file.toStdString());
 			Helper::getMainWindow()->manualInstallFile(file);
@@ -303,6 +347,8 @@ void StartGameTab::on_buttonHelpImportFiles_clicked()
 		" - Heroes III Campaigns (.h3c or .vcmp).\n"
 		" - Heroes III Chronicles using offline backup installer from GOG.com (.exe).\n"
 		" - VCMI mods in zip format (.zip)\n"
+		" - VCMI saves archive in zip format (.zip)\n"
+		" - VCMI save files (.vsgm1)\n"
 		" - VCMI configuration files (.json)\n"
 	);
 

--- a/lib/filesystem/CZipSaver.cpp
+++ b/lib/filesystem/CZipSaver.cpp
@@ -52,7 +52,7 @@ CZipOutputStream::CZipOutputStream(CZipSaver * owner_, zipFile archive, const st
 						nullptr,//password
 						0,//crcForCrypting
 						20,//versionMadeBy
-						0,//flagBase
+						(1 << 11),//flagBase - UTF-8 file names
 						0//zip64
 						);
 


### PR DESCRIPTION
### Motivation
- Provide users with the ability to export/import VCMI save files and archives (.vsgm1/.zip) from the launcher.
- Improve the import flow to handle cases where files are not directly readable (stage/copy before import) and surface progress to the UI.
- Unify mobile platform handling for log export and clean up a redundant include.

### Description
- Added an "Export saves" button to the About dialog UI and implemented `on_pushButtonExportSaves_clicked()` to collect user saves and write them into a zip archive using `CZipSaver` with a cancellable `QProgressDialog` and error handling.
- Added `.vsgm1` support across the launcher: drag-and-drop acceptance, file dialog filters, and help text updates to allow direct save files and save archives to be imported.
- Introduced `installSaves()` which extracts or copies saves into the user save directory with conflict detection and an overwrite dialog delegated to the new reusable `askOverwriteDialog()` helper; integrated `installSaves()` into `installFiles()` handling.
- Added progress UI helpers `showExternalProgress()` / `hideExternalProgress()` on `CModListView` and used them from `StartGameTab::on_buttonImportFiles_clicked()` to show staging progress while preparing files; the import flow now stages unreadable files into `tmp/import-cache` before invoking `manualInstallFile()`.
- Replaced platform-specific checks `VCMI_ANDROID || VCMI_IOS` with `VCMI_MOBILE` for log export behavior and removed a redundant include.

### Testing
- Built the project with `cmake`/`make` (desktop debug) and the build completed successfully.
- Ran the existing test suite via `ctest` and the current tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4513a8c54832da3ee5f089dcfeef6)