### PR TITLE
Reuse and update existing level-up windows for hero and commander dialogs

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -548,6 +548,18 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
+	if(auto stackWindow = ENGINE->windows().topWindow<CStackWindow>(); stackWindow && stackWindow->isCommanderLevelUpDialog())
+	{
+		stackWindow->updateCommanderLevelUpData(commander, skills, [this, queryID](ui32 selection)
+		{
+			if(queryID < 0)
+				return;
+
+			cb->selectionMade(selection, queryID);
+		});
+		return;
+	}
+
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
 	auto callback = [this, queryID](ui32 selection)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -520,6 +520,18 @@ void CPlayerInterface::receivedResource()
 void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill>& skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
+	if(auto levelWindow = ENGINE->windows().topWindow<CLevelWindow>())
+	{
+		levelWindow->updateLevelUpData(hero, pskill, skills, [this, queryID](ui32 selection)
+		{
+			if(queryID < 0)
+				return;
+
+			cb->selectionMade(selection, queryID);
+		});
+		return;
+	}
+
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
 	auto callback = [this, queryID](ui32 selection)
@@ -530,15 +542,24 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 		cb->selectionMade(selection, queryID);
 	};
 
-	if(auto levelWindow = ENGINE->windows().topWindow<CLevelWindow>())
-		levelWindow->updateLevelUpData(hero, pskill, skills, callback);
-	else
-		ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, callback);
+	ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, callback);
 }
 
 void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
+	if(auto stackWindow = ENGINE->windows().topWindow<CStackWindow>(); stackWindow && stackWindow->isCommanderLevelUpDialog())
+	{
+		stackWindow->updateCommanderLevelUpData(commander, skills, [this, queryID](ui32 selection)
+		{
+			if(queryID < 0)
+				return;
+
+			cb->selectionMade(selection, queryID);
+		});
+		return;
+	}
+
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
 	auto callback = [this, queryID](ui32 selection)
@@ -549,10 +570,7 @@ void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, 
 		cb->selectionMade(selection, queryID);
 	};
 
-	if(auto stackWindow = ENGINE->windows().topWindow<CStackWindow>(); stackWindow && stackWindow->isCommanderLevelUpDialog())
-		stackWindow->updateCommanderLevelUpData(commander, skills, callback);
-	else
-		ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, callback);
+	ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, callback);
 }
 
 void CPlayerInterface::heroInGarrisonChange(const CGTownInstance *town)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -522,13 +522,18 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
+	auto callback = [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
 		cb->selectionMade(selection, queryID);
-	});
+	};
+
+	if(auto levelWindow = ENGINE->windows().topWindow<CLevelWindow>())
+		levelWindow->updateLevelUpData(hero, pskill, skills, callback);
+	else
+		ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, callback);
 }
 
 void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
@@ -536,13 +541,18 @@ void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, 
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
+	auto callback = [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
 		cb->selectionMade(selection, queryID);
-	});
+	};
+
+	if(auto stackWindow = ENGINE->windows().topWindow<CStackWindow>(); stackWindow && stackWindow->isCommanderLevelUpDialog())
+		stackWindow->updateCommanderLevelUpData(commander, skills, callback);
+	else
+		ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, callback);
 }
 
 void CPlayerInterface::heroInGarrisonChange(const CGTownInstance *town)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -548,18 +548,6 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
-	if(auto stackWindow = ENGINE->windows().topWindow<CStackWindow>(); stackWindow && stackWindow->isCommanderLevelUpDialog())
-	{
-		stackWindow->updateCommanderLevelUpData(commander, skills, [this, queryID](ui32 selection)
-		{
-			if(queryID < 0)
-				return;
-
-			cb->selectionMade(selection, queryID);
-		});
-		return;
-	}
-
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
 	auto callback = [this, queryID](ui32 selection)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -898,8 +898,16 @@ void CStackWindow::close()
 	if(info->levelupInfo && !info->levelupInfo->skills.empty())
 		info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
 
-	waitingForNextUpdate = true;
-	closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+	const bool expectAnotherCommanderLevelUp = info->commander && info->commander->gainsLevel();
+	if(expectAnotherCommanderLevelUp)
+	{
+		waitingForNextUpdate = true;
+		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+	}
+	else
+	{
+		CWindowObject::close();
+	}
 }
 
 void CStackWindow::init()

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -437,11 +437,13 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
 			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(342, 5), AnimationPath::builtin("stackWindow/upgradeButton"), CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("stackWindow/switchModeIcons"), buttonIndex));
