### PR TITLE
Add Reinforcements adventure spell and garrison dialog integration

### DIFF
--- a/Mods/vcmi/Content/config/spells.json
+++ b/Mods/vcmi/Content/config/spells.json
@@ -67,7 +67,8 @@
 		"name": "Boiling Tar"
 	}
 
-	,"core:reinforcements" : {
+	,"reinforcements" : {
+		"index" : 82,
 		"name": "Reinforcements",
 		"school": {
 			"air": true

--- a/Mods/vcmi/Content/config/spells.json
+++ b/Mods/vcmi/Content/config/spells.json
@@ -66,4 +66,51 @@
 	"core:fortressMoat": {
 		"name": "Boiling Tar"
 	}
+
+	,"core:reinforcements" : {
+		"name": "Reinforcements",
+		"school": {
+			"air": true
+		},
+		"level": 4,
+		"power": 0,
+		"defaultGainChance": 0,
+		"gainChance": {},
+		"targetType": "NO_TARGET",
+		"levels" : {
+			"base": {
+				"description" : "Summon creatures from the closest town garrison once per day",
+				"cost" : 12,
+				"range" : "X",
+				"adventureEffect" : {
+					"type" : "reinforcements",
+					"allowTownSelection" : false,
+					"castsPerDay" : 1
+				}
+			},
+			"basic": {
+				"description" : "Summon creatures from the closest town garrison up to 2 times per day",
+				"adventureEffect" : {
+					"castsPerDay" : 2
+				}
+			},
+			"advanced": {
+				"description" : "Summon creatures from any town garrison up to 3 times per day",
+				"adventureEffect" : {
+					"allowTownSelection" : true,
+					"castsPerDay" : 3
+				}
+			},
+			"expert": {
+				"description" : "Summon creatures from any town garrison up to 4 times per day",
+				"adventureEffect" : {
+					"allowTownSelection" : true,
+					"castsPerDay" : 4
+				}
+			}
+		},
+		"flags" : {
+			"indifferent": true
+		}
+	}
 }

--- a/Mods/vcmi/Content/config/spells.json
+++ b/Mods/vcmi/Content/config/spells.json
@@ -70,14 +70,26 @@
 	,"reinforcements" : {
 		"index" : 82,
 		"name": "Reinforcements",
-		"school": {
-			"air": true
+		"school" : {
+			"air" : true,
+			"earth" : true,
+			"fire" : true,
+			"water" : true
 		},
 		"level": 4,
 		"power": 0,
+		"type" : "adventure",
 		"defaultGainChance": 0,
 		"gainChance": {},
 		"targetType": "NO_TARGET",
+
+		"graphics" : {
+			"iconBook" : "reinforcements/spellBook",
+			"iconScroll" : "reinforcements/spellScroll",
+			"iconScenarioBonus" : "reinforcements/spellBonus",
+			"iconEffect" : "reinforcements/spellEffect"
+		},
+
 		"levels" : {
 			"base": {
 				"description" : "Summon creatures from the closest town garrison once per day",
@@ -87,7 +99,8 @@
 					"type" : "reinforcements",
 					"allowTownSelection" : false,
 					"castsPerDay" : 1
-				}
+				},
+				"power" : 0
 			},
 			"basic": {
 				"description" : "Summon creatures from the closest town garrison up to 2 times per day",

--- a/Mods/vcmi/Content/config/translations/czech.json
+++ b/Mods/vcmi/Content/config/translations/czech.json
@@ -1098,4 +1098,8 @@
 	"vcmi.tutorialWindow.decription.RadialWheel": "Přejetí otevře kruhovou nabídku pro různé akce, třeba správa hrdiny/jednotek a příkazy měst.",
 	"vcmi.tutorialWindow.decription.RightClick": "Klepněte a držte prvek, na který byste chtěli použít pravé tlačítko myši. Klepněte na volnou oblast pro zavření.",
 	"vcmi.tutorialWindow.title": "Úvod ovládání dotykem"
+,
+	"vcmi.spells.reinforcements.selectTown.title": "Posily",
+	"vcmi.spells.reinforcements.selectTown.description": "Vyber město, odkud chceš povolat posily.",
+	"vcmi.spells.reinforcements.garrison.title": "Převzít posily"
 }

--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -1098,4 +1098,8 @@
 	"vcmi.tutorialWindow.decription.RadialWheel": "Swiping opens radial wheel for various actions, such as creature/hero management and town ordering.",
 	"vcmi.tutorialWindow.decription.RightClick": "Touch and hold the element on which you want to right-click. Touch the free area to close.",
 	"vcmi.tutorialWindow.title": "Touchscreen Introduction"
+,
+	"vcmi.spells.reinforcements.selectTown.title": "Reinforcements",
+	"vcmi.spells.reinforcements.selectTown.description": "Select a town to gather reinforcements from.",
+	"vcmi.spells.reinforcements.garrison.title": "Take Reinforcements"
 }

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1139,7 +1139,13 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	std::string titleText;
 	if(down->tempOwner == up->tempOwner)
 	{
-		titleText = LIBRARY->generaltexth->allTexts[709];
+		const auto * town = dynamic_cast<const CGTownInstance *>(up);
+		const bool isReinforcementsDialog = town != nullptr && down->getVisitedTown() != town;
+
+		if(isReinforcementsDialog)
+			titleText = LIBRARY->generaltexth->translate("vcmi.spells.reinforcements.garrison.title");
+		else
+			titleText = LIBRARY->generaltexth->allTexts[709];
 	}
 	else
 	{

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1143,7 +1143,10 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 		const bool isReinforcementsDialog = town != nullptr && down->getVisitedTown() != town;
 
 		if(isReinforcementsDialog)
+		{
 			titleText = LIBRARY->generaltexth->translate("vcmi.spells.reinforcements.garrison.title");
+			spellIcon = std::make_shared<CPicture>(ImagePath::builtin("reinforcements/spellScroll"), 243, 48);
+		}
 		else
 			titleText = LIBRARY->generaltexth->allTexts[709];
 	}

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1143,10 +1143,7 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 		const bool isReinforcementsDialog = town != nullptr && down->getVisitedTown() != town;
 
 		if(isReinforcementsDialog)
-		{
 			titleText = LIBRARY->generaltexth->translate("vcmi.spells.reinforcements.garrison.title");
-			spellIcon = std::make_shared<CPicture>(ImagePath::builtin("reinforcements/spellScroll"), 243, 48);
-		}
 		else
 			titleText = LIBRARY->generaltexth->allTexts[709];
 	}

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -424,7 +424,6 @@ class CGarrisonWindow : public CWindowObject, public IGarrisonHolder
 	std::shared_ptr<CLabel> title;
 	std::shared_ptr<CAnimImage> banner;
 	std::shared_ptr<CAnimImage> portrait;
-	std::shared_ptr<CPicture> spellIcon;
 
 	std::shared_ptr<CGarrisonInt> garr;
 

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -424,6 +424,7 @@ class CGarrisonWindow : public CWindowObject, public IGarrisonHolder
 	std::shared_ptr<CLabel> title;
 	std::shared_ptr<CAnimImage> banner;
 	std::shared_ptr<CAnimImage> portrait;
+	std::shared_ptr<CPicture> spellIcon;
 
 	std::shared_ptr<CGarrisonInt> garr;
 

--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -56,7 +56,7 @@
 			"properties" : {
 				"type" : {
 					"type" : "string",
-					"enum" : [ "generic", "dimensionDoor", "removeObject", "summonBoat", "townPortal", "viewWorld" ]
+					"enum" : [ "generic", "dimensionDoor", "removeObject", "summonBoat", "townPortal", "reinforcements", "viewWorld" ]
 				},
 				"castsPerDay" : { "type" : "number" },
 				"castsPerDayXL" : { "type" : "number" },
@@ -127,6 +127,19 @@
 							"movementPointsTaken" : { "type" : "number" },
 							"allowTownSelection" : { "type" : "boolean" },
 							"skipOccupiedTowns" : { "type" : "boolean" }
+						},
+						"additionalProperties" : false
+					}
+				},
+				{ 
+					"if" : { "properties" : { "type" : { "const" : "reinforcements" } } },
+					"then" : {
+						"properties" : {
+							"castsPerDay" : {},
+							"castsPerDayXL" : {},
+							"bonuses" : {},
+							"type" : {},
+							"allowTownSelection" : { "type" : "boolean" }
 						},
 						"additionalProperties" : false
 					}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -281,6 +281,7 @@ set(lib_MAIN_SRCS
 	spells/adventure/AdventureSpellMechanics.cpp
 	spells/adventure/DimensionDoorEffect.cpp
 	spells/adventure/RemoveObjectEffect.cpp
+	spells/adventure/ReinforcementsEffect.cpp
 	spells/adventure/SummonBoatEffect.cpp
 	spells/adventure/TownPortalEffect.cpp
 	spells/adventure/ViewWorldEffect.cpp
@@ -757,6 +758,7 @@ set(lib_MAIN_HEADERS
 	spells/adventure/AdventureSpellEffect.h
 	spells/adventure/DimensionDoorEffect.h
 	spells/adventure/RemoveObjectEffect.h
+	spells/adventure/ReinforcementsEffect.h
 	spells/adventure/SummonBoatEffect.h
 	spells/adventure/TownPortalEffect.h
 	spells/adventure/ViewWorldEffect.h

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -65,6 +65,7 @@ public:
 
 	virtual void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) = 0;
 	virtual bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) = 0;	//TODO: remove
+	virtual void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) = 0;
 
 	virtual void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) = 0;//TODO: type safety on query, use generic query packet when implemented
 };

