### PR TITLE
Copy Conan runtime DLLs to executable output directory on Windows

### DIFF
--- a/cmake_modules/VCMIUtils.cmake
+++ b/cmake_modules/VCMIUtils.cmake
@@ -161,6 +161,17 @@ endfunction()
 
 # generate .bat for .exe with proper PATH
 function(vcmi_create_exe_shim tgt)
+	if(WIN32 AND USING_CONAN AND EXISTS "${CONAN_RUNTIME_LIBS_FILE}")
+		file(STRINGS "${CONAN_RUNTIME_LIBS_FILE}" runtimeLibs)
+		if(runtimeLibs)
+			add_custom_command(TARGET ${tgt} POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E copy_if_different ${runtimeLibs} "$<TARGET_FILE_DIR:${tgt}>"
+				COMMAND_EXPAND_LISTS
+				VERBATIM
+			)
+		endif()
+	endif()
+
 	if(NOT CONAN_RUNENV_SCRIPT)
 		return()
 	endif()

--- a/docs/developers/Building_Windows.md
+++ b/docs/developers/Building_Windows.md
@@ -98,7 +98,9 @@ call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\devenv
     - Specify the following CMake variable: `ENABLE_CCACHE=ON`
     - See the [Visual Studio documentation](https://learn.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=msvc-170#cmake-variables-and-cache) for details
 4. Right click on `BUILD_ALL` project. This `BUILD_ALL` project should be in `CMakePredefinedTargets` tree in Solution Explorer. You can also build individual targets if you want.
-5. VCMI will be built in `%VCMI_DIR%/build/bin/<config>` folder where `<config>` is e.g. `RelWithDebInfo`. To launch the built executables from a file manager, use respective `bat` files, e.g. `VCMI_launcher.bat`.
+5. VCMI will be built in `%VCMI_DIR%/build/bin/<config>` folder where `<config>` is e.g. `RelWithDebInfo`.
+6. When building with Conan on Windows, required runtime DLLs are copied to the executable output directory as part of the build, so binaries in `%VCMI_DIR%/build/bin/<config>` are standalone for running from a file manager.
+7. `bat` launchers (e.g. `VCMI_launcher.bat`) are still generated and can be used as before.
 
 ### Compile VCMI with MinGW64 or UCRT64 via MSYS2
 


### PR DESCRIPTION
### Motivation
- Make Visual Studio-built executables runnable from the build output without requiring users to run the `conanrun` wrapper by copying required Conan-provided runtime DLLs into the executable output directory during the build.

### Description
- Add a Windows-only code path to `vcmi_create_exe_shim` in `cmake_modules/VCMIUtils.cmake` that reads `CONAN_RUNTIME_LIBS_FILE` (`file(STRINGS ...)`) and registers a `POST_BUILD` `add_custom_command` which runs `cmake -E copy_if_different` to copy listed runtime libs to `$<TARGET_FILE_DIR:...>` when `USING_CONAN` is set, while preserving the existing `.bat` shim generation; update `docs/developers/Building_Windows.md` to document that runtime DLLs are copied into the output directory.

### Testing
- Ran `cmake -P cmake_modules/VCMIUtils.cmake` as a basic CMake validation which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69c65cb6c832d96e28824a4177659)