### PR TITLE
Add --translate CLI option and CI validation for translation export

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -651,6 +651,18 @@ jobs:
             exit 1
         fi
 
+    - name: Validate translation export CLI
+      run: |
+        cd "${{github.workspace}}/out/build/${{matrix.preset}}/bin"
+        ./vcmiclient --translate missing > >(tee output.log) 2> >(tee error.log >&2)
+        if [ ! -s error.log ] && [ -d "$HOME/.local/share/vcmi/Extracted/translationMissing" ]; then
+            echo "Translation export validation OK!"
+            exit 0
+        else
+            echo "Translation export validation failed!"
+            exit 1
+        fi
+
   lobby:
     name: Test VCMI Lobby
     runs-on: ubuntu-latest

--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -141,6 +141,7 @@ int main(int argc, char * argv[])
 	opts.add_options()
 		("help,h", "display help and exit")
 		("version,v", "display version information and exit")
+		("translate", po::value<std::string>(), "exports translation files and exits: game|missing|maps|all")
 		("testmap", po::value<std::string>(), "")
 		("testsave", po::value<std::string>(), "")
 		("logLocation", po::value<std::string>(), "new location for log files")
@@ -253,7 +254,7 @@ int main(int argc, char * argv[])
 
 	setSettingBool("session/onlyai", "onlyAI");
 	setSettingBool("session/disableVideo", "disable-video");
-	if(vm.count("headless"))
+	if(vm.count("headless") || vm.count("translate"))
 	{
 		session["headless"].Bool() = true;
 		session["onlyai"].Bool() = true;
@@ -361,6 +362,30 @@ int main(int argc, char * argv[])
 		session["testsave"].String() = vm["testsave"].as<std::string>();
 		session["onlyai"].Bool() = true;
 		GAME->server().debugStartTest(session["testsave"].String(), true);
+	}
+	else if(vm.count("translate"))
+	{
+		ClientCommandManager commandController;
+		const auto mode = boost::to_lower_copy(vm["translate"].as<std::string>());
+
+		if(mode == "game")
+			commandController.processCommand("translate game", false);
+		else if(mode == "missing")
+			commandController.processCommand("translate missing", false);
+		else if(mode == "maps")
+			commandController.processCommand("translate maps", false);
+		else if(mode == "all")
+		{
+			commandController.processCommand("translate game", false);
+			commandController.processCommand("translate maps", false);
+		}
+		else
+		{
+			logGlobal->error("Invalid --translate mode '%s'. Supported values: game, missing, maps, all", mode);
+			return 1;
+		}
+
+		headlessQuit = true;
 	}
 	else if (!settings["session"]["headless"].Bool())
 	{


### PR DESCRIPTION
### Motivation
- Provide a headless way to export translation files from the client application for automation and CI usage.
- Ensure the translation export functionality is validated as part of the GitHub Actions build pipeline.
- Make it possible to script translation exports (game/missing/maps/all) without launching the GUI.

### Description
- Added a new command-line option `--translate` to `clientapp/EntryPoint.cpp` with supported modes `game|missing|maps|all`.
- Treat `--translate` as a headless run so the client does not initialize the GUI by setting the same headless flags as `--headless` and triggering `headlessQuit` after processing the command.
- Implemented translation export handling by instantiating `ClientCommandManager` and invoking `processCommand` for the requested mode; added error logging and non-zero exit on invalid mode.
- Added a new GitHub Actions step `Validate translation export CLI` to `.github/workflows/github.yml` that runs `./vcmiclient --translate missing`, captures output and errors, and verifies the expected extracted translation folder exists.

### Testing
- No automated tests were executed locally with this PR; CI workflow was updated to run the normal build (`cmake --build`) and tests (`ctest`) along with the new `Validate translation export CLI` step which checks exit status and the presence of `$HOME/.local/share/vcmi/Extracted/translationMissing`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7315a10c832daa14cda3f45daffc)