### PR TITLE
Make map-size filter buttons data-driven via JSON config

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -49,6 +49,47 @@
 #include "../../lib/UnlockGuard.h"
 #include "../../lib/GameLibrary.h"
 #include "../../lib/json/JsonUtils.h"
+#include "../../lib/json/JsonNode.h"
+
+namespace
+{
+struct MapSizeFilterButtonConfig
+{
+	int mapSize = 0;
+	Point position;
+	std::string image;
+	std::pair<std::string, std::string> tooltip;
+	EShortcut shortcut = {};
+};
+
+std::vector<MapSizeFilterButtonConfig> loadMapSizeFilterButtons()
+{
+	const JsonNode config(JsonPath::builtin("config/widgets/selectionTab.json"));
+
+	std::vector<MapSizeFilterButtonConfig> result;
+	for(const auto & item : config["mapSizeFilterButtons"].Vector())
+	{
+		if(item["position"].isNull() || item["image"].isNull() || item["size"].isNull())
+			continue;
+
+		MapSizeFilterButtonConfig buttonConfig;
+		buttonConfig.mapSize = item["size"].Integer();
+		buttonConfig.position = Point(item["position"]["x"].Integer(), item["position"]["y"].Integer());
+		buttonConfig.image = item["image"].String();
+
+		if(!item["help"].isNull())
+		{
+			if(item["help"].isString())
+				buttonConfig.tooltip = CButton::tooltip("", LIBRARY->generaltexth->translate(item["help"].String()));
+			else
+				buttonConfig.tooltip = CButton::tooltip("", LIBRARY->generaltexth->zelp[item["help"].Integer()]);
+		}
+
+		result.push_back(buttonConfig);
+	}
+	return result;
+}
+}
 
 bool mapSorter::operator()(const std::shared_ptr<ElementInfo> aaa, const std::shared_ptr<ElementInfo> bbb)
 {
@@ -184,13 +225,15 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 		inputName->setFilterFilename();
 		labelMapSizes = std::make_shared<CLabel>(87, 62, FONT_SMALL, ETextAlignment::CENTER, Colors::YELLOW, LIBRARY->generaltexth->allTexts[510]);
 
-		// TODO: Global constants?
-		constexpr std::array sizes = {CMapHeader::MAP_SIZE_SMALL, CMapHeader::MAP_SIZE_MIDDLE, CMapHeader::MAP_SIZE_LARGE, CMapHeader::MAP_SIZE_XLARGE, 0};
-		constexpr std::array filterIconNmes = {"SCSMBUT.DEF", "SCMDBUT.DEF", "SCLGBUT.DEF", "SCXLBUT.DEF", "SCALBUT.DEF"};
-		constexpr std::array filterShortcuts = { EShortcut::MAPS_SIZE_S, EShortcut::MAPS_SIZE_M, EShortcut::MAPS_SIZE_L, EShortcut::MAPS_SIZE_XL, EShortcut::MAPS_SIZE_ALL };
-
-		for(int i = 0; i < 5; i++)
-			buttonsSortBy.push_back(std::make_shared<CButton>(Point(158 + 47 * i, 46), AnimationPath::builtin(filterIconNmes[i]), LIBRARY->generaltexth->zelp[54 + i], std::bind(&SelectionTab::filter, this, sizes[i], true), filterShortcuts[i]));
+		for(const auto & mapSizeButton : loadMapSizeFilterButtons())
+		{
+			buttonsSortBy.push_back(std::make_shared<CButton>(
+				mapSizeButton.position,
+				AnimationPath::builtin(mapSizeButton.image),
+				mapSizeButton.tooltip,
+				std::bind(&SelectionTab::filter, this, mapSizeButton.mapSize, true),
+				mapSizeButton.shortcut));
+		}
 
 		constexpr std::array xpos = {23, 55, 88, 121, 306, 339};
 		constexpr std::array sortIconNames = {"SCBUTT1.DEF", "SCBUTT2.DEF", "SCBUTCP.DEF", "SCBUTT3.DEF", "SCBUTT4.DEF", "SCBUTT5.DEF"};

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -62,6 +62,25 @@ struct MapSizeFilterButtonConfig
 	EShortcut shortcut = {};
 };
 
