### PR TITLE
android: avoid ANR when SDLActivity is destroyed during startup

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/VcmiSDLActivity.java
@@ -16,6 +16,7 @@ import android.view.WindowManager;
 
 import org.libsdl.app.SDLActivity;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import eu.vcmi.vcmi.util.LibsLoader;
@@ -121,6 +122,7 @@ public class VcmiSDLActivity extends SDLActivity
     protected void onDestroy()
     {
         unbindServer();
+        detachSdlThreadForFastShutdown();
 
         super.onDestroy();
 
@@ -181,6 +183,30 @@ public class VcmiSDLActivity extends SDLActivity
         catch (ReflectiveOperationException ignored)
         {
             // Older/newer SDL Java wrappers may not expose onNativeFocusChanged.
+        }
+    }
+
+    private void detachSdlThreadForFastShutdown()
+    {
+        try
+        {
+            final Field sdlThreadField = SDLActivity.class.getDeclaredField("mSDLThread");
+            sdlThreadField.setAccessible(true);
+
+            final Object value = sdlThreadField.get(null);
+            if (value instanceof Thread sdlThread)
+            {
+                if (sdlThread.isAlive())
+                {
+                    Log.w(this, "Detaching running SDL thread during onDestroy to avoid ANR");
+                    sdlThread.interrupt();
+                }
+                sdlThreadField.set(null, null);
+            }
+        }
+        catch (ReflectiveOperationException ignored)
+        {
+            // SDL internals can vary by version; fallback to default shutdown path.
         }
     }
 


### PR DESCRIPTION
### Motivation

- Prevent an ANR caused by `SDLActivity.onDestroy()` blocking on the SDL thread during app shutdown when the SDL thread is still busy (e.g. long startup tasks such as mod scanning).

### Description

- Call `detachSdlThreadForFastShutdown()` from `VcmiSDLActivity.onDestroy()` before calling `super.onDestroy()` to avoid a blocking `Thread.join()` inside SDL lifecycle.
- Add `detachSdlThreadForFastShutdown()` which uses reflection to locate `SDLActivity`'s internal `mSDLThread`, interrupt it if alive, and clear the field to detach the thread.
- Add `import java.lang.reflect.Field` and log a warning when interrupting the running SDL thread, and silently fall back if SDL internals differ by catching `ReflectiveOperationException`.

### Testing

- Tried to compile the Android app Java sources with `./android/gradlew -p android :vcmi-app:compileDebugJavaWithJavac -x lint`, which failed in this environment with `Unsupported class file major version 69` so automated compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97731d0ec832d978959b89bb8f634)