### PR TITLE
xcode: bypass ccache for Objective-C compilation

### DIFF
--- a/xcode/launch-c.in
+++ b/xcode/launch-c.in
@@ -1,3 +1,10 @@
 #!/bin/sh
+
+for arg in "$@"; do
+	if [ "$arg" = "objective-c" ] || [ "$arg" = "objective-c++" ]; then
+		exec clang "$@"
+	fi
+done
+
 export CCACHE_CPP2=true
-ccache clang "$@"
+exec ccache clang "$@"


### PR DESCRIPTION
### Motivation
- iOS builds were failing while compiling Objective-C/Objective-C++ sources (e.g. `ios/iOS_utils.mm`) with Apple framework parse errors (unknown `NSUInteger`/`NSInteger` and missing `CoreVideo/CVDisplayLink.h`) when invoked through the `ccache` wrapper, so Objective-C invocations should bypass `ccache` to avoid the issue.

### Description
- Modify `xcode/launch-c.in` to detect `-x objective-c` and `-x objective-c++` arguments and `exec clang "$@"` directly for those cases, while preserving `ccache` for regular C/C++ compilations with `export CCACHE_CPP2=true` and `exec ccache clang "$@"`.

### Testing
- Validated the wrapper script syntax with `bash -n xcode/launch-c.in`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc6bfa94cc832d9491511b2aa7dbde)