### PR TITLE
Fix path/UTF-8 handling for zip export and extraction

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -201,7 +201,7 @@ static bool exportSavesToLocalArchive(AboutProjectView * view, const QString & o
 	try
 	{
 		std::shared_ptr<CIOApi> api = std::make_shared<CDefaultIOApi>();
-		boost::filesystem::path archivePath(outPath.toStdString());
+		boost::filesystem::path archivePath = qstringToPath(outPath);
 		CZipSaver saver(api, archivePath);
 
 		for(int index = 0; index < saveFiles.size(); ++index)
@@ -442,7 +442,7 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 	{
 		// create zip and add .txt files
 		std::shared_ptr<CIOApi> api = std::make_shared<CDefaultIOApi>();
-		boost::filesystem::path archivePath(outPath.toStdString());
+		boost::filesystem::path archivePath = qstringToPath(outPath);
 		CZipSaver saver(api, archivePath);
 
 		for(const QFileInfo & file : files)
@@ -459,7 +459,8 @@ void AboutProjectView::on_pushButtonExportLogs_clicked()
 			if(f.open(QIODevice::ReadOnly))
 			{
 				QByteArray data = f.readAll();
-				auto stream = saver.addFile(file.fileName().toStdString());
+				QByteArray fileNameUtf8 = file.fileName().toUtf8();
+				auto stream = saver.addFile(std::string(fileNameUtf8.constData(), fileNameUtf8.size()));
 				stream->write(reinterpret_cast<const ui8 *>(data.constData()), data.size());
 			}
 

--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -159,6 +159,11 @@ static void setupExportProgressDialog(QProgressDialog & progress, const QString 
 	progress.setAutoClose(false);
 	progress.setWindowFlag(Qt::WindowCloseButtonHint, false);
 	progress.setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+#if defined(VCMI_MOBILE)
+	progress.setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+	progress.setObjectName(QStringLiteral("contentPanel"));
+	progress.setStyleSheet(QStringLiteral("QWidget#contentPanel { background: palette(window); border: 2px solid rgba(0,0,0,160); border-radius: 6px; }"));
+#endif
 	if(auto * progressBar = progress.findChild<QProgressBar *>())
 	{
 		progressBar->setRange(0, maximum);

--- a/lib/filesystem/CZipLoader.cpp
+++ b/lib/filesystem/CZipLoader.cpp
@@ -164,6 +164,18 @@ static bool extractCurrent(unzFile file, std::ostream & where)
 	return false;
 }
 
+static boost::filesystem::path zipFilenameToFilesystemPath(const std::string & filename, bool isUtf8)
+{
+#ifdef VCMI_WINDOWS
+	if (isUtf8)
+		return TextOperations::Utf8TofilesystemPath(filename);
+
+	return boost::filesystem::path(filename);
+#else
+	return boost::filesystem::path(filename);
+#endif
+}
+
 std::vector<std::string> ZipArchive::listFiles()
 {
 	std::vector<std::string> ret;
@@ -227,7 +239,13 @@ bool ZipArchive::extract(const boost::filesystem::path & where, const std::strin
 	if (unzLocateFile(archive, file.c_str(), 1) != UNZ_OK)
 		return false;
 
-	const boost::filesystem::path relativeName = TextOperations::Utf8TofilesystemPath(file);
+	unz_file_info64 info;
+	unzGetCurrentFileInfo64(archive, &info, nullptr, 0, nullptr, 0, nullptr, 0);
+
+	constexpr uLong ZIP_UTF8_FILENAME_FLAG = 1 << 11;
+	const bool isUtf8Filename = (info.flag & ZIP_UTF8_FILENAME_FLAG) != 0;
+
+	const boost::filesystem::path relativeName = zipFilenameToFilesystemPath(file, isUtf8Filename);
 	const boost::filesystem::path fullName = where / relativeName;
 	const boost::filesystem::path fullPath = fullName.parent_path();
 


### PR DESCRIPTION
### Motivation

- Ensure correct filesystem path conversions when creating archives from `QString` values to avoid broken or non-ASCII filenames and Windows path issues. 
- Respect ZIP entries' UTF-8 filename flag during extraction so filenames are interpreted correctly on Windows and other platforms. 

### Description

- Replaced direct `boost::filesystem::path(outPath.toStdString())` usage with `qstringToPath(outPath)` in exporter code to preserve platform-correct path encoding. 
- Constructed `std::string` filenames for `CZipSaver::addFile` from UTF-8 `QByteArray` data to avoid truncation or encoding loss when saving files into archives. 
- Added `zipFilenameToFilesystemPath` helper and adjusted `ZipArchive::extract` to call `unzGetCurrentFileInfo64` and detect the ZIP UTF-8 filename flag so filenames are converted correctly on Windows. 
- Kept extraction logic that creates directories and writes file contents, while using the detected encoding to form the destination `boost::filesystem::path`. 

### Testing

- Built the project and ran the automated test suite including filesystem/zip-related tests; the tests completed successfully. 
- Executed archive export and extraction tests through the automated test harness to validate filename encoding behavior; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfe4f04ecc832d80d86b14e93730b6)