### PR TITLE
Fix commander level-up ability list indexing

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -503,48 +503,46 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 
 	if(parent->info->levelupInfo)
 	{
+		static constexpr ui32 commanderAbilitySkillOffset = 100;
+
 		abilitiesBackground = std::make_shared<CPicture>(ImagePath::builtin("stackWindow/commander-abilities.png"));
 		abilitiesBackground->moveBy(Point(0, pos.h));
 
-		size_t abilitiesCount = boost::range::count_if(parent->info->levelupInfo->skills, [](ui32 skillID)
+		std::vector<ui32> abilitySkills;
+		abilitySkills.reserve(parent->info->levelupInfo->skills.size());
+		for(ui32 skillID : parent->info->levelupInfo->skills)
 		{
-			return skillID >= 100;
-		});
+			if(skillID >= commanderAbilitySkillOffset)
+				abilitySkills.push_back(skillID);
+		}
+		size_t abilitiesCount = abilitySkills.size();
 
-		auto onCreate = [this](size_t index)->std::shared_ptr<CIntObject>
+		auto onCreate = [this, abilitySkills](size_t index)->std::shared_ptr<CIntObject>
 		{
-			for(auto skillID : parent->info->levelupInfo->skills)
+			if(index >= abilitySkills.size())
+				return nullptr;
+
+			const ui32 skillID = abilitySkills[index];
+			const auto bonuses = LIBRARY->creh->skillRequirements[skillID - commanderAbilitySkillOffset].first;
+			const CStackInstance * stack = parent->info->commander;
+			auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(stack->bonusToGraphics(bonuses[0])), true, [](){});
+			icon->callback = [this, skillID, icon]()
 			{
-				if(skillID < 100)
-					continue;
+				parent->setSelection(skillID, icon);
+			};
+			std::string abilityDescription;
+			for(size_t i = 0; i < bonuses.size(); i++)
+			{
+				if(!abilityDescription.empty())
+					abilityDescription += "\n";
 
-				if(index == 0)
-				{
-					const auto bonuses = LIBRARY->creh->skillRequirements[skillID-100].first;
-					const CStackInstance * stack = parent->info->commander;
-					auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(stack->bonusToGraphics(bonuses[0])), true, [](){});
-					icon->callback = [this, skillID, icon]()
-					{
-						parent->setSelection(skillID, icon);
-					};
-					std::string abilityDescription;
-					for(size_t i = 0; i < bonuses.size(); i++)
-					{
-						if(!abilityDescription.empty())
-							abilityDescription += "\n";
-
-						abilityDescription += LIBRARY->bth->bonusToString(bonuses[i]);
-					}
-
-					icon->hoverText = abilityDescription;
-					icon->text = abilityDescription;
-
-					return icon;
-				}
-
-				--index;
+				abilityDescription += LIBRARY->bth->bonusToString(bonuses[i]);
 			}
-			return nullptr;
+
+			icon->hoverText = abilityDescription;
+			icon->text = abilityDescription;
+
+			return icon;
 		};
 
 		abilities = std::make_shared<CListBox>(onCreate, Point(38, 3+pos.h), Point(63, 0), 6, abilitiesCount);

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -515,7 +515,10 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 		{
 			for(auto skillID : parent->info->levelupInfo->skills)
 			{
-				if(index == 0 && skillID >= 100)
+				if(skillID < 100)
+					continue;
+
+				if(index == 0)
 				{
 					const auto bonuses = LIBRARY->creh->skillRequirements[skillID-100].first;
 					const CStackInstance * stack = parent->info->commander;
@@ -538,6 +541,8 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 
 					return icon;
 				}
+
+				--index;
 			}
 			return nullptr;
 		};


### PR DESCRIPTION
### Motivation
- Fix a UI bug where commander abilities offered at level-up were rendered on top of each other because the list item factory always returned the first ability instead of the N-th ability requested by the list index.

### Description
- Update `client/windows/CCreatureWindow.cpp` in the `onCreate` lambda to skip non-ability entries (`skillID < 100`) and decrement the requested `index` only for ability entries so the factory returns the N-th commander ability instead of repeatedly returning the first one.

### Testing
- No automated tests were run for this UI logic change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95a314994832da1fdfba6394e0867)