### PR TITLE
Refactor launcher import/export flows to reduce cognitive complexity

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -241,6 +241,123 @@ static bool exportSavesToLocalArchive(AboutProjectView * view, const QString & o
 	return true;
 }
 
+static QString chooseLogArchivePath(AboutProjectView * view)
+{
+#if defined(VCMI_MOBILE)
+	QDir tempDir(QDir::tempPath());
+	const QFileInfoList oldArchives = tempDir.entryInfoList(QStringList() << "vcmi-logs-*.zip", QDir::Files, QDir::Name);
+	for(const QFileInfo & file : oldArchives)
+		QFile::remove(file.absoluteFilePath());
+
+	return tempDir.filePath(QString("vcmi-logs-%1.zip").arg(QString::number(QDateTime::currentMSecsSinceEpoch())));
+#else
+	const QString defaultName = QDir::home().filePath("vcmi-logs.zip");
+	QString outPath = QFileDialog::getSaveFileName(view, view->tr("Save logs"), defaultName, view->tr("Zip archives (*.zip)"));
+	if(outPath.isEmpty())
+		return {};
+	if(!outPath.endsWith(".zip", Qt::CaseInsensitive))
+		outPath += ".zip";
+	return outPath;
+#endif
+}
+
+static QString buildDataDirListing(const QString & dataDirPath)
+{
+	QString listing;
+	QDir dataDir(dataDirPath);
+	QDirIterator it(dataDirPath, QDir::NoDotAndDotDot | QDir::AllEntries, QDirIterator::Subdirectories);
+	QTextStream ts(&listing);
+	while(it.hasNext())
+	{
+		const QString path = it.next();
+		const QString rel = dataDir.relativeFilePath(path);
+		const QFileInfo info(path);
+
+		if(rel.startsWith(QLatin1String("Saves/")))
+			continue;
+
+		if(info.isDir())
+			ts << QChar('D') << QLatin1Char(' ') << rel << '\n';
+		else
+			ts << QChar('F') << QLatin1Char(' ') << rel << QLatin1String(" (") << info.size() << QLatin1String(")") << '\n';
+	}
+	return listing;
+}
+
+static bool advanceProgress(QProgressDialog & progress, int & value, const QString & outPath)
+{
+	++value;
+	progress.setValue(value);
+	qApp->processEvents();
+	if(progress.wasCanceled())
+	{
+		QFile::remove(outPath);
+		return false;
+	}
+	return true;
+}
+
+#if defined(VCMI_MOBILE)
+static void saveLogArchiveToDestination(AboutProjectView * view, const QString & sourcePath, const QString & targetPath)
+{
+	if(targetPath.isEmpty())
+		return;
+
+	if(Helper::performNativeCopy(sourcePath, targetPath))
+		QMessageBox::information(view, view->tr("Success"), view->tr("Logs saved to %1").arg(Helper::getRealPath(targetPath)));
+	else
+	{
+		logGlobal->error("Log export failed: could not copy archive from %s to %s", sourcePath.toStdString(), targetPath.toStdString());
+		QMessageBox::critical(view, view->tr("Error"), view->tr("Failed to save archive to selected destination"));
+	}
+}
+
+static void handleMobileLogArchiveDestination(AboutProjectView * view, const QString & outPath)
+{
+	QMessageBox destinationChoice(view);
+	destinationChoice.setIcon(QMessageBox::Question);
+	destinationChoice.setWindowTitle(view->tr("Export logs"));
+	destinationChoice.setText(view->tr("Choose what to do with the exported logs archive."));
+	QPushButton * shareButton = destinationChoice.addButton(view->tr("Share"), QMessageBox::AcceptRole);
+	QPushButton * saveButton = destinationChoice.addButton(view->tr("Save"), QMessageBox::ActionRole);
+	destinationChoice.addButton(QMessageBox::Cancel);
+	destinationChoice.exec();
+
+	if(destinationChoice.clickedButton() == shareButton)
+	{
+		QMessageBox::information(view, view->tr("Send logs"), view->tr("The archive will be sent via another application. Share your logs e.g. over discord to developers."));
+		Helper::sendFileToApp(outPath);
+		return;
+	}
+
+	if(destinationChoice.clickedButton() != saveButton)
+		return;
+
+	if(Helper::canUseFolderPicker())
+	{
+		Helper::nativeFolderPicker(view, [view, outPath](QString picked)
+		{
+			if(picked.isEmpty())
+				return;
+
+			const QString destination = Helper::createFile(picked, QStringLiteral("vcmi-logs.zip"), QStringLiteral("application/zip"));
+			saveLogArchiveToDestination(view, outPath, destination);
+		});
+		return;
+	}
+
+	logGlobal->warn("Log export: folder picker unavailable, using manual file selection fallback");
+	QMessageBox::information(view, view->tr("Select destination file"), view->tr("Please select destination file and save the archive as vcmi-logs.zip."));
+	const QString defaultName = QDir::home().filePath("vcmi-logs.zip");
+	QString pickedPath = QFileDialog::getSaveFileName(view, view->tr("Select destination file"), defaultName, view->tr("Zip archives (*.zip);;All files (*.*)"));
+	if(pickedPath.isEmpty())
+		return;
+	if(!pickedPath.endsWith(".zip", Qt::CaseInsensitive))
+		pickedPath += ".zip";
+	saveLogArchiveToDestination(view, outPath, pickedPath);
+}
+#endif
+
 void AboutProjectView::on_pushButtonExportSaves_clicked()
 {
 	auto ensureZipSuffix = [](QString path)
@@ -308,70 +425,19 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 void AboutProjectView::on_pushButtonExportLogs_clicked()
 {
 	QDir tempDir(ui->lineEditTempDir->text());
-
-#if defined(VCMI_MOBILE)
-    // cleanup old temp archives from previous runs (delete now)
-    {
-        QDir tdir(QDir::tempPath());
-        const QFileInfoList old = tdir.entryInfoList(QStringList() << "vcmi-logs-*.zip", QDir::Files, QDir::Name);
-        for(const QFileInfo & file : old)
-            QFile::remove(file.absoluteFilePath());
-    }
-	// On mobile: write archive to system temp and send via platform share (no save dialog)
-	const QString tmpDir = QDir::tempPath();
-	const QString outPath = QDir(tmpDir).filePath(QString("vcmi-logs-%1.zip").arg(QString::number(QDateTime::currentMSecsSinceEpoch())));
-#else
-	const QString defaultName = QDir::home().filePath("vcmi-logs.zip");
-	QString outPath = QFileDialog::getSaveFileName(this, tr("Save logs"), defaultName, tr("Zip archives (*.zip)"));
+	const QString outPath = chooseLogArchivePath(this);
 	if(outPath.isEmpty())
 		return;
 
-	if(!outPath.endsWith(".zip", Qt::CaseInsensitive))
-		outPath += ".zip";
-#endif
-
 	QFileInfoList files = tempDir.entryInfoList({ "*.txt" }, QDir::Files, QDir::Name);
 	files.append(QDir(ui->lineEditConfigDir->text()).entryInfoList({ "*.json", "*.ini" }, QDir::Files, QDir::Name));
-
-	// build data dir file/folder listing and add as a virtual text file
-	const QString dataDirPath = ui->lineEditUserDataDir->text();
-	QString listing;
-	QDir dataDir(dataDirPath);
-	QDirIterator it(dataDirPath, QDir::NoDotAndDotDot | QDir::AllEntries, QDirIterator::Subdirectories);
-	QTextStream ts(&listing);
-	while(it.hasNext())
-	{
-		const QString path = it.next();
-		const QString rel = dataDir.relativeFilePath(path);
-		QFileInfo info(path);
-
-		if(rel.startsWith(QLatin1String("Saves/")))
-			continue;
-
-		if(info.isDir())
-			ts << QChar('D') << QLatin1Char(' ') << rel << '\n';
-		else
-			ts << QChar('F') << QLatin1Char(' ') << rel << QLatin1String(" (") << info.size() << QLatin1String(")") << '\n';
-	}
+	const QString listing = buildDataDirListing(ui->lineEditUserDataDir->text());
 
 	const int progressMaximum = files.size() + 3;
 	QProgressDialog progress(tr("Exporting logs..."), tr("Cancel"), 0, progressMaximum, this);
 	setupExportProgressDialog(progress, tr("Log export"), tr("Exporting logs..."), progressMaximum);
 
 	int progressValue = 0;
-	auto advanceProgress = [&]()
-	{
-		++progressValue;
-		progress.setValue(progressValue);
-		qApp->processEvents();
-		if(progress.wasCanceled())
-		{
-			QFile::remove(outPath);
-			return false;
-		}
-		return true;
-	};
-
 	try
 	{
 		// create zip and add .txt files
@@ -384,7 +450,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 			// Skip persistent storage to avoid logging private data (e.g. lobby login tokens)
 			if(file.fileName().compare(QStringLiteral("persistentStorage.json"), Qt::CaseInsensitive) == 0)
 			{
-				if(!advanceProgress())
+				if(!advanceProgress(progress, progressValue, outPath))
 					return;
 				continue;
 			}
@@ -397,7 +463,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 				stream->write(reinterpret_cast<const ui8 *>(data.constData()), data.size());
 			}
 
-			if(!advanceProgress())
+			if(!advanceProgress(progress, progressValue, outPath))
 				return;
 		}
 
@@ -427,7 +493,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 				}
 			}
 		}
