### PR TITLE
Improve mobile file-picker fallback and support content:// URIs for exports

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -374,13 +374,9 @@ static void handleMobileLogArchiveDestination(AboutProjectView * view, const QSt
 		return;
 	}
 
-	logGlobal->warn("Log export: folder picker unavailable, trying save dialog with fallback");
-	QString pickedPath = QFileDialog::getSaveFileName(view, view->tr("Select destination file"), QDir::home().filePath("vcmi-logs.zip"), view->tr("Zip archives (*.zip);;All files (*.*)"));
-	if(pickedPath.isEmpty())
-	{
-		QMessageBox::information(view, view->tr("Manual filename required"), view->tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-logs.zip)."));
-		pickedPath = QFileDialog::getOpenFileName(view, view->tr("Select destination file"), QDir::homePath(), view->tr("All files (*.*)"));
-	}
+	logGlobal->warn("Log export: folder picker unavailable, using direct open-file fallback");
+	QMessageBox::information(view, view->tr("Manual filename required"), view->tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-logs.zip)."));
+	QString pickedPath = QFileDialog::getOpenFileName(view, view->tr("Select destination file"), QDir::homePath(), view->tr("All files (*.*)"));
 	if(pickedPath.isEmpty())
 		return;
 	if(!pickedPath.startsWith("content://", Qt::CaseInsensitive) && !pickedPath.endsWith(".zip", Qt::CaseInsensitive))
@@ -433,13 +429,9 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 	}
 	else
 	{
-		logGlobal->warn("Save export: folder picker unavailable, trying save dialog with fallback");
-		QString pickedPath = QFileDialog::getSaveFileName(this, tr("Select destination file"), QDir::home().filePath("vcmi-saves.zip"), tr("Zip archives (*.zip);;All files (*.*)"));
-		if(pickedPath.isEmpty())
-		{
-			QMessageBox::information(this, tr("Manual filename required"), tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-saves.zip)."));
-			pickedPath = QFileDialog::getOpenFileName(this, tr("Select destination file"), QDir::homePath(), tr("All files (*.*)"));
-		}
+		logGlobal->warn("Save export: folder picker unavailable, using direct open-file fallback");
+		QMessageBox::information(this, tr("Manual filename required"), tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-saves.zip)."));
+		const QString pickedPath = QFileDialog::getOpenFileName(this, tr("Select destination file"), QDir::homePath(), tr("All files (*.*)"));
 		if(pickedPath.isEmpty())
 			return;
 		exportViaTarget(ensureZipSuffix(pickedPath), true);

--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -374,9 +374,13 @@ static void handleMobileLogArchiveDestination(AboutProjectView * view, const QSt
 		return;
 	}
 
-	logGlobal->warn("Log export: folder picker unavailable, using manual file selection fallback");
-	QMessageBox::information(view, view->tr("Manual filename required"), view->tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-logs.zip)."));
-	QString pickedPath = QFileDialog::getOpenFileName(view, view->tr("Select destination file"), QDir::homePath(), view->tr("All files (*.*)"));
+	logGlobal->warn("Log export: folder picker unavailable, trying save dialog with fallback");
+	QString pickedPath = QFileDialog::getSaveFileName(view, view->tr("Select destination file"), QDir::home().filePath("vcmi-logs.zip"), view->tr("Zip archives (*.zip);;All files (*.*)"));
+	if(pickedPath.isEmpty())
+	{
+		QMessageBox::information(view, view->tr("Manual filename required"), view->tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-logs.zip)."));
+		pickedPath = QFileDialog::getOpenFileName(view, view->tr("Select destination file"), QDir::homePath(), view->tr("All files (*.*)"));
+	}
 	if(pickedPath.isEmpty())
 		return;
 	if(!pickedPath.startsWith("content://", Qt::CaseInsensitive) && !pickedPath.endsWith(".zip", Qt::CaseInsensitive))
@@ -429,9 +433,13 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 	}
 	else
 	{
-		logGlobal->warn("Save export: folder picker unavailable, using manual file selection fallback");
-		QMessageBox::information(this, tr("Manual filename required"), tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-saves.zip)."));
-		const QString pickedPath = QFileDialog::getOpenFileName(this, tr("Select destination file"), QDir::homePath(), tr("All files (*.*)"));
+		logGlobal->warn("Save export: folder picker unavailable, trying save dialog with fallback");
+		QString pickedPath = QFileDialog::getSaveFileName(this, tr("Select destination file"), QDir::home().filePath("vcmi-saves.zip"), tr("Zip archives (*.zip);;All files (*.*)"));
+		if(pickedPath.isEmpty())
+		{
+			QMessageBox::information(this, tr("Manual filename required"), tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-saves.zip)."));
+			pickedPath = QFileDialog::getOpenFileName(this, tr("Select destination file"), QDir::homePath(), tr("All files (*.*)"));
+		}
 		if(pickedPath.isEmpty())
 			return;
 		exportViaTarget(ensureZipSuffix(pickedPath), true);

--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -375,12 +375,11 @@ static void handleMobileLogArchiveDestination(AboutProjectView * view, const QSt
 	}
 
 	logGlobal->warn("Log export: folder picker unavailable, using manual file selection fallback");
-	QMessageBox::information(view, view->tr("Select destination file"), view->tr("Please select destination file and save the archive as vcmi-logs.zip."));
-	const QString defaultName = QDir::home().filePath("vcmi-logs.zip");
-	QString pickedPath = QFileDialog::getSaveFileName(view, view->tr("Select destination file"), defaultName, view->tr("Zip archives (*.zip);;All files (*.*)"));
+	QMessageBox::information(view, view->tr("Manual filename required"), view->tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-logs.zip)."));
+	QString pickedPath = QFileDialog::getOpenFileName(view, view->tr("Select destination file"), QDir::homePath(), view->tr("All files (*.*)"));
 	if(pickedPath.isEmpty())
 		return;
-	if(!pickedPath.endsWith(".zip", Qt::CaseInsensitive))
+	if(!pickedPath.startsWith("content://", Qt::CaseInsensitive) && !pickedPath.endsWith(".zip", Qt::CaseInsensitive))
 		pickedPath += ".zip";
 	saveLogArchiveToDestination(view, outPath, pickedPath);
 }
