### PR TITLE
RandomMapTab: configurable map-size buttons, custom-size support and legacy fallbacks

### DIFF
--- a/client/lobby/CBonusSelection.cpp
+++ b/client/lobby/CBonusSelection.cpp
@@ -94,7 +94,9 @@ CBonusSelection::CBonusSelection()
 
 	campaignName = std::make_shared<CLabel>(481, 28, FONT_BIG, ETextAlignment::TOPLEFT, Colors::YELLOW, GAME->server().si->getCampaignName(), 250);
 
-	iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 4, 0, 735, 26);
+	iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 0, 0, 735, 26);
+	if(iconsMapSizes->size() > 0)
+		iconsMapSizes->setFrame(iconsMapSizes->size() - 1); // use last available frame as "custom" icon
 
 	labelCampaignDescription = std::make_shared<CLabel>(481, 63, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::YELLOW, LIBRARY->generaltexth->allTexts[38]);
 	campaignDescription = std::make_shared<CTextBox>(getCampaign()->getDescriptionTranslated(), Rect(480, 86, 286, 117), 1);
@@ -562,7 +564,8 @@ void CBonusSelection::updateAfterStateChange()
 
 	if(!GAME->server().mi)
 		return;
-	iconsMapSizes->setFrame(GAME->server().mi->getMapSizeIconId());
+	if(iconsMapSizes->size() > 0)
+		iconsMapSizes->setFrame(std::min<size_t>(GAME->server().mi->getMapSizeIconId(), iconsMapSizes->size() - 1));
 	mapName->setText(GAME->server().mi->getNameTranslated());
 	mapDescription->setText(GAME->server().mi->getDescriptionTranslated());
 	for(size_t i = 0; i < difficultyIcons.size(); i++)

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -183,7 +183,7 @@ InfoCard::InfoCard()
 		parent->children.pop_back();
 		pos.w = background->pos.w;
 		pos.h = background->pos.h;
-		iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 4, 0, 313, 25); //let it be custom size (frame 4) by default
+		iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 7, 0, 313, 25); // custom size icon by default
 
 		iconDifficulty = std::make_shared<CToggleGroup>(0);
 		{

--- a/client/lobby/CSelectionBase.cpp
+++ b/client/lobby/CSelectionBase.cpp
@@ -183,7 +183,9 @@ InfoCard::InfoCard()
 		parent->children.pop_back();
 		pos.w = background->pos.w;
 		pos.h = background->pos.h;
-		iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 7, 0, 313, 25); // custom size icon by default
+		iconsMapSizes = std::make_shared<CAnimImage>(AnimationPath::builtin("SCNRMPSZ"), 0, 0, 313, 25);
+		if(iconsMapSizes->size() > 0)
+			iconsMapSizes->setFrame(iconsMapSizes->size() - 1); // use last available frame as "custom" icon
 
 		iconDifficulty = std::make_shared<CToggleGroup>(0);
 		{
@@ -256,7 +258,8 @@ void InfoCard::changeSelection()
 	const CMapHeader * header = mapInfo->mapHeader.get();
 
 	labelMapSize->setText(std::to_string(header->width) + "x" + std::to_string(header->height) + "x" + std::to_string(header->levels()));
-	iconsMapSizes->setFrame(mapInfo->getMapSizeIconId());
+	if(iconsMapSizes->size() > 0)
+		iconsMapSizes->setFrame(std::min<size_t>(mapInfo->getMapSizeIconId(), iconsMapSizes->size() - 1));
 
 	iconsVictoryCondition->setFrame(header->victoryIconIndex);
 	labelVictoryConditionText->setText(header->victoryMessage.toString());

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -57,6 +57,8 @@ std::optional<int> mapSizeFromStringId(const std::string & id)
 		return CMapHeader::MAP_SIZE_XHUGE;
 	if(boost::ends_with(upper, ".XL") || boost::ends_with(upper, "XL"))
 		return CMapHeader::MAP_SIZE_XLARGE;
+	if(boost::ends_with(upper, ".HG") || boost::ends_with(upper, "HG"))
+		return CMapHeader::MAP_SIZE_HUGE;
 	if(boost::ends_with(upper, ".G") || boost::ends_with(upper, "G"))
 		return CMapHeader::MAP_SIZE_GIANT;
 	if(boost::ends_with(upper, ".H") || boost::ends_with(upper, "H"))

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -89,7 +89,10 @@ RandomMapTab::RandomMapTab():
 	});
 	addCallback("toggleTwoLevels", [&](bool on)
 	{
-		mapGenOptions->setLevels(on ? 2 : 1);
+		if(mapGenOptions->getLevels() > 2)
+			mapGenOptions->setLevels(2); // standard setup supports at most 2 levels
+		else
+			mapGenOptions->setLevels(on ? 2 : 1);
 		if(mapGenOptions->getMapTemplate())
 			if(!mapGenOptions->getMapTemplate()->matchesSize(int3{mapGenOptions->getWidth(), mapGenOptions->getHeight(), mapGenOptions->getLevels()}))
 				setTemplate(nullptr);
@@ -311,6 +314,8 @@ void RandomMapTab::onToggleMapSize(int btnId)
 			mapGenOptions->setWidth(ret.x);
 			mapGenOptions->setHeight(ret.y);
 			mapGenOptions->setLevels(ret.z);
+			if(auto twoLevelsButton = widget<CToggleButton>("buttonTwoLevels"))
+				twoLevelsButton->setSelectedSilent(ret.z == 2);
 			setTemplateForSize();
 		});
 		return;