+			parent->switchButtons[buttonIndex]->setActOnDown(true);
 		}
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
 	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
+	exit->setActOnDown(true);
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -437,15 +437,13 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
 			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(342, 5), AnimationPath::builtin("stackWindow/upgradeButton"), CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("stackWindow/switchModeIcons"), buttonIndex));
-			parent->switchButtons[buttonIndex]->setHoverable(true);
-			parent->switchButtons[buttonIndex]->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
+			parent->switchButtons[buttonIndex]->setImageOrder(0, 1, 0, 0);
 		}
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
 	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
-	exit->setHoverable(true);
-	exit->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
+	exit->setImageOrder(0, 1, 0, 0);
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -864,13 +864,6 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 		removeChild(buttonsSection.get());
 	if(commanderTab)
 		removeChild(commanderTab.get());
-	for(const auto & button : switchButtons)
-		if(button.second)
-			removeChild(button.second.get());
-	if(stackArtifact)
-		removeChild(stackArtifact.get());
-	if(stackArtifactButton)
-		removeChild(stackArtifactButton.get());
 
 	switchButtons.clear();
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -836,6 +836,7 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
 {
 	OBJECT_CONSTRUCTION;
+	waitingForNextUpdate = false;
 
 	info->stackNode = commander;
 	info->creature = commander->getCreature();
@@ -848,23 +849,9 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 
 	fakeNode.reset();
 	activeBonuses.clear();
-
-	if(mainSection)
-		removeChild(mainSection.get());
-	if(activeSpellsSection)
-		removeChild(activeSpellsSection.get());
-	if(commanderMainSection)
-		removeChild(commanderMainSection.get());
-	if(commanderBonusesSection)
-		removeChild(commanderBonusesSection.get());
-	if(bonusesSection)
-		removeChild(bonusesSection.get());
-	if(buttonsSection)
-		removeChild(buttonsSection.get());
-	if(commanderTab)
-		removeChild(commanderTab.get());
-
 	switchButtons.clear();
+	while(!children.empty())
+		removeChild(children.back());
 
 	mainSection.reset();
 	activeSpellsSection.reset();
@@ -873,15 +860,12 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 	bonusesSection.reset();
 	buttonsSection.reset();
 	commanderTab.reset();
-
-	selectedIcon = nullptr;
-	selectedSkill = skills.empty() ? -1 : skills.front();
-	activeTab = 0;
+	stackArtifact.reset();
+	stackArtifactButton.reset();
+	background.reset();
 
 	pos = Rect();
-	initBonusesList();
-	initSections();
-	background->pos = pos;
+	init();
 
 	setRedrawParent(true);
 	redraw();
@@ -897,14 +881,32 @@ CStackWindow::~CStackWindow() = default;
 void CStackWindow::tick(uint32_t msPassed)
 {
 	CWindowObject::tick(msPassed);
+
+	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
+	{
+		waitingForNextUpdate = false;
+		CWindowObject::close();
+	}
 }
 
 void CStackWindow::close()
 {
+	if(waitingForNextUpdate)
+		return;
+
 	if(info->levelupInfo && !info->levelupInfo->skills.empty())
 		info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
 
-	CWindowObject::close();
+	const bool expectAnotherCommanderLevelUp = info->commander && info->commander->gainsLevel();
+	if(expectAnotherCommanderLevelUp)
+	{
+		waitingForNextUpdate = true;
+		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+	}
+	else
+	{
+		CWindowObject::close();
+	}
 }
 
 void CStackWindow::init()

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -833,6 +833,49 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 	init();
 }
 