-		if(!advanceProgress())
+		if(!advanceProgress(progress, progressValue, outPath))
 			return;
 
 		// add generated listing as game-directory-structure.txt
@@ -437,7 +503,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 			auto stream = saver.addFile(std::string("data-directory-structure.txt"));
 			stream->write(reinterpret_cast<const ui8 *>(data.constData()), data.size());
 		}
-		if(!advanceProgress())
+		if(!advanceProgress(progress, progressValue, outPath))
 			return;
 
 		// add device information as device-info.txt
@@ -450,7 +516,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 				streamDev->write(reinterpret_cast<const ui8 *>(dataDev.constData()), dataDev.size());
 			}
 		}
-		if(!advanceProgress())
+		if(!advanceProgress(progress, progressValue, outPath))
 			return;
 
 		progress.hide();
@@ -465,61 +531,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 
 	// On mobile platforms, let user choose between share and saving to selected destination.
 #if defined(VCMI_MOBILE)
-	QMessageBox destinationChoice(this);
-	destinationChoice.setIcon(QMessageBox::Question);
-	destinationChoice.setWindowTitle(tr("Export logs"));
-	destinationChoice.setText(tr("Choose what to do with the exported logs archive."));
-	QPushButton * shareButton = destinationChoice.addButton(tr("Share"), QMessageBox::AcceptRole);
-	QPushButton * saveButton = destinationChoice.addButton(tr("Save"), QMessageBox::ActionRole);
-	destinationChoice.addButton(QMessageBox::Cancel);
-	destinationChoice.exec();
-
-	if(destinationChoice.clickedButton() == shareButton)
-	{
-		QMessageBox::information(this, tr("Send logs"), tr("The archive will be sent via another application. Share your logs e.g. over discord to developers."));
-		Helper::sendFileToApp(outPath);
-	}
-	else if(destinationChoice.clickedButton() == saveButton)
-	{
-		auto saveArchiveTo = [this, outPath](const QString & targetPath)
-		{
-			if(targetPath.isEmpty())
-				return;
-
-			if(Helper::performNativeCopy(outPath, targetPath))
-				QMessageBox::information(this, tr("Success"), tr("Logs saved to %1").arg(Helper::getRealPath(targetPath)));
-			else
-			{
-				logGlobal->error("Log export failed: could not copy archive from %s to %s", outPath.toStdString(), targetPath.toStdString());
-				QMessageBox::critical(this, tr("Error"), tr("Failed to save archive to selected destination"));
-			}
-		};
-
-		if(Helper::canUseFolderPicker())
-		{
-			Helper::nativeFolderPicker(this, [saveArchiveTo](QString picked)
-			{
-				if(picked.isEmpty())
-					return;
-
-				const QString destination = Helper::createFile(picked, QStringLiteral("vcmi-logs.zip"), QStringLiteral("application/zip"));
-				saveArchiveTo(destination);
-			});
-		}
-		else
-		{
-			logGlobal->warn("Log export: folder picker unavailable, using manual file selection fallback");
-			QMessageBox::information(this, tr("Select destination file"), tr("Please select destination file and save the archive as vcmi-logs.zip."));
-			const QString defaultName = QDir::home().filePath("vcmi-logs.zip");
-			QString pickedPath = QFileDialog::getSaveFileName(this, tr("Select destination file"), defaultName, tr("Zip archives (*.zip);;All files (*.*)"));
-			if(!pickedPath.isEmpty())
-			{
-				if(!pickedPath.endsWith(".zip", Qt::CaseInsensitive))
-					pickedPath += ".zip";
-				saveArchiveTo(pickedPath);
-			}
-		}
-	}
+	handleMobileLogArchiveDestination(this, outPath);
 #else
 	// desktop: notify user and do not auto-send
 	QMessageBox::information(this, tr("Success"), tr("Logs saved to %1, please send them to the developers").arg(Helper::getRealPath(outPath)));

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1197,25 +1197,20 @@ void CModListView::installFiles(QStringList files)
 		loadScreenshots();
 }
 
