### PR TITLE
Refactor RandomMapTab map size handling to use RANDOM_SIZE and add bounds check

### DIFF
--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -205,9 +205,6 @@ RandomMapTab::RandomMapTab():
 
 void RandomMapTab::onToggleMapSize(int btnId)
 {
-	if(btnId == -1)
-		return;
-
 	auto mapSizeVal = getStandardMapSizes();
 
 	auto setTemplateForSize = [this](){
@@ -217,7 +214,7 @@ void RandomMapTab::onToggleMapSize(int btnId)
 		updateMapInfoByHost();
 	};
 
-	if(btnId == mapSizeVal.size() - 1)
+	auto openCustomSizeWindow = [this, setTemplateForSize]()
 	{
 		ENGINE->windows().createAndPushWindow<SetSizeWindow>(int3(mapGenOptions->getWidth(), mapGenOptions->getHeight(), mapGenOptions->getLevels()), mapGenOptions->getMapTemplate(), [this, setTemplateForSize](int3 ret){
 			if(ret.z > 2)
@@ -230,8 +227,16 @@ void RandomMapTab::onToggleMapSize(int btnId)
 			mapGenOptions->setLevels(ret.z);
 			setTemplateForSize();
 		});
+	};
+
+	if(btnId == CMapGenOptions::RANDOM_SIZE)
+	{
+		openCustomSizeWindow();
 		return;
 	}
+
+	if(btnId < 0 || btnId >= mapSizeVal.size())
+		return;
 
 	mapGenOptions->setWidth(mapSizeVal[btnId]);
 	mapGenOptions->setHeight(mapSizeVal[btnId]);


### PR DESCRIPTION
### Motivation
- Replace a magic index and fragile `-1` early-return in `RandomMapTab::onToggleMapSize` with an explicit `CMapGenOptions::RANDOM_SIZE` branch and improve input validation to make opening the custom size window and size handling more robust and clearer. 

### Description
- Introduced an `openCustomSizeWindow` lambda that captures `setTemplateForSize` and opens `SetSizeWindow`, replaced the `mapSizeVal.size() - 1` special-case with a check against `CMapGenOptions::RANDOM_SIZE`, removed the old `if(btnId == -1)` check, and added a bounds check `if(btnId < 0 || btnId >= mapSizeVal.size())` before using `btnId`. 

### Testing
- Project was built and the existing automated test suite was executed (`make` / `ctest`) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbe849ab0c832da54a3d2b7f51f073)