### PR TITLE
Use Linux Conan prebuilts for PortMaster ARM64 pipeline

### DIFF
--- a/.github/workflows/portmaster.yml
+++ b/.github/workflows/portmaster.yml
@@ -1,0 +1,59 @@
+name: Build Portmaster
+
+on:
+  push:
+    branches:
+      - beta
+      - master
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": { "containerd-snapshotter": true }
+            }
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          file: docker/BuildPortmaster-aarch64.dockerfile
+          context: .
+          tags: vcmi-portmaster-build:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build VCMI
+        shell: bash
+        run: docker run --rm -v "$PWD":/vcmi vcmi-portmaster-build
+
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p vcmi-portmaster/libs
+          sudo mv ./out/build/portmaster-conan-release/bin/*so* vcmi-portmaster/libs/ || true
+          mkdir -p vcmi-portmaster/libs/AI
+          sudo mv ./out/build/portmaster-conan-release/bin/AI/*so* vcmi-portmaster/libs/AI/ || true
+          mkdir -p vcmi-portmaster/bin
+          sudo mv ./out/build/portmaster-conan-release/bin/vcmi* vcmi-portmaster/bin/ || true
+          cp -r ./Mods vcmi-portmaster/Mods
+          cp -r ./config vcmi-portmaster/config
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: vcmi-portmaster
+          path: vcmi-portmaster

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -404,6 +404,15 @@
                 "ENABLE_GOLDMASTER": "ON",
                 "VCMI_PORTMASTER": "ON"
             }
+        },
+        {
+            "name": "portmaster-conan-release",
+            "displayName": "PortMaster + Conan",
+            "description": "VCMI PortMaster using Conan dependencies",
+            "inherits": [
+                "portmaster-release",
+                "build-with-conan"
+            ]
         }
     ],
     "buildPresets": [
@@ -565,6 +574,12 @@
         {
             "name": "portmaster-release",
             "configurePreset": "portmaster-release",
+            "inherits": "default-release",
+            "configuration": "Release"
+        },
+        {
+            "name": "portmaster-conan-release",
+            "configurePreset": "portmaster-conan-release",
             "inherits": "default-release",
             "configuration": "Release"
         }

--- a/docker/BuildPortmaster-aarch64.dockerfile
+++ b/docker/BuildPortmaster-aarch64.dockerfile
@@ -3,24 +3,48 @@ WORKDIR /usr/local/app
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# from VCMI build docs
-RUN apt-get update && apt-get install -y cmake g++ clang libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev zlib1g-dev libavformat-dev libswscale-dev libboost-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-locale-dev libboost-iostreams-dev qtbase5-dev libtbb-dev libluajit-5.1-dev liblzma-dev libsqlite3-dev libminizip-dev qttools5-dev ninja-build ccache
+# Runtime build dependencies for PortMaster + Conan toolchain restore
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential wget ca-certificates git curl \
+    python3 python3-pipx \
+    libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev \
+    qtbase5-dev qttools5-dev libqt5svg5-dev \
+    ninja-build libavformat-dev libswscale-dev \
+    libluajit-5.1-dev libminizip-dev libsqlite3-dev \
+    libicu-dev zlib1g-dev libbz2-dev liblzma-dev \
+ && rm -rf /var/lib/apt/lists/*
 
-# newer cmake version to support presets
-RUN apt-get remove -y cmake
-RUN apt-get install -y libssl-dev
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.31.5/cmake-3.31.5.tar.gz ; tar zxvf cmake-3.31.5.tar.gz ; cd cmake-3.31.5 ; ./bootstrap ; make ; make install ; cd .. ; rm -rf cmake-3.31.5
+# CMake >= 3.31 (presets support)
+ARG CMAKE_VER=3.31.5
+RUN set -eux; \
+  wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-aarch64.tar.gz; \
+  tar -xzf cmake-${CMAKE_VER}-linux-aarch64.tar.gz -C /opt; \
+  ln -s /opt/cmake-${CMAKE_VER}-linux-aarch64/bin/* /usr/local/bin/; \
+  rm -f cmake-${CMAKE_VER}-linux-aarch64.tar.gz; \
+  cmake --version
+
+RUN pipx install conan
 
 CMD ["sh", "-c", " \
-    # switch to mounted dir
-    cd /vcmi ; \
-    # fix for wrong path of base image
-    ln -s /usr/lib/libSDL2.so /usr/lib/aarch64-linux-gnu/libSDL2.so ; \
-    # build
-    cmake --preset portmaster-release ; \
-    cmake --build --preset portmaster-release ; \
-    # export missing libraries
-    ldd /vcmi/out/build/portmaster-release/bin/vcmiclient | grep -e libboost -e libtbb -e libicu | awk 'NF == 4 { system(\"cp \" $3 \" /vcmi/out/build/portmaster-release/bin/\") }' \
+    set -euo pipefail; \
+    cd /vcmi; \
+    # fix for wrong path of base image \
+    ln -sf /usr/lib/libSDL2.so /usr/lib/aarch64-linux-gnu/libSDL2.so; \
+    export PATH=/root/.local/bin:${PATH}; \
+    export RUNNER_TEMP=/tmp; \
+    # restore linux ARM64 prebuilt Conan dependencies and generate toolchain \
+    source /vcmi/CI/install_conan_dependencies.sh dependencies-linux-arm64; \
+    conan profile detect --force; \
+    conan install . \
+      --output-folder=conan-generated \
+      --build=never \
+      --profile=dependencies/conan_profiles/linux-arm64 \
+      --conf=tools.cmake.cmaketoolchain:generator=Ninja; \
+    # build \
+    cmake --preset portmaster-conan-release; \
+    cmake --build --preset portmaster-conan-release; \
+    # export missing shared libraries \
+    ldd /vcmi/out/build/portmaster-conan-release/bin/vcmiclient | grep -e libboost -e libtbb -e libicu | awk 'NF == 4 { system(\"cp \" $3 \" /vcmi/out/build/portmaster-conan-release/bin/\") }' \
 "]
 
 # Build on ARM64 processor or ARM64 chroot with:


### PR DESCRIPTION
### Motivation
- Align PortMaster ARM64 builds with existing Linux AppImage flow by using Conan prebuilt dependencies instead of building Boost/TBB from source.
- Reduce CI build time and maintenance by restoring published `dependencies-linux-arm64` and using the Conan-generated toolchain.

### Description
- Add a new CMake configure/build preset `portmaster-conan-release` in `CMakePresets.json` that inherits `portmaster-release` and `build-with-conan` so the Conan toolchain is applied to PortMaster builds.
- Replace bespoke dependency compilation in `docker/BuildPortmaster-aarch64.dockerfile` with runtime steps to install `conan` (`pipx install conan`), restore prebuilt archive via `CI/install_conan_dependencies.sh`, run `conan install` with the `dependencies/conan_profiles/linux-arm64` profile, and build using `cmake --preset portmaster-conan-release`.
- Update the Dockerfile to install only the runtime build dependencies and CMake (prebuilt aarch64 binary), and to copy out missing shared libraries from the `portmaster-conan-release` build output.
- Add a dedicated GitHub Actions workflow `.github/workflows/portmaster.yml` that builds the updated Docker image on `ubuntu-24.04-arm`, runs the container to build PortMaster, packages the artifacts from `out/build/portmaster-conan-release`, and uploads them as an artifact.

### Testing
- Validated JSON syntax of `CMakePresets.json` with `python -m json.tool CMakePresets.json` which returned success.
- Ran repository checks with `git diff --check` which reported no whitespace or trivial errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5aa65de18832d9c004498e261c591)