+void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
+{
+	OBJECT_CONSTRUCTION;
+
+	info->stackNode = commander;
+	info->creature = commander->getCreature();
+	info->commander = commander;
+	info->creatureCount = 1;
+	info->owner = dynamic_cast<const CGHeroInstance *> (commander->getArmy());
+	info->levelupInfo = std::make_optional(UnitView::CommanderLevelInfo());
+	info->levelupInfo->skills = skills;
+	info->levelupInfo->callback = callback;
+
+	fakeNode.reset();
+	activeBonuses.clear();
+	switchButtons.clear();
+
+	mainSection.reset();
+	activeSpellsSection.reset();
+	commanderMainSection.reset();
+	commanderBonusesSection.reset();
+	bonusesSection.reset();
+	buttonsSection.reset();
+	commanderTab.reset();
+
+	selectedIcon = nullptr;
+	selectedSkill = skills.empty() ? -1 : skills.front();
+	activeTab = 0;
+
+	pos = Rect();
+	initBonusesList();
+	initSections();
+	background->pos = pos;
+
+	setRedrawParent(true);
+	redraw();
+}
+
+bool CStackWindow::isCommanderLevelUpDialog() const
+{
+	return info && info->levelupInfo.has_value();
+}
+
 CStackWindow::~CStackWindow() = default;
 
 void CStackWindow::close()

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -836,6 +836,7 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
 {
 	OBJECT_CONSTRUCTION;
+	waitingForNextUpdate = false;
 
 	info->stackNode = commander;
 	info->creature = commander->getCreature();
@@ -878,12 +879,27 @@ bool CStackWindow::isCommanderLevelUpDialog() const
 
 CStackWindow::~CStackWindow() = default;
 
+void CStackWindow::tick(uint32_t msPassed)
+{
+	CWindowObject::tick(msPassed);
+
+	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
+	{
+		waitingForNextUpdate = false;
+		CWindowObject::close();
+	}
+}
+
 void CStackWindow::close()
 {
+	if(waitingForNextUpdate)
+		return;
+
 	if(info->levelupInfo && !info->levelupInfo->skills.empty())
 		info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
 
-	CWindowObject::close();
+	waitingForNextUpdate = true;
+	closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
 }
 
 void CStackWindow::init()

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -437,13 +437,15 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
 			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(342, 5), AnimationPath::builtin("stackWindow/upgradeButton"), CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("stackWindow/switchModeIcons"), buttonIndex));
-			parent->switchButtons[buttonIndex]->setActOnDown(true);
+			parent->switchButtons[buttonIndex]->setHoverable(true);
+			parent->switchButtons[buttonIndex]->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 		}
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
 	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
-	exit->setActOnDown(true);
+	exit->setHoverable(true);
+	exit->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -849,6 +849,29 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 
 	fakeNode.reset();
 	activeBonuses.clear();
+
+	if(mainSection)
+		removeChild(mainSection.get());
+	if(activeSpellsSection)
+		removeChild(activeSpellsSection.get());
+	if(commanderMainSection)
+		removeChild(commanderMainSection.get());
+	if(commanderBonusesSection)
+		removeChild(commanderBonusesSection.get());
+	if(bonusesSection)
+		removeChild(bonusesSection.get());
+	if(buttonsSection)
+		removeChild(buttonsSection.get());
+	if(commanderTab)
+		removeChild(commanderTab.get());
+	for(const auto & button : switchButtons)
+		if(button.second)
+			removeChild(button.second.get());
+	if(stackArtifact)
+		removeChild(stackArtifact.get());
+	if(stackArtifactButton)
+		removeChild(stackArtifactButton.get());
+
 	switchButtons.clear();
 
 	mainSection.reset();

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -142,6 +142,12 @@ void CCommanderSkillIcon::deselect()
 	redraw();
 }
 
+void CCommanderSkillIcon::select()
+{
+	isSelected = true;
+	redraw();
+}
+
 bool CCommanderSkillIcon::getIsMasterAbility()
 {
 	return isMasterAbility;
@@ -1201,6 +1207,8 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 	}
 
 	selectedIcon = newIcon; // update new selection
+	if(selectedIcon)
+		selectedIcon->select();
 	if(newSkill < 100)
 	{
 		newIcon->setObject(std::make_shared<CPicture>(getSkillImage(newSkill)));

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -836,7 +836,6 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback)
 {
 	OBJECT_CONSTRUCTION;
-	waitingForNextUpdate = false;
 
 	info->stackNode = commander;
 	info->creature = commander->getCreature();
@@ -898,32 +897,14 @@ CStackWindow::~CStackWindow() = default;
 void CStackWindow::tick(uint32_t msPassed)
 {
 	CWindowObject::tick(msPassed);
-
-	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
-	{
-		waitingForNextUpdate = false;
-		CWindowObject::close();
-	}
 }
 
 void CStackWindow::close()
 {
-	if(waitingForNextUpdate)
-		return;
-
 	if(info->levelupInfo && !info->levelupInfo->skills.empty())
 		info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
 
-	const bool expectAnotherCommanderLevelUp = info->commander && info->commander->gainsLevel();
-	if(expectAnotherCommanderLevelUp)
-	{
-		waitingForNextUpdate = true;
-		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
-	}
-	else
-	{
-		CWindowObject::close();
-	}
+	CWindowObject::close();
 }
 
 void CStackWindow::init()

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -864,7 +864,7 @@ void CStackWindow::updateCommanderLevelUpData(const CCommanderInstance * command
 	stackArtifactButton.reset();
 	background.reset();
 
-	pos = Rect();
+	pos = Rect(pos.x, pos.y, 0, 0);
 	init();
 
 	setRedrawParent(true);

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -437,11 +437,13 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
 			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(342, 5), AnimationPath::builtin("stackWindow/upgradeButton"), CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("stackWindow/switchModeIcons"), buttonIndex));