-void CModListView::installSaves(QStringList saves)
+namespace
 {
-	const auto savesPath = VCMIDirs::get().userSavePath();
-	boost::filesystem::create_directories(savesPath);
+QString resolveSaveFileName(const QString & originalPath, const QString & realPath)
+{
+	QString fileName = QFileInfo(realPath).fileName();
+	if(fileName.isEmpty())
+		fileName = QFileInfo(originalPath).fileName();
+	if(fileName.isEmpty())
+		fileName = QUrl(originalPath).fileName();
+	return fileName;
+}
 
-	QDir savesDir(pathToQString(savesPath));
-	const auto saveDestDir = savesDir.absolutePath() + QChar{'/'};
-
-	auto resolveSaveFileName = [](const QString & originalPath, const QString & realPath)
-	{
-		QString fileName = QFileInfo(realPath).fileName();
-		if(fileName.isEmpty())
-			fileName = QFileInfo(originalPath).fileName();
-		if(fileName.isEmpty())
-			fileName = QUrl(originalPath).fileName();
-		return fileName;
-	};
-
-	int importedCount = 0;
+int countSaveConflicts(const QStringList & saves, const QString & saveDestDir)
+{
 	int conflictCount = 0;
 
 	for(const auto & save : saves)
@@ -1251,8 +1246,83 @@ void CModListView::installSaves(QStringList saves)
 			conflictCount++;
 	}
 
+	return conflictCount;
+}
+
+bool shouldOverwriteSave(const std::function<bool(const QString &)> & askOverwrite, const QString & destinationPath, const QString & entryName)
+{
+	if(!QFile::exists(destinationPath))
+		return true;
+
+	if(!askOverwrite(entryName))
+		return false;
+
+	QFile::remove(destinationPath);
+	return true;
+}
+
+void importSaveFromArchive(CModListView * view, ZipArchive & archive, const QString & realSavePath, const boost::filesystem::path & savesPath, const QString & saveDestDir, const std::function<bool(const QString &)> & askOverwrite, int & importedCount)
+{
+	const auto fileList = archive.listFiles();
+	for(const auto & file : fileList)
+	{
+		QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
+		if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
+			continue;
+
+		const QString destinationPath = saveDestDir + relativePath;
+		if(!shouldOverwriteSave(askOverwrite, destinationPath, relativePath))
+			continue;
+
+		if(archive.extract(savesPath, file))
+			importedCount++;
+		else
+		{
+			logGlobal->warn("Failed to import save %s from archive %s", relativePath.toStdString(), realSavePath.toStdString());
+			QMessageBox::warning(view, QObject::tr("Import failed"), QObject::tr("Failed to import save %1 from %2").arg(relativePath, realSavePath));
+		}
+	}
+}
+
+void importSingleSaveFile(CModListView * view, const QString & sourcePath, const QString & fileName, const QString & saveDestDir, const std::function<bool(const QString &)> & askOverwrite, int & importedCount)
+{
+	const QString destinationPath = saveDestDir + fileName;
+	if(!shouldOverwriteSave(askOverwrite, destinationPath, fileName))
+		return;
+
+	if(Helper::performNativeCopy(sourcePath, destinationPath))
+	{
+		importedCount++;
+		return;
+	}
+
+	logGlobal->warn("Failed to import save file %s to %s", sourcePath.toStdString(), destinationPath.toStdString());
+	QMessageBox::warning(view, QObject::tr("Import failed"), QObject::tr("Failed to import save file %1").arg(sourcePath));
+}
+}
+
+void CModListView::installSaves(QStringList saves)
+{
+	const auto savesPath = VCMIDirs::get().userSavePath();
+	boost::filesystem::create_directories(savesPath);
+
+	QDir savesDir(pathToQString(savesPath));
+	const auto saveDestDir = savesDir.absolutePath() + QChar{'/'};
+
+	int importedCount = 0;
+	int conflictCount = countSaveConflicts(saves, saveDestDir);
+
 	bool applyToAll = false;
 	bool overwriteAll = false;
+	const auto askOverwrite = [this, conflictCount, &applyToAll, &overwriteAll](const QString & entryName)
+	{
+		return askOverwriteDialog(
+			tr("Save exists"),
+			tr("Save '%1' already exists. Do you want to overwrite it?").arg(entryName),
+			conflictCount,
+			applyToAll,
+			overwriteAll);
+	};
 
 	for(const auto & save : saves)
 	{
@@ -1263,31 +1333,7 @@ void CModListView::installSaves(QStringList saves)
 			try
 			{
 				ZipArchive archive(qstringToPath(realSavePath));
-				auto fileList = archive.listFiles();
-
-				for(const auto & file : fileList)
-				{
-					QString relativePath = QString::fromUtf8(file.data(), static_cast<int>(file.size()));
-					if(!relativePath.endsWith(".vsgm1", Qt::CaseInsensitive))
-						continue;
-
-					const QString destinationPath = saveDestDir + relativePath;
-					if(QFile::exists(destinationPath))
-					{
-						if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(relativePath), conflictCount, applyToAll, overwriteAll))
-							continue;
-
-						QFile::remove(destinationPath);
-					}
-
-					if(archive.extract(savesPath, file))
-						importedCount++;
-					else
-					{
-						logGlobal->warn("Failed to import save %s from archive %s", relativePath.toStdString(), realSavePath.toStdString());
-						QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save %1 from %2").arg(relativePath, realSavePath));
-					}
-				}
+				importSaveFromArchive(this, archive, realSavePath, savesPath, saveDestDir, askOverwrite, importedCount);
 			}
 			catch(const std::exception & e)
 			{
@@ -1301,22 +1347,7 @@ void CModListView::installSaves(QStringList saves)
 		if(fileName.isEmpty())
 			continue;
 
-		const QString destinationPath = saveDestDir + fileName;
-		if(QFile::exists(destinationPath))
-		{
-			if(!askOverwriteDialog(tr("Save exists"), tr("Save '%1' already exists. Do you want to overwrite it?").arg(fileName), conflictCount, applyToAll, overwriteAll))
-				continue;
-
-			QFile::remove(destinationPath);
-		}
-
-		if(Helper::performNativeCopy(realSavePath, destinationPath))
-			importedCount++;
-		else
-		{
-			logGlobal->warn("Failed to import save file %s to %s", realSavePath.toStdString(), destinationPath.toStdString());
-			QMessageBox::warning(this, tr("Import failed"), tr("Failed to import save file %1").arg(realSavePath));
-		}
+		importSingleSaveFile(this, realSavePath, fileName, saveDestDir, askOverwrite, importedCount);
 	}
 
 	if(importedCount > 0)

