### PR TITLE
Set split creature slider default to half stack size

### DIFF
--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -335,6 +335,9 @@ CSplitWindow::CSplitWindow(const CCreature * creature, std::function<void(int, i
 	int total = leftAmount + rightAmount;
 	int leftMax = total - rightMin;
 	int rightMax = total - leftMin;
+	int defaultRightAmount = std::clamp(total / 2, rightMin, rightMax);
+	leftAmount = total - defaultRightAmount;
+	rightAmount = defaultRightAmount;
 
 	ok = std::make_shared<CButton>(Point(20, 263), AnimationPath::builtin("IOK6432"), CButton::tooltip(), std::bind(&CSplitWindow::apply, this), EShortcut::GLOBAL_ACCEPT);
 	cancel = std::make_shared<CButton>(Point(214, 263), AnimationPath::builtin("ICN6432"), CButton::tooltip(), std::bind(&CSplitWindow::close, this), EShortcut::GLOBAL_CANCEL);
@@ -357,7 +360,7 @@ CSplitWindow::CSplitWindow(const CCreature * creature, std::function<void(int, i
 	animLeft = std::make_shared<CCreaturePic>(20, 54, creature, true, false);
 	animRight = std::make_shared<CCreaturePic>(177, 54,creature, true, false);
 
-	slider = std::make_shared<CSlider>(Point(21, 194), 257, std::bind(&CSplitWindow::sliderMoved, this, _1), 0, sliderPosition, rightAmount - rightMin, Orientation::HORIZONTAL);
+	slider = std::make_shared<CSlider>(Point(21, 194), 257, std::bind(&CSplitWindow::sliderMoved, this, _1), 0, sliderPosition, defaultRightAmount - rightMin, Orientation::HORIZONTAL);
 
 	std::string titleStr = LIBRARY->generaltexth->allTexts[256];
 	boost::algorithm::replace_first(titleStr,"%s", creature->getNamePluralTranslated());

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -335,7 +335,9 @@ CSplitWindow::CSplitWindow(const CCreature * creature, std::function<void(int, i
 	int total = leftAmount + rightAmount;
 	int leftMax = total - rightMin;
 	int rightMax = total - leftMin;
-	int defaultRightAmount = std::clamp(total / 2, rightMin, rightMax);
+	int defaultRightAmount = rightAmount;
+	if(settings["general"]["enableUiEnhancements"].Bool())
+		defaultRightAmount = std::clamp(total / 2, rightMin, rightMax);
 	leftAmount = total - defaultRightAmount;
 	rightAmount = defaultRightAmount;
 


### PR DESCRIPTION
### Motivation
- Make the split-creatures dialog start with the slider set to half the stack (`total / 2`, rounded down) so splitting a stack is simpler and more convenient while respecting existing minimum constraints.

### Description
- In `client/windows/GUIClasses.cpp` update `CSplitWindow` constructor to compute `defaultRightAmount = std::clamp(total / 2, rightMin, rightMax)`, set `leftAmount`/`rightAmount` from that value, and initialize the slider with `defaultRightAmount - rightMin` so the dialog opens in the middle.

### Testing
- No automated tests were run for this UI-only change; it is a small behavior tweak limited to `CSplitWindow` initialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d971609264832dbc0059e4145efdc1)