@@ -390,7 +389,7 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 {
 	auto ensureZipSuffix = [](QString path)
 	{
-		if(path.endsWith(".zip", Qt::CaseInsensitive))
+		if(path.startsWith("content://", Qt::CaseInsensitive) || path.endsWith(".zip", Qt::CaseInsensitive))
 			return path;
 		return path + ".zip";
 	};
@@ -431,9 +430,8 @@ void AboutProjectView::on_pushButtonExportSaves_clicked()
 	else
 	{
 		logGlobal->warn("Save export: folder picker unavailable, using manual file selection fallback");
-		QMessageBox::information(this, tr("Select destination file"), tr("Please select destination file and save the archive as vcmi-saves.zip."));
-		const QString defaultName = QDir::home().filePath("vcmi-saves.zip");
-		const QString pickedPath = QFileDialog::getSaveFileName(this, tr("Select destination file"), defaultName, tr("Zip archives (*.zip);;All files (*.*)"));
+		QMessageBox::information(this, tr("Manual filename required"), tr("This fallback picker may not prefill a filename on some devices. If no filename is shown, create one manually (for example: vcmi-saves.zip)."));
+		const QString pickedPath = QFileDialog::getOpenFileName(this, tr("Select destination file"), QDir::homePath(), tr("All files (*.*)"));
 		if(pickedPath.isEmpty())
 			return;
 		exportViaTarget(ensureZipSuffix(pickedPath), true);


### PR DESCRIPTION
### Motivation
- Fix fallback behavior on mobile where the save-file dialog may not prefill a filename and where Android content URIs (`content://`) should be treated as valid destinations without forcing a `.zip` suffix.

### Description
- Replaced fallback `getSaveFileName` usage with `getOpenFileName` for mobile fallback and updated the informational message to instruct users to type a filename manually when the picker doesn't prefill one.
- Added handling to accept `content://` URIs as valid destinations and avoid appending `.zip` to those URIs when exporting logs or saves.
- Normalized initial directory usage to `QDir::homePath()` in the fallback pickers and unified the suffix logic in the `ensureZipSuffix` lambda.
- Changes are applied in the mobile export flows in `aboutproject_moc.cpp` (log export and save export fallbacks).

### Testing
- Project was built after changes and the automated test suite was run; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7dc3b8cec832db7c7de65a2a1831b)