### PR TITLE
Add per-town tavern rumors and random selection in tavern UI

### DIFF
--- a/config/schemas/faction.json
+++ b/config/schemas/faction.json
@@ -167,6 +167,13 @@
 					"description" : "Video for tavern window",
 					"format" : "videoFile"
 				},
+				"tavernRumors" : {
+					"type" : "array",
+					"description" : "Localized rumors that can be randomly shown in the tavern window for this town",
+					"items" : {
+						"type" : "string"
+					}
+				},
 				"townBackground" : {
 					"type" : "string",
 					"description" : "Background for town screen",

--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -24,6 +24,7 @@
 #include "../spells/CSpellHandler.h"
 #include "../mapping/CMap.h"
 #include "../CPlayerState.h"
+#include "../CRandomGenerator.h"
 
 #define ASSERT_IF_CALLED_WITH_PLAYER if(!getPlayerID()) {logGlobal->error(BOOST_CURRENT_FUNCTION); assert(0);}
 
@@ -617,29 +618,46 @@ std::string CGameInfoCallback::getTavernRumor(const CGObjectInstance * townOrTav
 {
 	MetaString text;
 	text.appendLocalString(EMetaText::GENERAL_TXT, 216);
-	
-	std::string extraText;
-	if(gameState().currentRumor.type == RumorState::TYPE_NONE)
-		return text.toString();
 
-	auto rumor = gameState().currentRumor.last.at(gameState().currentRumor.type);
-	switch(gameState().currentRumor.type)
+	if(gameState().currentRumor.type != RumorState::TYPE_NONE)
 	{
-	case RumorState::TYPE_SPECIAL:
-		text.replaceLocalString(EMetaText::GENERAL_TXT, rumor.first);
-		if(rumor.first == RumorState::RUMOR_GRAIL)
-			text.replaceTextID(TextIdentifier("core", "arraytxt", 158 + rumor.second).get());
-		else
-			text.replaceTextID(TextIdentifier("core", "plcolors", rumor.second).get());
+		auto rumor = gameState().currentRumor.last.at(gameState().currentRumor.type);
+		switch(gameState().currentRumor.type)
+		{
+		case RumorState::TYPE_SPECIAL:
+			text.replaceLocalString(EMetaText::GENERAL_TXT, rumor.first);
+			if(rumor.first == RumorState::RUMOR_GRAIL)
+				text.replaceTextID(TextIdentifier("core", "arraytxt", 158 + rumor.second).get());
+			else
+				text.replaceTextID(TextIdentifier("core", "plcolors", rumor.second).get());
+			break;
 
-		break;
-	case RumorState::TYPE_MAP:
-		text.replaceRawString(gameState().getMap().rumors[rumor.first].text.toString());
-		break;
+		case RumorState::TYPE_MAP:
+			text.replaceRawString(gameState().getMap().rumors[rumor.first].text.toString());
+			break;
 
-	case RumorState::TYPE_RAND:
-		text.replaceTextID(TextIdentifier("core", "randtvrn", rumor.first).get());
-		break;
+		case RumorState::TYPE_RAND:
+			text.replaceTextID(TextIdentifier("core", "randtvrn", rumor.first).get());
+			break;
+		}
+	}
+
+	const auto * town = dynamic_cast<const CGTownInstance *>(townOrTavern);
+	if(town != nullptr)
+	{
+		const auto rumorsCount = town->getTown()->getTavernRumorsCount();
+		if(rumorsCount > 0)
+		{
+			std::vector<std::string> availableRumors;
+			availableRumors.reserve(rumorsCount + 1);
+			availableRumors.push_back(text.toString());
+
+			for(size_t rumorIndex = 0; rumorIndex < rumorsCount; rumorIndex++)
+				availableRumors.push_back(LIBRARY->generaltexth->translate(town->getTown()->getTavernRumorTextID(rumorIndex)));
+
+			const auto selectedRumor = static_cast<size_t>(CRandomGenerator::getDefault().nextInt(static_cast<int>(availableRumors.size() - 1)));
+			return availableRumors[selectedRumor];
+		}
 	}
 
 	return text.toString();

--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -25,6 +25,7 @@
 #include "../mapping/CMap.h"
 #include "../CPlayerState.h"
 #include "../CRandomGenerator.h"
+#include "../texts/CGeneralTextHandler.h"
 
 #define ASSERT_IF_CALLED_WITH_PLAYER if(!getPlayerID()) {logGlobal->error(BOOST_CURRENT_FUNCTION); assert(0);}
 

--- a/lib/callback/CGameInfoCallback.cpp
+++ b/lib/callback/CGameInfoCallback.cpp
@@ -656,7 +656,15 @@ std::string CGameInfoCallback::getTavernRumor(const CGObjectInstance * townOrTav
 			for(size_t rumorIndex = 0; rumorIndex < rumorsCount; rumorIndex++)
 				availableRumors.push_back(LIBRARY->generaltexth->translate(town->getTown()->getTavernRumorTextID(rumorIndex)));
 
-			const auto selectedRumor = static_cast<size_t>(CRandomGenerator::getDefault().nextInt(static_cast<int>(availableRumors.size() - 1)));
+			static thread_local std::unordered_map<si32, size_t> lastRumorByTown;
+			const auto objectId = townOrTavern->id.getNum();
+			const auto previous = lastRumorByTown.find(objectId);
+
+			size_t selectedRumor = static_cast<size_t>(CRandomGenerator::getDefault().nextInt(static_cast<int>(availableRumors.size() - 1)));
+			if(availableRumors.size() > 1 && previous != lastRumorByTown.end() && selectedRumor == previous->second)
+				selectedRumor = (selectedRumor + 1 + static_cast<size_t>(CRandomGenerator::getDefault().nextInt(static_cast<int>(availableRumors.size() - 2)))) % availableRumors.size();
+
+			lastRumorByTown[objectId] = selectedRumor;
 			return availableRumors[selectedRumor];
 		}
 	}

--- a/lib/entities/faction/CTown.cpp
+++ b/lib/entities/faction/CTown.cpp
@@ -34,6 +34,16 @@ size_t CTown::getRandomNamesCount() const
 	return namesCount;
 }
 
+std::string CTown::getTavernRumorTextID(size_t index) const
+{
+	return TextIdentifier("faction", faction->modScope, faction->identifier, "tavernRumor", index).get();
+}
+
+size_t CTown::getTavernRumorsCount() const
+{
+	return tavernRumorsCount;
+}
+
 std::string CTown::getBuildingScope() const
 {
 	if(faction == nullptr)

--- a/lib/entities/faction/CTown.h
+++ b/lib/entities/faction/CTown.h
@@ -42,6 +42,7 @@ class DLL_LINKAGE CTown : boost::noncopyable
 {
 	friend class CTownHandler;
 	size_t namesCount = 0;
+	size_t tavernRumorsCount = 0;
 
 public:
 	CTown();
@@ -54,6 +55,8 @@ public:
 
 	std::string getRandomNameTextID(size_t index) const;
 	size_t getRandomNamesCount() const;
+	std::string getTavernRumorTextID(size_t index) const;
+	size_t getTavernRumorsCount() const;
 
 	CFaction * faction;
 

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -655,6 +655,13 @@ void CTownHandler::loadTown(CTown * town, const JsonNode & source)
 		town->namesCount += 1;
 	}
 
+	town->tavernRumorsCount = 0;
+	for(const auto & rumor : source["tavernRumors"].Vector())
+	{
+		LIBRARY->generaltexth->registerString(town->faction->modScope, town->getTavernRumorTextID(town->tavernRumorsCount), rumor);
+		town->tavernRumorsCount += 1;
+	}
+
 	if (!source["moatAbility"].isNull()) // VCMI 1.2 compatibility code
 	{
 		LIBRARY->identifiers()->requestIdentifier( "spell", source["moatAbility"], [=](si32 ability)


### PR DESCRIPTION
### Motivation
- Allow towns to provide localized tavern rumors that can be randomly shown in the tavern window in addition to the existing global/map/special rumors.

### Description
- Add `tavernRumors` array schema to `config/schemas/faction.json` to declare per-faction tavern rumors as strings.
- Extend `CTown` with a `tavernRumorsCount` member and accessor methods `getTavernRumorTextID` and `getTavernRumorsCount` to address localized rumor strings.
- Load and register tavern rumor strings in `CTownHandler::loadTown` from the `tavernRumors` JSON field.
- Update `CGameInfoCallback::getTavernRumor` to incorporate the existing global/map/special rumor logic and, when a `CGTownInstance` is provided, collect town-specific rumors, prepend the default rumor text, and return a randomly selected entry using `CRandomGenerator`.

### Testing
- Project was built successfully after the changes (`make`).
- Automated test suite was executed (`make test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92a1a08f8832db2deffab3c407e38)