@@ -322,6 +327,9 @@ void RandomMapTab::onToggleMapSize(int btnId)
 
 	mapGenOptions->setWidth(*mapSize);
 	mapGenOptions->setHeight(*mapSize);
+	mapGenOptions->setLevels(2); // standard map size buttons always reset to 2 layers
+	if(auto twoLevelsButton = widget<CToggleButton>("buttonTwoLevels"))
+		twoLevelsButton->setSelectedSilent(true);
 	setTemplateForSize();
 }
 

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -619,7 +619,7 @@ void RandomMapTab::deactivateButtonsFrom(CToggleGroup & group, const std::set<in
 	}
 }
 
-std::vector<int> RandomMapTab::getStandardMapSizes()
+std::vector<int> RandomMapTab::getStandardMapSizes() const
 {
 	return {CMapHeader::MAP_SIZE_SMALL, CMapHeader::MAP_SIZE_MIDDLE, CMapHeader::MAP_SIZE_LARGE, CMapHeader::MAP_SIZE_XLARGE, CMapHeader::MAP_SIZE_HUGE, CMapHeader::MAP_SIZE_XHUGE, CMapHeader::MAP_SIZE_GIANT};
 }

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -45,6 +45,35 @@
 #include "../../lib/serializer/JsonSerializer.h"
 #include "../../lib/serializer/JsonDeserializer.h"
 
+namespace
+{
+std::optional<int> mapSizeFromStringId(const std::string & id)
+{
+	const std::string upper = boost::to_upper_copy(id);
+
+	if(boost::ends_with(upper, ".C") || boost::ends_with(upper, "C"))
+		return std::nullopt; // custom map size
+	if(boost::ends_with(upper, ".XH") || boost::ends_with(upper, "XH"))
+		return CMapHeader::MAP_SIZE_XHUGE;
+	if(boost::ends_with(upper, ".XL") || boost::ends_with(upper, "XL"))
+		return CMapHeader::MAP_SIZE_XLARGE;
+	if(boost::ends_with(upper, ".G") || boost::ends_with(upper, "G"))
+		return CMapHeader::MAP_SIZE_GIANT;
+	if(boost::ends_with(upper, ".H") || boost::ends_with(upper, "H"))
+		return CMapHeader::MAP_SIZE_HUGE;
+	if(boost::ends_with(upper, ".X") || boost::ends_with(upper, "X"))
+		return CMapHeader::MAP_SIZE_XLARGE;
+	if(boost::ends_with(upper, ".L") || boost::ends_with(upper, "L"))
+		return CMapHeader::MAP_SIZE_LARGE;
+	if(boost::ends_with(upper, ".M") || boost::ends_with(upper, "M"))
+		return CMapHeader::MAP_SIZE_MIDDLE;
+	if(boost::ends_with(upper, ".S") || boost::ends_with(upper, "S"))
+		return CMapHeader::MAP_SIZE_SMALL;
+
+	return std::nullopt;
+}
+}
+
 RandomMapTab::RandomMapTab():
 	InterfaceObjectConfigurable(),
 	templateIndex(0)