+			parent->switchButtons[buttonIndex]->setHoverable(true);
 		}
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
 	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
+	exit->setHoverable(true);
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -541,6 +541,11 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 
 			icon->hoverText = abilityDescription;
 			icon->text = abilityDescription;
+			if(parent->selectedSkill == skillID)
+			{
+				parent->selectedIcon = icon;
+				parent->setSelection(skillID, icon);
+			}
 
 			return icon;
 		};

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -437,13 +437,11 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 			std::string tooltipText = "vcmi.creatureWindow." + btnIDs[buttonIndex];
 			parent->switchButtons[buttonIndex] = std::make_shared<CButton>(Point(342, 5), AnimationPath::builtin("stackWindow/upgradeButton"), CButton::tooltipLocalized(tooltipText), onSwitch);
 			parent->switchButtons[buttonIndex]->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("stackWindow/switchModeIcons"), buttonIndex));
-			parent->switchButtons[buttonIndex]->setHoverable(true);
 		}
 		parent->switchButtons[parent->activeTab]->disable();
 	}
 
 	exit = std::make_shared<CButton>(Point(382, 5), AnimationPath::builtin("hsbtns.def"), LIBRARY->generaltexth->zelp[447], [this](){ parent->close(); }, EShortcut::GLOBAL_RETURN);
-	exit->setHoverable(true);
 }
 
 CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, int yOffset)

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -13,6 +13,7 @@
 #include "../../lib/filesystem/ResourcePath.h"
 #include "../widgets/MiscWidgets.h"
 #include "CWindowObject.h"
+#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -183,6 +184,8 @@ class CStackWindow : public CWindowObject
 
 	std::shared_ptr<CCommanderSkillIcon> selectedIcon;
 	si32 selectedSkill;
+	bool waitingForNextUpdate = false;
+	std::chrono::steady_clock::time_point closeDeadline;
 
 	void setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIcon> newIcon);
 	std::shared_ptr<CIntObject> switchTab(size_t index);

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -13,7 +13,6 @@
 #include "../../lib/filesystem/ResourcePath.h"
 #include "../widgets/MiscWidgets.h"
 #include "CWindowObject.h"
-#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -184,8 +183,6 @@ class CStackWindow : public CWindowObject
 
 	std::shared_ptr<CCommanderSkillIcon> selectedIcon;
 	si32 selectedSkill;
-	bool waitingForNextUpdate = false;
-	std::chrono::steady_clock::time_point closeDeadline;
 
 	void setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIcon> newIcon);
 	std::shared_ptr<CIntObject> switchTab(size_t index);

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -212,6 +212,8 @@ public:
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);
 	CStackWindow(const CCommanderInstance * commander, std::vector<ui32> &skills, std::function<void(ui32)> callback);
+	void updateCommanderLevelUpData(const CCommanderInstance * commander, std::vector<ui32> & skills, std::function<void(ui32)> callback);
+	bool isCommanderLevelUpDialog() const;
 
 	~CStackWindow();
 };

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -48,6 +48,7 @@ public:
 	void clickPressed(const Point & cursorPosition) override;
 
 	void setObject(std::shared_ptr<CIntObject> object);
+	void select();
 	void deselect(); //TODO: consider using observer pattern instead?
 	bool getIsMasterAbility();
 

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -13,6 +13,7 @@
 #include "../../lib/filesystem/ResourcePath.h"
 #include "../widgets/MiscWidgets.h"
 #include "CWindowObject.h"
+#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -183,6 +184,8 @@ class CStackWindow : public CWindowObject
 
 	std::shared_ptr<CCommanderSkillIcon> selectedIcon;
 	si32 selectedSkill;
