### PR TITLE
launcher: preserve submod states during mod update

### DIFF
--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1111,7 +1111,6 @@ void CModListView::installMods(QStringList archives)
 	QStringList modNames;
 	QStringList modsToEnable;
 	QMap<QString, QMap<QString, bool>> submodStateBeforeUpdate;
-	const QStringList allKnownMods = modStateModel->getAllMods();
 
 	for(QString archive : archives)
 	{
@@ -1135,13 +1134,10 @@ void CModListView::installMods(QStringList archives)
 		{
 			// Update flow is uninstall + install. Save submod states now so we can restore
 			// user configuration after reinstall (including nested "main.sub.another" ids).
-			for(const auto & knownMod : allKnownMods)
+			const auto modSettings = modStateModel->getModSettings(mod);
+			for (auto settingIt = modSettings.cbegin(); settingIt != modSettings.cend(); ++settingIt)
 			{
-				if(!knownMod.startsWith(mod + '.') || !modStateModel->isModInstalled(knownMod))
-					continue;
-
-				const QString settingID = knownMod.mid(mod.size() + 1);
-				submodStateBeforeUpdate[mod][knownMod] = modStateModel->isModSettingEnabled(mod, settingID);
+				submodStateBeforeUpdate[mod][mod + '.' + settingIt.key()] = settingIt.value();
 			}
 
 			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1112,6 +1112,7 @@ void CModListView::installMods(QStringList archives)
 	QStringList modsToEnable;
 	QMap<QString, QSet<QString>> submodsEnabledBeforeUpdate;
 	QMap<QString, QSet<QString>> submodsDisabledBeforeUpdate;
+	QMap<QString, QStringList> submodsByTopParent;
 
 	for(QString archive : archives)
 	{
@@ -1120,6 +1121,13 @@ void CModListView::installMods(QStringList archives)
 		QString modName = archive.section('/', -1, -1).section('.', 0, 0);
 
 		modNames.push_back(modName);
+	}
+
+	for(const auto & knownMod : modStateModel->getAllMods())
+	{
+		const auto modState = modStateModel->getMod(knownMod);
+		if(modState.isSubmod())
+			submodsByTopParent[modState.getTopParentID()].push_back(knownMod);
 	}
 
 	if (!activatingPreset.isEmpty())
@@ -1133,12 +1141,11 @@ void CModListView::installMods(QStringList archives)
 	{
 		if(modStateModel->isModExists(mod) && modStateModel->getMod(mod).isInstalled())
 		{
-			for(const auto & knownMod : modStateModel->getAllMods())
+			for(const auto & knownMod : submodsByTopParent.value(mod))
 			{
-				if(!knownMod.startsWith(mod + '.'))
-					continue;
+				const QString settingID = knownMod.mid(mod.size() + 1);
 
-				if(modStateModel->isModSettingEnabled(mod, knownMod.section('.', 1)))
+				if(modStateModel->isModSettingEnabled(mod, settingID))
 					submodsEnabledBeforeUpdate[mod].insert(knownMod);
 				else
 					submodsDisabledBeforeUpdate[mod].insert(knownMod);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1111,7 +1111,6 @@ void CModListView::installMods(QStringList archives)
 	QStringList modNames;
 	QStringList modsToEnable;
 	QMap<QString, QMap<QString, bool>> submodStateBeforeUpdate;
-	const QStringList allKnownMods = modStateModel->getAllMods();
 
 	for(QString archive : archives)
 	{
@@ -1133,13 +1132,11 @@ void CModListView::installMods(QStringList archives)
 	{
 		if(modStateModel->isModExists(mod) && modStateModel->getMod(mod).isInstalled())
 		{
-			for(const auto & knownMod : allKnownMods)
+			const auto modSettings = modStateModel->getModSettings(mod);
+			for (auto settingIt = modSettings.cbegin(); settingIt != modSettings.cend(); ++settingIt)
 			{
-				if(!knownMod.startsWith(mod + '.') || !modStateModel->isModInstalled(knownMod))
-					continue;
-
-				const QString settingID = knownMod.mid(mod.size() + 1);
-				submodStateBeforeUpdate[mod][knownMod] = modStateModel->isModSettingEnabled(mod, settingID);
+				const QString submodID = mod + '.' + settingIt.key();
+				submodStateBeforeUpdate[mod][submodID] = settingIt.value();
 			}
 
 			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1110,9 +1110,8 @@ void CModListView::installMods(QStringList archives)
 {
 	QStringList modNames;
 	QStringList modsToEnable;
-	QMap<QString, QSet<QString>> submodsEnabledBeforeUpdate;
-	QMap<QString, QSet<QString>> submodsDisabledBeforeUpdate;
-	QMap<QString, QStringList> submodsByTopParent;
+	QMap<QString, QMap<QString, bool>> submodStateBeforeUpdate;
+	const QStringList allKnownMods = modStateModel->getAllMods();
 
 	for(QString archive : archives)
 	{
@@ -1121,13 +1120,6 @@ void CModListView::installMods(QStringList archives)
 		QString modName = archive.section('/', -1, -1).section('.', 0, 0);
 
 		modNames.push_back(modName);
-	}
-
-	for(const auto & knownMod : modStateModel->getAllMods())
-	{
-		const auto modState = modStateModel->getMod(knownMod);
-		if(modState.isSubmod())
-			submodsByTopParent[modState.getTopParentID()].push_back(knownMod);
 	}
 
 	if (!activatingPreset.isEmpty())
@@ -1141,14 +1133,14 @@ void CModListView::installMods(QStringList archives)
 	{
 		if(modStateModel->isModExists(mod) && modStateModel->getMod(mod).isInstalled())
 		{
-			for(const auto & knownMod : submodsByTopParent.value(mod))
+			for(const auto & knownMod : allKnownMods)
 			{
-				const QString settingID = knownMod.mid(mod.size() + 1);
+				const auto knownModState = modStateModel->getMod(knownMod);
+				if(!knownModState.isSubmod() || knownModState.getTopParentID() != mod)
+					continue;
 
-				if(modStateModel->isModSettingEnabled(mod, settingID))
-					submodsEnabledBeforeUpdate[mod].insert(knownMod);
-				else
-					submodsDisabledBeforeUpdate[mod].insert(knownMod);
+				const QString settingID = knownMod.mid(mod.size() + 1);
+				submodStateBeforeUpdate[mod][knownMod] = modStateModel->isModSettingEnabled(mod, settingID);
 			}
 
 			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());
@@ -1194,15 +1186,17 @@ void CModListView::installMods(QStringList archives)
 		if (!modStateModel->isModExists(mod) || !modStateModel->isModEnabled(mod))
 			continue;
 
-		for (const auto & submod : submodsEnabledBeforeUpdate[mod])
+		for (auto submodIt = submodStateBeforeUpdate[mod].cbegin(); submodIt != submodStateBeforeUpdate[mod].cend(); ++submodIt)
 		{
-			if (modStateModel->isModExists(submod) && !modStateModel->isModEnabled(submod))
-				manager->enableMods({submod});
-		}
+			const QString & submod = submodIt.key();
+			const bool wasEnabled = submodIt.value();
 
-		for (const auto & submod : submodsDisabledBeforeUpdate[mod])
-		{
-			if (modStateModel->isModExists(submod) && modStateModel->isModEnabled(submod))
+			if(!modStateModel->isModExists(submod))
+				continue;
+
+			if(wasEnabled && !modStateModel->isModEnabled(submod))
+				manager->enableMods({submod});
+			else if(!wasEnabled && modStateModel->isModEnabled(submod))
 				manager->disableMod(submod);
 		}
 	}

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1135,8 +1135,7 @@ void CModListView::installMods(QStringList archives)
 		{
 			for(const auto & knownMod : allKnownMods)
 			{
-				const auto knownModState = modStateModel->getMod(knownMod);
-				if(!knownModState.isSubmod() || knownModState.getTopParentID() != mod)
+				if(!knownMod.startsWith(mod + '.') || !modStateModel->isModInstalled(knownMod))
 					continue;
 
 				const QString settingID = knownMod.mid(mod.size() + 1);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1110,6 +1110,8 @@ void CModListView::installMods(QStringList archives)
 {
 	QStringList modNames;
 	QStringList modsToEnable;
+	QMap<QString, QSet<QString>> submodsEnabledBeforeUpdate;
+	QMap<QString, QSet<QString>> submodsDisabledBeforeUpdate;
 
 	for(QString archive : archives)
 	{
@@ -1131,6 +1133,17 @@ void CModListView::installMods(QStringList archives)
 	{
 		if(modStateModel->isModExists(mod) && modStateModel->getMod(mod).isInstalled())
 		{
+			for(const auto & knownMod : modStateModel->getAllMods())
+			{
+				if(!knownMod.startsWith(mod + '.'))
+					continue;
+
+				if(modStateModel->isModSettingEnabled(mod, knownMod.section('.', 1)))
+					submodsEnabledBeforeUpdate[mod].insert(knownMod);
+				else
+					submodsDisabledBeforeUpdate[mod].insert(knownMod);
+			}
+
 			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());
 			if (modStateModel->isModEnabled(mod))
 				modsToEnable.push_back(mod);
@@ -1167,6 +1180,24 @@ void CModListView::installMods(QStringList archives)
 	if (!modsToEnable.empty())
 	{
 		manager->enableMods(modsToEnable);
+	}
+
+	for (const auto & mod : modNames)
+	{
+		if (!modStateModel->isModExists(mod) || !modStateModel->isModEnabled(mod))
+			continue;
+
+		for (const auto & submod : submodsEnabledBeforeUpdate[mod])
+		{
+			if (modStateModel->isModExists(submod) && !modStateModel->isModEnabled(submod))
+				manager->enableMods({submod});
+		}
+
+		for (const auto & submod : submodsDisabledBeforeUpdate[mod])
+		{
+			if (modStateModel->isModExists(submod) && modStateModel->isModEnabled(submod))
+				manager->disableMod(submod);
+		}
 	}
 
 	checkManagerErrors();

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1111,6 +1111,7 @@ void CModListView::installMods(QStringList archives)
 	QStringList modNames;
 	QStringList modsToEnable;
 	QMap<QString, QMap<QString, bool>> submodStateBeforeUpdate;
+	const QStringList allKnownMods = modStateModel->getAllMods();
 
 	for(QString archive : archives)
 	{
@@ -1132,11 +1133,15 @@ void CModListView::installMods(QStringList archives)
 	{
 		if(modStateModel->isModExists(mod) && modStateModel->getMod(mod).isInstalled())
 		{
-			const auto modSettings = modStateModel->getModSettings(mod);
-			for (auto settingIt = modSettings.cbegin(); settingIt != modSettings.cend(); ++settingIt)
+			// Update flow is uninstall + install. Save submod states now so we can restore
+			// user configuration after reinstall (including nested "main.sub.another" ids).
+			for(const auto & knownMod : allKnownMods)
 			{
-				const QString submodID = mod + '.' + settingIt.key();
-				submodStateBeforeUpdate[mod][submodID] = settingIt.value();
+				if(!knownMod.startsWith(mod + '.') || !modStateModel->isModInstalled(knownMod))
+					continue;
+
+				const QString settingID = knownMod.mid(mod.size() + 1);
+				submodStateBeforeUpdate[mod][knownMod] = modStateModel->isModSettingEnabled(mod, settingID);
 			}
 
 			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -1135,10 +1135,8 @@ void CModListView::installMods(QStringList archives)
 			// Update flow is uninstall + install. Save submod states now so we can restore
 			// user configuration after reinstall (including nested "main.sub.another" ids).
 			const auto modSettings = modStateModel->getModSettings(mod);
-			for (auto settingIt = modSettings.cbegin(); settingIt != modSettings.cend(); ++settingIt)
-			{
-				submodStateBeforeUpdate[mod][mod + '.' + settingIt.key()] = settingIt.value();
-			}
+			for (const auto & settingID : modSettings.keys())
+				submodStateBeforeUpdate[mod][mod + '.' + settingID] = modSettings.value(settingID);
 
 			logGlobal->info("Uninstalling old version of mod '%s'", mod.toStdString());
 			if (modStateModel->isModEnabled(mod))
@@ -1183,10 +1181,10 @@ void CModListView::installMods(QStringList archives)
 		if (!modStateModel->isModExists(mod) || !modStateModel->isModEnabled(mod))
 			continue;
 
-		for (auto submodIt = submodStateBeforeUpdate[mod].cbegin(); submodIt != submodStateBeforeUpdate[mod].cend(); ++submodIt)
+		const auto submodsForMod = submodStateBeforeUpdate.value(mod);
+		for (const auto & submod : submodsForMod.keys())
 		{
-			const QString & submod = submodIt.key();
-			const bool wasEnabled = submodIt.value();
+			const bool wasEnabled = submodsForMod.value(submod);
 
 			if(!modStateModel->isModExists(submod))
 				continue;

--- a/launcher/modManager/modstatemodel.cpp
+++ b/launcher/modManager/modstatemodel.cpp
@@ -73,6 +73,14 @@ bool ModStateModel::isModSettingEnabled(QString rootModName, QString modSettingN
 	return modManager->isModSettingActive(rootModName.toStdString(), modSettingName.toStdString());
 }
 
+QMap<QString, bool> ModStateModel::getModSettings(QString rootModName) const
+{
+	QMap<QString, bool> result;
+	for (const auto & entry : modManager->getModSettings(rootModName.toStdString()))
+		result[QString::fromStdString(entry.first)] = entry.second;
+	return result;
+}
+
 bool ModStateModel::isModEnabled(QString modName) const
 {
 	return modManager->isModActive(modName.toStdString());

--- a/launcher/modManager/modstatemodel.cpp
+++ b/launcher/modManager/modstatemodel.cpp
@@ -73,14 +73,6 @@ bool ModStateModel::isModSettingEnabled(QString rootModName, QString modSettingN
 	return modManager->isModSettingActive(rootModName.toStdString(), modSettingName.toStdString());
 }
 
-QMap<QString, bool> ModStateModel::getModSettings(QString rootModName) const
-{
-	QMap<QString, bool> result;
-	for (const auto & entry : modManager->getModSettings(rootModName.toStdString()))
-		result[QString::fromStdString(entry.first)] = entry.second;
-	return result;
-}
-
 bool ModStateModel::isModEnabled(QString modName) const
 {
 	return modManager->isModActive(modName.toStdString());

--- a/launcher/modManager/modstatemodel.h
+++ b/launcher/modManager/modstatemodel.h
@@ -11,6 +11,8 @@
 
 #include "modstate.h"
 
+#include <QMap>
+
 VCMI_LIB_NAMESPACE_BEGIN
 class JsonNode;
 class ModManager;
@@ -41,6 +43,7 @@ public:
 	bool isModInstalled(QString modName) const;
 	bool isModEnabled(QString modName) const;
 	bool isModSettingEnabled(QString rootModName, QString modSettingName) const;
+	QMap<QString, bool> getModSettings(QString rootModName) const;
 	bool isModUpdateAvailable(QString modName) const;
 	bool isModVisible(QString modName) const;
 

--- a/launcher/modManager/modstatemodel.h
+++ b/launcher/modManager/modstatemodel.h
@@ -11,8 +11,6 @@
 
 #include "modstate.h"
 
-#include <QMap>
-
 VCMI_LIB_NAMESPACE_BEGIN
 class JsonNode;
 class ModManager;
@@ -43,7 +41,6 @@ public:
 	bool isModInstalled(QString modName) const;
 	bool isModEnabled(QString modName) const;
 	bool isModSettingEnabled(QString rootModName, QString modSettingName) const;
-	QMap<QString, bool> getModSettings(QString rootModName) const;
 	bool isModUpdateAvailable(QString modName) const;
 	bool isModVisible(QString modName) const;
 

--- a/lib/modding/ModManager.cpp
+++ b/lib/modding/ModManager.cpp
@@ -529,6 +529,11 @@ bool ModManager::isModSettingActive(const TModID & rootModID, const TModID & mod
 	return modsPreset->getModSettings(rootModID).at(modSettingID);
 }
 
+std::map<TModID, bool> ModManager::getModSettings(const TModID & rootModID) const
+{
+	return modsPreset->getModSettings(rootModID);
+}
+
 bool ModManager::isModActive(const TModID & modID) const
 {
 	return vstd::contains(getActiveMods(), modID);

--- a/lib/modding/ModManager.h
+++ b/lib/modding/ModManager.h
@@ -147,6 +147,7 @@ public:
 	TModList getAllMods() const;
 
 	bool isModSettingActive(const TModID & rootModID, const TModID & modSettingID) const;
+	std::map<TModID, bool> getModSettings(const TModID & rootModID) const;
 	bool isModActive(const TModID & modID) const;
 	uint32_t computeChecksum(const TModID & modName) const;
 	std::optional<uint32_t> getValidatedChecksum(const TModID & modName) const;


### PR DESCRIPTION
### Motivation
- Updating a mod currently uninstalls and reinstalls it, which resets per-submod (mod settings) state and loses user preferences.
- The goal is to preserve submod enabled/disabled toggles across the update process and tolerate mod restructuring or missing submods.

### Description
- Added ephemeral storage for submod states in `CModListView::installMods` by introducing `submodsEnabledBeforeUpdate` and `submodsDisabledBeforeUpdate` maps.
- Before uninstalling an old mod version the code now iterates `modStateModel->getAllMods()` to record which submods of the parent were enabled or disabled using `isModSettingEnabled`.
- After reinstall and `reload`, the code restores the parent mod enable state and reapplies recorded submod toggles only for submods that still exist, using `manager->enableMods` and `manager->disableMod`.
- Change is localized to `launcher/modManager/cmodlistview_moc.cpp` in the `CModListView::installMods` flow and is resilient to missing/renamed submods.

### Testing
- Ran `git diff --check` and it reported no whitespace errors, which succeeded.
- Verified repository status with `git status --short` showing the modified file, which succeeded.
- Committed the change with `git commit` and confirmed the commit (`66a6285cf`) was created successfully.
- Created the PR metadata via the `make_pr` helper, which produced the PR title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d160cbdef8832da0c00c481f0965e1)