### PR TITLE
Hide turn options controls on scenario info during gameplay

### DIFF
--- a/client/lobby/OptionsTabBase.cpp
+++ b/client/lobby/OptionsTabBase.cpp
@@ -445,6 +445,15 @@ void OptionsTabBase::recreate(bool campaign)
 		buttonTurnOptions->block(GAME->server().isGuest() || campaign);
 	}
 
+	if(SEL->screenType == ESelectionScreen::scenarioInfo)
+	{
+		if(auto timerPresetSelector = widget<CIntObject>("timerPresetSelector"))
+			timerPresetSelector->setEnabled(false);
+
+		if(auto buttonTurnOptions = widget<CIntObject>("buttonTurnOptions"))
+			buttonTurnOptions->setEnabled(false);
+	}
+
 	if(auto textureCampaignOverdraw = widget<CFilledTexture>("textureCampaignOverdraw"))
 		textureCampaignOverdraw->setEnabled(campaign);
 }


### PR DESCRIPTION
### Motivation
- Scenario Info opened from the adventure map (in-game) should not show controls that modify timers or turn options, which are only relevant during pre-game setup, so hide those widgets when viewing `ESelectionScreen::scenarioInfo`.

### Description
- In `OptionsTabBase::recreate(bool)` (file `client/lobby/OptionsTabBase.cpp`) disable the `timerPresetSelector` and `buttonTurnOptions` widgets when `SEL->screenType == ESelectionScreen::scenarioInfo`, leaving pre-game/lobby behavior unchanged.

### Testing
- Ran `git diff --check` to ensure there are no whitespace/style issues and the patch is clean (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d966e0a398832d9ad26e923edad46e)