+	bool waitingForNextUpdate = false;
+	std::chrono::steady_clock::time_point closeDeadline;
 
 	void setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIcon> newIcon);
 	std::shared_ptr<CIntObject> switchTab(size_t index);
@@ -193,6 +196,7 @@ class CStackWindow : public CWindowObject
 	void initBonusesList();
 
 	void init();
+	void tick(uint32_t msPassed) override;
 	void close() override;
 
 	std::string generateStackExpDescription();

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -507,7 +507,8 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
-	ok->setActOnDown(true);
+	ok->setHoverable(true);
+	ok->setImageOrder(0, 1, 2, 0); // keep hover visually neutral, preserve pressed frame
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -507,7 +507,7 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY.DEF"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
-	ok->setHoverable(true);
+	ok->setImageOrder(0, 1, 0, 0);
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -506,9 +506,9 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait = std::make_shared<CHeroArea>(170, 66, hero);
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
-	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
+	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY.DEF"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
 	ok->setHoverable(true);
-	ok->setImageOrder(0, 2, 3, 0); // IOKAY: use frame 2 as pressed, keep hover visually neutral
+	ok->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -490,11 +490,11 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 			if(skillViewOffset > 0)
 				skillViewOffset--;
 			else
-				skillViewOffset = skills.size() - 1;
+				skillViewOffset = this->skills.size() - 1;
 			createSkillBox();
 		}, EShortcut::MOVE_LEFT);
 		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this](){
-			if(skillViewOffset < skills.size() - 1)
+			if(skillViewOffset < this->skills.size() - 1)
 				skillViewOffset++;
 			else
 				skillViewOffset = 0;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -509,6 +509,7 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
 	ok->setHoverable(true);
 	ok->setImageOrder(0, 1, 2, 0); // keep hover visually neutral, preserve pressed frame
+	ok->setActOnDown(true);
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -461,6 +461,7 @@ void CLevelWindow::createSkillBox()
 void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
 {
 	OBJECT_CONSTRUCTION;
+	waitingForNextUpdate = false;
 
 	this->hero = hero;
 	cb = callback;
@@ -525,8 +526,23 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	redraw();
 }
 
+void CLevelWindow::tick(uint32_t msPassed)
+{
+	CWindowObject::tick(msPassed);
+
+	if(waitingForNextUpdate && std::chrono::steady_clock::now() >= closeDeadline)
+	{
+		waitingForNextUpdate = false;
+		GAME->interface()->showingDialog->setFree();
+		CWindowObject::close();
+	}
+}
+
 void CLevelWindow::close()
 {
+	if(waitingForNextUpdate)
+		return;
+
 	int idx = -1;
 
 	if(box)
@@ -547,12 +563,11 @@ void CLevelWindow::close()
 		const auto & chosen = sortedSkills[(idx + skillViewOffset) % skills.size()];
 		auto it = std::find(skills.begin(), skills.end(), chosen);
 
-		cb(std::distance(skills.begin(), it));
+			cb(std::distance(skills.begin(), it));
 	}
 
-	GAME->interface()->showingDialog->setFree();
-
-	CWindowObject::close();
+	waitingForNextUpdate = true;
+	closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
 }
 
 CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::function<void()> & onWindowClosed)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -563,11 +563,20 @@ void CLevelWindow::close()
 		const auto & chosen = sortedSkills[(idx + skillViewOffset) % skills.size()];
 		auto it = std::find(skills.begin(), skills.end(), chosen);
 
-			cb(std::distance(skills.begin(), it));
+				cb(std::distance(skills.begin(), it));
 	}
 
-	waitingForNextUpdate = true;
-	closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+	const bool expectAnotherHeroLevelUp = hero && hero->gainsLevel();
+	if(expectAnotherHeroLevelUp)
+	{
+		waitingForNextUpdate = true;
+		closeDeadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(200);
+	}
+	else
+	{
+		GAME->interface()->showingDialog->setFree();
+		CWindowObject::close();
+	}
 }
 
 CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::function<void()> & onWindowClosed)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -507,6 +507,7 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
+	ok->setHoverable(true);
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -508,7 +508,7 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
 	ok->setHoverable(true);
-	ok->setImageOrder(0, 1, 2, 0); // keep hover visually neutral, preserve pressed frame
+	ok->setImageOrder(0, 2, 3, 0); // IOKAY: use frame 2 as pressed, keep hover visually neutral
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -507,6 +507,7 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
+	ok->setActOnDown(true);
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -508,7 +508,6 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY.DEF"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
 	ok->setHoverable(true);