--- a/launcher/startGame/StartGameTab.cpp
+++ b/launcher/startGame/StartGameTab.cpp
@@ -237,82 +237,98 @@ void StartGameTab::on_buttonGameEditor_clicked()
 	startEditor({});
 }
 
+QStringList StartGameTab::selectImportFiles()
+{
+#ifndef VCMI_MOBILE
+	QString filter =
+		tr("All supported files") + " (*.h3m *.vmap *.h3c *.vcmp *.vsgm1 *.zip *.json *.exe);;" +
+		tr("Maps") + " (*.h3m *.vmap);;" +
+		tr("Campaigns") + " (*.h3c *.vcmp);;" +
+		tr("Saves") + " (*.vsgm1);;" +
+		tr("Configs") + " (*.json);;" +
+		tr("Mods") + " (*.zip);;" +
+		tr("Gog files") + " (*.exe)";
+#else
+	//Workaround for sometimes incorrect mime for some extensions (e.g. for exe)
+	QString filter = tr("All files (*.*)");
+#endif
+	return QFileDialog::getOpenFileNames(
+		this,
+		tr("Select files (configs, mods, saves, maps, campaigns, gog files) to install..."),
+		QDir::homePath(),
+		filter);
+}
+
+QStringList StartGameTab::stageUnreadableFiles(const QStringList & files)
+{
+	QStringList preparedFiles;
+	preparedFiles.reserve(files.size());
+
+	QDir userDataDir(pathToQString(VCMIDirs::get().userDataPath()));
+	const QString importCachePath = userDataDir.filePath("tmp/import-cache");
+
+	QDir importCacheDir(importCachePath);
+	if(importCacheDir.exists() && !importCacheDir.removeRecursively())
+		logGlobal->warn("Failed to cleanup import cache dir: %s", importCachePath.toStdString());
+
+	userDataDir.mkpath("tmp/import-cache");
+	importCacheDir.setPath(importCachePath);
+
+	auto * modView = Helper::getMainWindow()->getModView();
+	modView->showExternalProgress(tr("Preparing selected files for import..."), 0, files.size());
+
+	for(int index = 0; index < files.size(); ++index)
+	{
+		const QString file = files[index];
+		modView->showExternalProgress(tr("Preparing selected files for import... %1/%2").arg(index + 1).arg(files.size()), index, files.size());
+		qApp->processEvents();
+
+		QString importPath = file;
+		QFile sourceFile(file);
+		if(!sourceFile.open(QIODevice::ReadOnly))
+		{
+			QString baseName = QFileInfo(Helper::getRealPath(file)).fileName();
+			if(baseName.isEmpty())
+				baseName = QStringLiteral("import_%1").arg(index + 1);
+
+			QString stagedPath = importCacheDir.filePath(QStringLiteral("%1_%2").arg(index + 1).arg(baseName));
+			for(int duplicateIndex = 1; QFileInfo::exists(stagedPath); duplicateIndex++)
+				stagedPath = importCacheDir.filePath(QStringLiteral("%1_%2_%3").arg(index + 1).arg(duplicateIndex).arg(baseName));
+
+			if(!Helper::performNativeCopy(file, stagedPath))
+			{
+				QMessageBox::warning(this, tr("Import failed"), tr("Failed to prepare file for import: %1").arg(Helper::getRealPath(file)));
+				continue;
+			}
+			importPath = stagedPath;
+		}
+
+		preparedFiles << importPath;
+	}
+
+	modView->showExternalProgress(tr("Preparing selected files for import..."), files.size(), files.size());
+	modView->hideExternalProgress();
+	return preparedFiles;
+}
+
+void StartGameTab::importPreparedFiles(const QStringList & files)
+{
+	for(const auto & file : files)
+	{
+		logGlobal->info("Importing file %s", file.toStdString());
+		Helper::getMainWindow()->manualInstallFile(file);
+	}
+}
+
 void StartGameTab::on_buttonImportFiles_clicked()
 {
 	const auto & importFunctor = [this]
 	{
-#ifndef VCMI_MOBILE
-		QString filter =
-			tr("All supported files") + " (*.h3m *.vmap *.h3c *.vcmp *.vsgm1 *.zip *.json *.exe);;" +
-			tr("Maps") + " (*.h3m *.vmap);;" +
-			tr("Campaigns") + " (*.h3c *.vcmp);;" +
-			tr("Saves") + " (*.vsgm1);;" +
-			tr("Configs") + " (*.json);;" +
-			tr("Mods") + " (*.zip);;" +
-			tr("Gog files") + " (*.exe)";
-#else
-		//Workaround for sometimes incorrect mime for some extensions (e.g. for exe)
-		QString filter = tr("All files (*.*)");
-#endif
-		QStringList files = QFileDialog::getOpenFileNames(this, tr("Select files (configs, mods, saves, maps, campaigns, gog files) to install..."), QDir::homePath(), filter);
+		QStringList files = selectImportFiles();
 		if(files.isEmpty())
 			return;
 
-		QStringList preparedFiles;
-		preparedFiles.reserve(files.size());
-
-		QDir userDataDir(pathToQString(VCMIDirs::get().userDataPath()));
-		const QString importCachePath = userDataDir.filePath("tmp/import-cache");
-
-		QDir importCacheDir(importCachePath);
-		if(importCacheDir.exists() && !importCacheDir.removeRecursively())
-			logGlobal->warn("Failed to cleanup import cache dir: %s", importCachePath.toStdString());
-
-		userDataDir.mkpath("tmp/import-cache");
-		importCacheDir.setPath(importCachePath);
-
-		auto * modView = Helper::getMainWindow()->getModView();
-		modView->showExternalProgress(tr("Preparing selected files for import..."), 0, files.size());
-
-		for(int index = 0; index < files.size(); ++index)
-		{
-			const QString file = files[index];
-			modView->showExternalProgress(tr("Preparing selected files for import... %1/%2").arg(index + 1).arg(files.size()), index, files.size());
-			qApp->processEvents();
-
-			QString importPath = file;
-
-			// Some exotic systems allows read after copy
-			QFile sourceFile(file);
-			if(!sourceFile.open(QIODevice::ReadOnly))
-			{
-				QString baseName = QFileInfo(Helper::getRealPath(file)).fileName();
-				if(baseName.isEmpty())
-					baseName = QStringLiteral("import_%1").arg(index + 1);
-
-				QString stagedPath = importCacheDir.filePath(QStringLiteral("%1_%2").arg(index + 1).arg(baseName));
-				for(int duplicateIndex = 1; QFileInfo::exists(stagedPath); duplicateIndex++)
-					stagedPath = importCacheDir.filePath(QStringLiteral("%1_%2_%3").arg(index + 1).arg(duplicateIndex).arg(baseName));
-
-				if(!Helper::performNativeCopy(file, stagedPath))
-				{
-					QMessageBox::warning(this, tr("Import failed"), tr("Failed to prepare file for import: %1").arg(Helper::getRealPath(file)));
-					continue;
-				}
-				importPath = stagedPath;
-			}
-
-			preparedFiles << importPath;
-		}
-
-		modView->showExternalProgress(tr("Preparing selected files for import..."), files.size(), files.size());
-		modView->hideExternalProgress();
-
-		for(const auto & file : preparedFiles)
-		{
-			logGlobal->info("Importing file %s", file.toStdString());
-			Helper::getMainWindow()->manualInstallFile(file);
-		}
+		importPreparedFiles(stageUnreadableFiles(files));
 	};
 
 	// iOS can't display modal dialogs when called directly on button press

--- a/launcher/startGame/StartGameTab.h
+++ b/launcher/startGame/StartGameTab.h
@@ -74,5 +74,9 @@ private slots:
 
 	void clipboardDataChanged();
 private:
+	QStringList selectImportFiles();
+	QStringList stageUnreadableFiles(const QStringList & files);
+	void importPreparedFiles(const QStringList & files);
+
 	Ui::StartGameTab * ui;
 };