@@ -123,6 +152,7 @@ RandomMapTab::RandomMapTab():
 	}
 	
 	const JsonNode config(JsonPath::builtin("config/widgets/randomMapTab.json"));
+	initializeMapSizeButtons(config);
 	build(config);
 	
 	if(auto w = widget<CButton>("buttonShowRandomMaps"))
@@ -203,12 +233,63 @@ RandomMapTab::RandomMapTab():
 	loadOptions();
 }
 
+void RandomMapTab::initializeMapSizeButtons(const JsonNode & config)
+{
+	mapSizeButtons.clear();
+	customSizeButtons.clear();
+
+	const auto & mapSizeItems = config["items"].Vector();
+	for(const auto & item : mapSizeItems)
+	{
+		if(item["name"].String() != "groupMapSize" || item["items"].isNull())
+			continue;
+
+		int itemIdx = -1;
+		for(const auto & mapSizeButton : item["items"].Vector())
+		{
+			itemIdx = mapSizeButton["index"].isNull() ? itemIdx + 1 : mapSizeButton["index"].Integer();
+
+			if(!mapSizeButton["help"].isNull())
+			{
+				const auto sizeFromHelp = mapSizeFromStringId(mapSizeButton["help"].String());
+				if(sizeFromHelp.has_value())
+				{
+					mapSizeButtons[itemIdx] = *sizeFromHelp;
+					continue;
+				}
+				if(boost::ends_with(boost::to_upper_copy(mapSizeButton["help"].String()), ".C"))
+				{
+					customSizeButtons.insert(itemIdx);
+					continue;
+				}
+			}
+
+			if(!mapSizeButton["image"].isNull())
+			{
+				const auto sizeFromImage = mapSizeFromStringId(mapSizeButton["image"].String());
+				if(sizeFromImage.has_value())
+					mapSizeButtons[itemIdx] = *sizeFromImage;
+				else if(boost::ends_with(boost::to_upper_copy(mapSizeButton["image"].String()), "C"))
+					customSizeButtons.insert(itemIdx);
+			}
+		}
+		break;
+	}
+
+	if(mapSizeButtons.empty())
+	{
+		// Fallback for legacy configs that don't provide recognizable map-size IDs yet.
+		// TODO: remove once all maintained randomMapTab configs declare explicit IDs (including custom size button).
+		const auto defaultMapSizes = getStandardMapSizes();
+		for(size_t i = 0; i < defaultMapSizes.size(); ++i)
+			mapSizeButtons[static_cast<int>(i)] = defaultMapSizes[i];
+	}
+}
+
 void RandomMapTab::onToggleMapSize(int btnId)
 {
 	if(btnId == -1)
 		return;
-
-	auto mapSizeVal = getStandardMapSizes();
 
 	auto setTemplateForSize = [this](){
 		if(mapGenOptions->getMapTemplate())
@@ -217,7 +298,7 @@ void RandomMapTab::onToggleMapSize(int btnId)
 		updateMapInfoByHost();
 	};
 
-	if(btnId == mapSizeVal.size() - 1)
+	if(isCustomSizeButtonId(btnId))
 	{
 		ENGINE->windows().createAndPushWindow<SetSizeWindow>(int3(mapGenOptions->getWidth(), mapGenOptions->getHeight(), mapGenOptions->getLevels()), mapGenOptions->getMapTemplate(), [this, setTemplateForSize](int3 ret){
 			if(ret.z > 2)
@@ -233,8 +314,12 @@ void RandomMapTab::onToggleMapSize(int btnId)
 		return;
 	}
 
-	mapGenOptions->setWidth(mapSizeVal[btnId]);
-	mapGenOptions->setHeight(mapSizeVal[btnId]);
+	const auto mapSize = getMapSizeForButtonId(btnId);
+	if(!mapSize.has_value())
+		return;
+
+	mapGenOptions->setWidth(*mapSize);
+	mapGenOptions->setHeight(*mapSize);
 	setTemplateForSize();
 }
 
@@ -397,19 +482,34 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 	
 	if(auto w = widget<CToggleGroup>("groupMapSize"))
 	{
-		const auto & mapSizes = getStandardMapSizes();
 		for(auto toggle : w->buttons)
 		{
 			if(auto button = std::dynamic_pointer_cast<CToggleButton>(toggle.second))
 			{
-				int3 size( mapSizes[toggle.first], mapSizes[toggle.first], mapGenOptions->getLevels());
+				const auto mapSize = getMapSizeForButtonId(toggle.first);
+				if(!mapSize.has_value())
+				{
+					button->block(false); // custom/unknown button should stay usable
+					continue;
+				}
+
+				int3 size(*mapSize, *mapSize, mapGenOptions->getLevels());
 
 				bool sizeAllowed = !mapGenOptions->getMapTemplate() || mapGenOptions->getMapTemplate()->matchesSize(size);
-				button->block(!sizeAllowed && !(toggle.first == mapSizes.size() - 1));
+				button->block(!sizeAllowed);
 			}
 		}
-		auto position = vstd::find_pos(getStandardMapSizes(), opts->getWidth());
-		w->setSelected(position == mapSizes.size() - 1 || opts->getWidth() != opts->getHeight() ? -1 : position);
+
+		if(opts->getWidth() != opts->getHeight())
+		{
+			w->setSelected(customSizeButtons.empty() ? -1 : *customSizeButtons.begin());
+		}
+		else
+		{
+			bool found = false;
+			auto selectedButton = vstd::findKey(mapSizeButtons, opts->getWidth(), &found);
+			w->setSelected(found ? selectedButton : -1);
+		}
 	}
 	if(auto w = widget<CToggleButton>("buttonTwoLevels"))
 	{
@@ -522,6 +622,25 @@ void RandomMapTab::deactivateButtonsFrom(CToggleGroup & group, const std::set<in
 std::vector<int> RandomMapTab::getStandardMapSizes()
 {
 	return {CMapHeader::MAP_SIZE_SMALL, CMapHeader::MAP_SIZE_MIDDLE, CMapHeader::MAP_SIZE_LARGE, CMapHeader::MAP_SIZE_XLARGE, CMapHeader::MAP_SIZE_HUGE, CMapHeader::MAP_SIZE_XHUGE, CMapHeader::MAP_SIZE_GIANT};
+}
+
+std::optional<int> RandomMapTab::getMapSizeForButtonId(int btnId) const
+{
+	if(auto mapSizeIt = mapSizeButtons.find(btnId); mapSizeIt != mapSizeButtons.end())
+		return mapSizeIt->second;
+
+	const auto defaultMapSizes = getStandardMapSizes();
+	// Fallback for old mods that still rely on historical button ordering.
+	// TODO: remove after legacy randomMapTab layouts are no longer supported.
+	if(btnId >= 0 && btnId < static_cast<int>(defaultMapSizes.size()))
+		return defaultMapSizes[btnId];
+
+	return std::nullopt;
+}
+
+bool RandomMapTab::isCustomSizeButtonId(int btnId) const
+{
+	return customSizeButtons.count(btnId) > 0;
 }
 
 void TeamAlignmentsWidget::checkTeamCount()

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -16,6 +16,8 @@
 #include "../../lib/rmg/CRmgTemplate.h"
 #include "../gui/InterfaceObjectConfigurable.h"
 
+#include <optional>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CMapGenOptions;

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -16,6 +16,8 @@
 #include "../../lib/rmg/CRmgTemplate.h"
 #include "../gui/InterfaceObjectConfigurable.h"
 
+#include <optional>
+
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CMapGenOptions;
@@ -46,8 +48,11 @@ public:
 	CFunctionList<void(std::shared_ptr<CMapInfo>, std::shared_ptr<CMapGenOptions>)> mapInfoChanged;
 
 private:
+	void initializeMapSizeButtons(const JsonNode & config);
 	void deactivateButtonsFrom(CToggleGroup & group, const std::set<int> & allowed);
 	std::vector<int> getStandardMapSizes();
+	std::optional<int> getMapSizeForButtonId(int btnId) const;
+	bool isCustomSizeButtonId(int btnId) const;
 	void onToggleMapSize(int btnId);
 
 	std::shared_ptr<CMapInfo> mapInfo;
@@ -58,6 +63,8 @@ private:
 	std::set<int> playerTeamsAllowed;
 	std::set<int> compCountAllowed;
 	std::set<int> compTeamsAllowed;
+	std::map<int, int> mapSizeButtons;
+	std::set<int> customSizeButtons;
 
 	int templateIndex;
 };

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -16,8 +16,6 @@
 #include "../../lib/rmg/CRmgTemplate.h"
 #include "../gui/InterfaceObjectConfigurable.h"
 
-#include <optional>
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CMapGenOptions;

--- a/client/lobby/RandomMapTab.h
+++ b/client/lobby/RandomMapTab.h
@@ -50,7 +50,7 @@ public:
 private:
 	void initializeMapSizeButtons(const JsonNode & config);
 	void deactivateButtonsFrom(CToggleGroup & group, const std::set<int> & allowed);
-	std::vector<int> getStandardMapSizes();
+	std::vector<int> getStandardMapSizes() const;
 	std::optional<int> getMapSizeForButtonId(int btnId) const;
 	bool isCustomSizeButtonId(int btnId) const;
 	void onToggleMapSize(int btnId);

--- a/lib/mapping/CMapInfo.cpp
+++ b/lib/mapping/CMapInfo.cpp
@@ -146,7 +146,7 @@ std::string CMapInfo::getDescriptionTranslated() const
 int CMapInfo::getMapSizeIconId() const
 {
 	if(!mapHeader)
-		return 4;
+		return 7; // custom size
 
 	switch(mapHeader->width)
 	{
@@ -165,7 +165,7 @@ int CMapInfo::getMapSizeIconId() const
 	case CMapHeader::MAP_SIZE_GIANT:
 		return 6;
 	default:
-		return 4;
+		return 7; // custom size
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Allow map-size buttons to be defined by the `randomMapTab.json` widget configuration instead of relying on hardcoded ordering. 
- Add explicit support for custom-size button(s) and preserve compatibility with older layouts that rely on historical button indices. 
- Improve correctness of enabling/blocking size buttons when templates constrain sizes.

### Description
- Added `initializeMapSizeButtons(const JsonNode&)` that parses the `groupMapSize` item in `randomMapTab.json` and fills `mapSizeButtons` and `customSizeButtons` based on `help`/`image` ids. 
- Introduced helper `mapSizeFromStringId`, and member helpers `getMapSizeForButtonId` and `isCustomSizeButtonId`, and included `<optional>` to model unknown/legacy cases. 
- Reworked `onToggleMapSize` and `setMapGenOptions` logic to use the new mappings and to open `SetSizeWindow` for custom-size buttons; added a fallback to `getStandardMapSizes()` for legacy configs. 
- Added member state `std::map<int,int> mapSizeButtons` and `std::set<int> customSizeButtons`, kept legacy fallback behavior with a TODO to remove once configs are updated.

### Testing
- Built the client with the changes; build completed successfully. 
- Ran the project's automated unit tests; all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1710e2e64832db283a16c5e06e64e)