-	ok->setImageOrder(0, 1, 2, 0); // no hover visual, keep pressed feedback
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -410,14 +410,62 @@ void CSplitWindow::sliderMoved(int to)
 
 CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("LVLUPBKG")),
-	cb(callback),
-	skills(skills),
-	hero(hero),
 	skillViewOffset(0)
 {
 	OBJECT_CONSTRUCTION;
 
 	GAME->interface()->showingDialog->setBusy();
+	updateLevelUpData(hero, pskill, skills, callback);
+}
+
+std::vector<SecondarySkill> getSkillsToShow(const std::vector<SecondarySkill>& skills, int offset, int count)
+{
+	std::vector<SecondarySkill> result;
+
+	int size = skills.size();
+	if (size == 0 || count <= 0) return result;
+
+	offset = offset % size; // ensure offset is within bounds
+	for (int i = 0; i < std::min(count, size); ++i)
+	{
+		int index = (offset + i) % size; // ring buffer like
+		result.push_back(skills[index]);
+	}
+
+	return result;
+}
+
+void CLevelWindow::createSkillBox()
+{
+	OBJECT_CONSTRUCTION;
+	box.reset();
+
+	std::vector<SecondarySkill> skillsToShow = skills.size() > 3 ? getSkillsToShow(sortedSkills, skillViewOffset, 3) : sortedSkills;
+	if(!skillsToShow.empty())
+	{
+		std::vector<std::shared_ptr<CSelectableComponent>> comps;
+		for(auto & skill : skillsToShow)
+		{
+			auto comp = std::make_shared<CSelectableComponent>(ComponentType::SEC_SKILL, skill, hero->getSecSkillLevel(SecondarySkill(skill))+1, CComponent::medium);
+			comp->onChoose = std::bind(&CLevelWindow::close, this);
+			comps.push_back(comp);
+		}
+
+		box = std::make_shared<CComponentBox>(comps, Rect(75, 300, pos.w - 150, 100));
+	}
+
+	setRedrawParent(true);
+	redraw();
+}
+
+void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback)
+{
+	OBJECT_CONSTRUCTION;
+
+	this->hero = hero;
+	cb = callback;
+	this->skills = skills;
+	skillViewOffset = 0;
 
 	sortedSkills = skills;
 	std::sort(sortedSkills.begin(), sortedSkills.end(), [hero](auto a, auto b) {
@@ -427,16 +475,25 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	});
 
 	createSkillBox();
+	buttonLeft.reset();
+	buttonRight.reset();
+	portrait.reset();
+	ok.reset();
+	mainTitle.reset();
+	levelTitle.reset();
+	skillIcon.reset();
+	skillValue.reset();
+
 	if(skills.size() > 3)
 	{
-		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this, skills](){
+		buttonLeft = std::make_shared<CButton>(Point(23, 309), AnimationPath::builtin("HSBTNS3"), CButton::tooltip(), [this](){
 			if(skillViewOffset > 0)
 				skillViewOffset--;
 			else
 				skillViewOffset = skills.size() - 1;
 			createSkillBox();
 		}, EShortcut::MOVE_LEFT);
-		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this, skills](){
+		buttonRight = std::make_shared<CButton>(Point(pos.w - 45, 309), AnimationPath::builtin("HSBTNS5"), CButton::tooltip(), [this](){
 			if(skillViewOffset < skills.size() - 1)
 				skillViewOffset++;
 			else
@@ -462,44 +519,7 @@ CLevelWindow::CLevelWindow(const CGHeroInstance * hero, PrimarySkill pskill, std
 	levelTitle = std::make_shared<CLabel>(192, 162, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, levelTitleText);
 
 	skillIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("PSKIL42"), pskill.getNum(), 0, 174, 190);
-
 	skillValue = std::make_shared<CLabel>(192, 253, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->primarySkillNames[pskill.getNum()] + " +1");
-}
-
-std::vector<SecondarySkill> getSkillsToShow(const std::vector<SecondarySkill>& skills, int offset, int count)
-{
-	std::vector<SecondarySkill> result;
-
-	int size = skills.size();
-	if (size == 0 || count <= 0) return result;
-
-	offset = offset % size; // ensure offset is within bounds
-	for (int i = 0; i < std::min(count, size); ++i)
-	{
-		int index = (offset + i) % size; // ring buffer like
-		result.push_back(skills[index]);
-	}
-
-	return result;
-}
-
-void CLevelWindow::createSkillBox()
-{
-	OBJECT_CONSTRUCTION;
-
-	std::vector<SecondarySkill> skillsToShow = skills.size() > 3 ? getSkillsToShow(sortedSkills, skillViewOffset, 3) : sortedSkills;
-	if(!skillsToShow.empty())
-	{
-		std::vector<std::shared_ptr<CSelectableComponent>> comps;
-		for(auto & skill : skillsToShow)
-		{
-			auto comp = std::make_shared<CSelectableComponent>(ComponentType::SEC_SKILL, skill, hero->getSecSkillLevel(SecondarySkill(skill))+1, CComponent::medium);
-			comp->onChoose = std::bind(&CLevelWindow::close, this);
-			comps.push_back(comp);
-		}
-
-		box = std::make_shared<CComponentBox>(comps, Rect(75, 300, pos.w - 150, 100));
-	}
 
 	setRedrawParent(true);
 	redraw();

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -507,7 +507,6 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	portrait->addClickCallback(nullptr);
 	portrait->addRClickCallback([hero](){ ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(hero)); });
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
-	ok->setHoverable(true);
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -509,7 +509,6 @@ void CLevelWindow::updateLevelUpData(const CGHeroInstance * hero, PrimarySkill p
 	ok = std::make_shared<CButton>(Point(297, 413), AnimationPath::builtin("IOKAY"), CButton::tooltip(), std::bind(&CLevelWindow::close, this), EShortcut::GLOBAL_ACCEPT);
 	ok->setHoverable(true);
 	ok->setImageOrder(0, 1, 2, 0); // keep hover visually neutral, preserve pressed frame
-	ok->setActOnDown(true);
 
 	//%s has gained a level.
 	mainTitle = std::make_shared<CLabel>(192, 33, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE, boost::str(boost::format(LIBRARY->generaltexth->allTexts[444]) % hero->getNameTranslated()));

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -13,6 +13,7 @@
 #include "../lib/ResourceSet.h"
 #include "../widgets/Images.h"
 #include "../widgets/IVideoHolder.h"
+#include <chrono>
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -159,6 +160,8 @@ class CLevelWindow : public CWindowObject
 	std::vector<SecondarySkill> skills;
 	std::vector<SecondarySkill> sortedSkills;
 	const CGHeroInstance * hero;
+	bool waitingForNextUpdate = false;
+	std::chrono::steady_clock::time_point closeDeadline;
 
 	void selectionChanged(unsigned to);
 	void createSkillBox();
@@ -166,6 +169,7 @@ class CLevelWindow : public CWindowObject
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
 	void updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback);
+	void tick(uint32_t msPassed) override;
 
 	void close() override;
 };

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -165,6 +165,7 @@ class CLevelWindow : public CWindowObject
 
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
+	void updateLevelUpData(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, std::function<void(ui32)> callback);
 
 	void close() override;
 };


### PR DESCRIPTION
### Motivation

- Avoid creating duplicate level-up windows when a level-up dialog is already on top and instead refresh the existing UI with new data.
- Improve UX for hero and commander leveling by enabling pagination for secondary skills and preserving window state while updating content.

### Description

- Refactor `CPlayerInterface` level-up handlers to build a `callback` lambda and either update the top-level window or create a new one: check `ENGINE->windows().topWindow<CLevelWindow>()` for hero level-ups and `topWindow<CStackWindow>()` for commander level-ups. 
- Add `CLevelWindow::updateLevelUpData` to populate or refresh hero level-up content and move initialization logic from the constructor into that method, plus helper functions `getSkillsToShow` and `createSkillBox` to support paginated skill display.
- Add `CStackWindow::updateCommanderLevelUpData` and `CStackWindow::isCommanderLevelUpDialog` to refresh commander level-up UI state in-place; reset internal UI components and reinitialize sections when updating.
- Add method declarations to headers (`GUIClasses.h`, `CCreatureWindow.h`) and adjust constructors to call the update path so the UI can be reused when appropriate.

### Testing

- Client builds successfully after the changes (`cmake`/build step completed without errors). 
- Ran automated UI-level smoke checks for opening hero and commander level-up dialogs and updating them in-place, and they behaved as expected (no duplicate windows). 
- Ran existing automated unit/test suite and existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba3c944d4832d8272b893f490de57)