### PR DESCRIPTION
### Motivation

- Reduce Sonar-reported cognitive complexity in large UI handlers for import/export while preserving existing behavior and dialogs.  
- Make the `StartGameTab`, `CModListView` and `AboutProjectView` flows easier to read and maintain by extracting focused helpers.

### Description

- Extracted helpers in `launcher/modManager/cmodlistview_moc.cpp` for save imports: `resolveSaveFileName`, `countSaveConflicts`, `shouldOverwriteSave`, `importSaveFromArchive`, and `importSingleSaveFile`, and keep calling behavior of `installSaves` unchanged.  
- Split `StartGameTab::on_buttonImportFiles_clicked` into `selectImportFiles`, `stageUnreadableFiles` and `importPreparedFiles`, and added their declarations to `launcher/startGame/StartGameTab.h` to remove a large inline lambda.  
- Extracted helpers in `launcher/aboutProject/aboutproject_moc.cpp`: `chooseLogArchivePath`, `buildDataDirListing`, `advanceProgress`, and mobile-specific helpers `saveLogArchiveToDestination` and `handleMobileLogArchiveDestination`, simplifying `on_pushButtonExportLogs_clicked` without changing output or UI flows.  
- Kept existing dialogs, overwrite logic and error reporting intact; only internal structure was refactored for clarity.

### Testing

- Ran static check `git diff --check`, which reported no issues.  
- Attempted a build in the CI container but it was skipped because no `build/` directory is present in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea37d9de4832d879e5c2e70bf74e5)