+EShortcut mapSizeFilterShortcut(int mapSize)
+{
+	switch(mapSize)
+	{
+	case CMapHeader::MAP_SIZE_SMALL:
+		return EShortcut::MAPS_SIZE_S;
+	case CMapHeader::MAP_SIZE_MIDDLE:
+		return EShortcut::MAPS_SIZE_M;
+	case CMapHeader::MAP_SIZE_LARGE:
+		return EShortcut::MAPS_SIZE_L;
+	case CMapHeader::MAP_SIZE_XLARGE:
+		return EShortcut::MAPS_SIZE_XL;
+	case 0:
+		return EShortcut::MAPS_SIZE_ALL;
+	default:
+		return {};
+	}
+}
+
 std::vector<MapSizeFilterButtonConfig> loadMapSizeFilterButtons()
 {
 	const JsonNode config(JsonPath::builtin("config/widgets/selectionTab.json"));
@@ -76,13 +95,11 @@ std::vector<MapSizeFilterButtonConfig> loadMapSizeFilterButtons()
 		buttonConfig.mapSize = item["size"].Integer();
 		buttonConfig.position = Point(item["position"]["x"].Integer(), item["position"]["y"].Integer());
 		buttonConfig.image = item["image"].String();
+		buttonConfig.shortcut = mapSizeFilterShortcut(buttonConfig.mapSize);
 
 		if(!item["help"].isNull())
 		{
-			if(item["help"].isString())
-				buttonConfig.tooltip = CButton::tooltip("", LIBRARY->generaltexth->translate(item["help"].String()));
-			else
-				buttonConfig.tooltip = CButton::tooltip("", LIBRARY->generaltexth->zelp[item["help"].Integer()]);
+			buttonConfig.tooltip = CButton::tooltip("", LIBRARY->generaltexth->translate(item["help"].String()));
 		}
 
 		result.push_back(buttonConfig);

--- a/config/widgets/selectionTab.json
+++ b/config/widgets/selectionTab.json
@@ -1,0 +1,35 @@
+{
+	"mapSizeFilterButtons":
+	[
+		{
+			"size": 36,
+			"image": "SCSMBUT.DEF",
+			"help": 54,
+			"position": {"x": 158, "y": 46}
+		},
+		{
+			"size": 72,
+			"image": "SCMDBUT.DEF",
+			"help": 55,
+			"position": {"x": 205, "y": 46}
+		},
+		{
+			"size": 108,
+			"image": "SCLGBUT.DEF",
+			"help": 56,
+			"position": {"x": 252, "y": 46}
+		},
+		{
+			"size": 144,
+			"image": "SCXLBUT.DEF",
+			"help": 57,
+			"position": {"x": 299, "y": 46}
+		},
+		{
+			"size": 0,
+			"image": "SCALBUT.DEF",
+			"help": 58,
+			"position": {"x": 346, "y": 46}
+		}
+	]
+}

--- a/config/widgets/selectionTab.json
+++ b/config/widgets/selectionTab.json
@@ -4,31 +4,31 @@
 		{
 			"size": 36,
 			"image": "SCSMBUT.DEF",
-			"help": 54,
+			"help": "core.help.198",
 			"position": {"x": 158, "y": 46}
 		},
 		{
 			"size": 72,
 			"image": "SCMDBUT.DEF",
-			"help": 55,
+			"help": "core.help.199",
 			"position": {"x": 205, "y": 46}
 		},
 		{
 			"size": 108,
 			"image": "SCLGBUT.DEF",
-			"help": 56,
+			"help": "core.help.200",
 			"position": {"x": 252, "y": 46}
 		},
 		{
 			"size": 144,
 			"image": "SCXLBUT.DEF",
-			"help": 57,
+			"help": "core.help.201",
 			"position": {"x": 299, "y": 46}
 		},
 		{
 			"size": 0,
 			"image": "SCALBUT.DEF",
-			"help": 58,
+			"help": "core.help.202",
 			"position": {"x": 346, "y": 46}
 		}
 	]


### PR DESCRIPTION
### Motivation
- Move hardcoded map-size filter button layout, images and tooltips out of code so UI tweaks can be made without code changes.
- Centralize button metadata for the selection tab to simplify maintenance and localization handling.

### Description
- Added `config/widgets/selectionTab.json` containing `mapSizeFilterButtons` with `size`, `image`, `help`, and `position` entries.
- Introduced `MapSizeFilterButtonConfig` and `loadMapSizeFilterButtons()` in `SelectionTab.cpp` (anonymous namespace) to parse the JSON using `JsonNode` and construct tooltip data via `CButton::tooltip`.
- Replaced the previous hardcoded `sizes` / `filterIconNmes` / `filterShortcuts` arrays with dynamic creation of size filter buttons using parsed config while preserving the existing click handler `SelectionTab::filter`.
- Included `JsonNode.h` and kept the existing sorting button creation logic unchanged.

### Testing
- No automated tests were run for this change.
- Please run the project CI/build to validate compilation and UI behavior after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d516308d70832da9298379a7c7a5ac)