--- a/lib/spells/adventure/AdventureSpellMechanics.cpp
+++ b/lib/spells/adventure/AdventureSpellMechanics.cpp
@@ -14,6 +14,7 @@
 #include "AdventureSpellEffect.h"
 #include "DimensionDoorEffect.h"
 #include "RemoveObjectEffect.h"
+#include "ReinforcementsEffect.h"
 #include "SummonBoatEffect.h"
 #include "TownPortalEffect.h"
 #include "ViewWorldEffect.h"
@@ -42,6 +43,8 @@ std::unique_ptr<IAdventureSpellEffect> AdventureSpellMechanics::createAdventureE
 		return std::make_unique<SummonBoatEffect>(s, node);
 	if(typeID == "townPortal")
 		return std::make_unique<TownPortalEffect>(s, node);
+	if(typeID == "reinforcements")
+		return std::make_unique<ReinforcementsEffect>(s, node);
 	if(typeID == "viewWorld")
 		return std::make_unique<ViewWorldEffect>(s, node);
 

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -51,11 +51,22 @@ ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, con
 
 	if(!parameters.pos.isValid() && allowTownSelection)
 	{
-		auto queryCallback = [&mechanics, env, parameters](std::optional<int32_t> reply) -> void
+		std::vector<ObjectInstanceID> offeredTownIDs;
+		offeredTownIDs.reserve(towns.size());
+
+		for(const auto * town : towns)
+			offeredTownIDs.push_back(town->id);
+
+		auto queryCallback = [&mechanics, env, parameters, offeredTownIDs](std::optional<int32_t> reply) -> void
 		{
 			if(reply.has_value())
 			{
 				ObjectInstanceID townId(*reply);
+				if(!vstd::contains(offeredTownIDs, townId))
+				{
+					env->complain("Invalid town selected in reinforcement dialog");
+					return;
+				}
 
 				const CGObjectInstance * object = env->getCb()->getObj(townId, true);
 				if(object == nullptr)
@@ -83,8 +94,7 @@ ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, con
 		request.description.appendLocalString(EMetaText::JK_TXT, 41);
 		request.icon = Component(ComponentType::SPELL, owner->id);
 
-		for(const auto * town : towns)
-			request.objects.push_back(town->id);
+		request.objects = offeredTownIDs;
 
 		env->genericQuery(&request, request.player, queryCallback);
 		return ESpellCastResult::PENDING;
@@ -110,10 +120,13 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 	}
 	else if(env->getMap()->isInTheMap(parameters.pos))
 	{
-		const TerrainTile & tile = env->getMap()->getTile(parameters.pos);
-		ObjectInstanceID topObjID = tile.topVisitableObj(false);
-		const CGObjectInstance * topObj = env->getMap()->getObject(topObjID);
-		destination = dynamic_cast<const CGTownInstance *>(topObj);
+		auto selectedTown = std::find_if(towns.begin(), towns.end(), [&parameters](const CGTownInstance * town)
+		{
+			return town->visitablePos() == parameters.pos;
+		});
+
+		if(selectedTown != towns.end())
+			destination = *selectedTown;
 	}
 
 	if(destination == nullptr)

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -1,0 +1,165 @@
+/*
+ * ReinforcementsEffect.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+#include "ReinforcementsEffect.h"
+
+#include "AdventureSpellMechanics.h"
+
+#include "../CSpellHandler.h"
+
+#include "../../CPlayerState.h"
+#include "../../callback/IGameInfoCallback.h"
+#include "../../mapObjects/CGHeroInstance.h"
+#include "../../mapObjects/CGTownInstance.h"
+#include "../../mapping/CMap.h"
+#include "../../networkPacks/PacksForClient.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+ReinforcementsEffect::ReinforcementsEffect(const CSpell * s, const JsonNode & config)
+	: owner(s)
+	, allowTownSelection(config["allowTownSelection"].Bool())
+{
+}
+
+ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const
+{
+	std::vector<const CGTownInstance *> towns = getPossibleTowns(env, parameters);
+
+	if(!parameters.caster->getHeroCaster())
+	{
+		env->complain("Not a hero caster!");
+		return ESpellCastResult::ERROR;
+	}
+
+	if(towns.empty())
+	{
+		InfoWindow iw;
+		iw.player = parameters.caster->getCasterOwner();
+		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 124);
+		env->apply(iw);
+		return ESpellCastResult::CANCEL;
+	}
+
+	if(!parameters.pos.isValid() && allowTownSelection)
+	{
+		auto queryCallback = [&mechanics, env, parameters](std::optional<int32_t> reply) -> void
+		{
+			if(reply.has_value())
+			{
+				ObjectInstanceID townId(*reply);
+
+				const CGObjectInstance * object = env->getCb()->getObj(townId, true);
+				if(object == nullptr)
+				{
+					env->complain("Invalid object instance selected");
+					return;
+				}
+
+				if(!dynamic_cast<const CGTownInstance *>(object))
+				{
+					env->complain("Object instance is not town");
+					return;
+				}
+
+				AdventureSpellCastParameters nextCast;
+				nextCast.caster = parameters.caster;
+				nextCast.pos = object->visitablePos();
+				mechanics.performCast(env, nextCast);
+			}
+		};
+
+		MapObjectSelectDialog request;
+		request.player = parameters.caster->getCasterOwner();
+		request.title.appendLocalString(EMetaText::JK_TXT, 40);
+		request.description.appendLocalString(EMetaText::JK_TXT, 41);
+		request.icon = Component(ComponentType::SPELL, owner->id);
+
+		for(const auto * town : towns)
+			request.objects.push_back(town->id);
+
+		env->genericQuery(&request, request.player, queryCallback);
+		return ESpellCastResult::PENDING;
+	}
+
+	return ESpellCastResult::OK;
+}
+
+ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
+{
+	const CGTownInstance * destination = nullptr;
+	std::vector<const CGTownInstance *> towns = getPossibleTowns(env, parameters);
+
+	if(!parameters.caster->getHeroCaster())
+	{
+		env->complain("Not a hero caster!");
+		return ESpellCastResult::ERROR;
+	}
+
+	if(!allowTownSelection)
+	{
+		destination = findNearestTown(parameters, towns);
+	}
+	else if(env->getMap()->isInTheMap(parameters.pos))
+	{
+		const TerrainTile & tile = env->getMap()->getTile(parameters.pos);
+		ObjectInstanceID topObjID = tile.topVisitableObj(false);
+		const CGObjectInstance * topObj = env->getMap()->getObject(topObjID);
+		destination = dynamic_cast<const CGTownInstance *>(topObj);
+	}
+
+	if(destination == nullptr)
+	{
+		env->complain("Failed to find destination town for reinforcements");
+		return ESpellCastResult::ERROR;
+	}
+
+	env->showGarrisonDialog(destination->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true);
+	return ESpellCastResult::OK;
+}
+
+const CGTownInstance * ReinforcementsEffect::findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool) const
+{
+	if(pool.empty() || !parameters.caster->getHeroCaster())
+		return nullptr;
+
+	auto nearest = pool.cbegin();
+	si32 distance = (*nearest)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
+
+	for(auto iter = nearest + 1; iter != pool.cend(); ++iter)
+	{
+		si32 currentDistance = (*iter)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
+
+		if(currentDistance < distance)
+		{
+			nearest = iter;
+			distance = currentDistance;
+		}
+	}
+
+	return *nearest;
+}
+
+std::vector<const CGTownInstance *> ReinforcementsEffect::getPossibleTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
+{
+	std::vector<const CGTownInstance *> result;
+
+	const TeamState * team = env->getCb()->getPlayerTeam(parameters.caster->getCasterOwner());
+	for(const auto & color : team->players)
+	{
+		for(const auto * town : env->getCb()->getPlayerState(color)->getTowns())
+			result.push_back(town);
+	}
+
+	return result;
+}
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -90,8 +90,8 @@ ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, con
 
 		MapObjectSelectDialog request;
 		request.player = parameters.caster->getCasterOwner();
-		request.title.appendLocalString(EMetaText::JK_TXT, 40);
-		request.description.appendLocalString(EMetaText::JK_TXT, 41);
+		request.title.appendTextID("vcmi.spells.reinforcements.selectTown.title");
+		request.description.appendTextID("vcmi.spells.reinforcements.selectTown.description");
 		request.icon = Component(ComponentType::SPELL, owner->id);
 
 		request.objects = offeredTownIDs;

--- a/lib/spells/adventure/ReinforcementsEffect.h
+++ b/lib/spells/adventure/ReinforcementsEffect.h
@@ -1,0 +1,34 @@
+/*
+ * ReinforcementsEffect.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include "AdventureSpellEffect.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+class CGTownInstance;
+
+class DLL_LINKAGE ReinforcementsEffect final : public IAdventureSpellEffect
+{
+	const CSpell * owner;
+	bool allowTownSelection;
+
+public:
+	ReinforcementsEffect(const CSpell * s, const JsonNode & config);
+
+private:
+	ESpellCastResult applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const override;
+	ESpellCastResult beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const override;
+	const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool) const;
+	std::vector<const CGTownInstance *> getPossibleTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const;
+};
+
+VCMI_LIB_NAMESPACE_END

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3461,6 +3461,18 @@ bool CGameHandler::isAllowedExchange(ObjectInstanceID id1, ObjectInstanceID id2)
 	if (id1 == id2)
 		return true;
 
+	for(const auto & query : queries->allQueries())
+	{
+		const auto * garrisonQuery = dynamic_cast<const CGarrisonDialogQuery *>(query.get());
+		if(garrisonQuery == nullptr)
+			continue;
+
+		const bool matchesForward = garrisonQuery->exchangingArmies[0]->id == id1 && garrisonQuery->exchangingArmies[1]->id == id2;
+		const bool matchesBackward = garrisonQuery->exchangingArmies[0]->id == id2 && garrisonQuery->exchangingArmies[1]->id == id1;
+		if(matchesForward || matchesBackward)
+			return true;
+	}
+
 	const CGObjectInstance *o1 = gameInfo().getObj(id1);
 	const CGObjectInstance *o2 = gameInfo().getObj(id2);
 	if (!o1 || !o2)

--- a/server/ServerSpellCastEnvironment.cpp
+++ b/server/ServerSpellCastEnvironment.cpp
@@ -99,6 +99,11 @@ void ServerSpellCastEnvironment::createBoat(const int3 & visitablePosition, Boat
 	return gh->createBoat(visitablePosition, type, initiator);
 }
 
+void ServerSpellCastEnvironment::showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits)
+{
+	gh->showGarrisonDialog(upobj, hid, removableUnits);
+}
+
 void ServerSpellCastEnvironment::genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback)
 {
 	auto query = std::make_shared<CGenericQuery>(gh, color, callback);

--- a/server/ServerSpellCastEnvironment.h
+++ b/server/ServerSpellCastEnvironment.h
@@ -38,6 +38,7 @@ public:
 	const IGameInfoCallback * getCb() const override;
 	bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) override;
 	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override;
+	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override;
 	void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) override;
 private:
 	CGameHandler * gh;

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -134,6 +134,10 @@ public:
 		return false;
 	}
 
+	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override
+	{
+	}
+
 	void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) override
 	{
 		//todo:


### PR DESCRIPTION
### Motivation
- Add a new adventure spell that summons reinforcements from town garrisons with optional town selection and per-level casts per day options.
- Extend data validation to accept the new `reinforcements` adventure effect type in spell definitions.
- Provide server-side plumbing so the spell can open the garrison dialog and allow safe stack exchanges while the dialog is active.

### Description
- Add a `core:reinforcements` entry to `Mods/vcmi/Content/config/spells.json` with configurable `castsPerDay`, `allowTownSelection`, level descriptions, and cost.
- Extend the spell schema `config/schemas/spell.json` to include `"reinforcements"` in the `adventureEffect.type` enum and add validation for `allowTownSelection` and `castsPerDay` properties.
- Implement `ReinforcementsEffect` (`lib/spells/adventure/ReinforcementsEffect.h/.cpp`) that collects possible towns, allows optional town selection via `genericQuery`, selects nearest town when needed, and triggers the garrison dialog through the spell environment.
- Wire the new effect into the engine by adding sources/headers to `lib/CMakeLists.txt` and registering it in `AdventureSpellMechanics::createAdventureEffect`.
- Add `showGarrisonDialog` to the `SpellCastEnvironment` interface (`lib/spells/ISpellMechanics.h`) and implement/forward it in `ServerSpellCastEnvironment.h/.cpp` to call `CGameHandler::showGarrisonDialog` on the server.
- Update server logic in `server/CGameHandler.cpp` to treat active `CGarrisonDialogQuery` queries as allowing stack exchanges during the garrison dialog (`isAllowedExchange`).

### Testing
- Performed a full project build with the updated CMake configuration which completed successfully.
- Ran the project's automated test suite related to spells and server logic, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d988522f8c832dbf66d5ae37480e09)