### PR TITLE
Use CMultiLineLabel for hero specialty names to support wrapping

### DIFF
--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -399,7 +399,7 @@ void OptionsTab::CPlayerOptionTooltipBox::genHeroWindow()
 	labelHeroSpeciality = std::make_shared<CLabel>(pos.w / 2 + 4, 117, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, LIBRARY->generaltexth->allTexts[78]);
 
 	imageSpeciality = std::make_shared<CAnimImage>(AnimationPath::builtin("UN44"), (*LIBRARY->heroh)[heroIndex]->imageIndex, 0, pos.w / 2 - 22, 134);
-	labelSpecialityName = std::make_shared<CLabel>(pos.w / 2, 188, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, (*LIBRARY->heroh)[heroIndex]->getSpecialtyNameTranslated());
+	labelSpecialityName = std::make_shared<CMultiLineLabel>(Rect(pos.w / 2 - 90, 184, 180, 24), FONT_SMALL, ETextAlignment::TOPCENTER, Colors::WHITE, (*LIBRARY->heroh)[heroIndex]->getSpecialtyNameTranslated());
 }
 
 void OptionsTab::CPlayerOptionTooltipBox::genBonusWindow()

--- a/client/windows/CHeroOverview.cpp
+++ b/client/windows/CHeroOverview.cpp
@@ -109,7 +109,7 @@ void CHeroOverview::genControls()
 	r = Rect(2 * borderOffset + 44, 6 * borderOffset + yOffset + 278, 235, 44);
 	backgroundRectangles.push_back(std::make_shared<TransparentFilledRectangle>(r.resize(1), rectangleColor, borderColor));
 	labelHeroSpeciality = std::make_shared<CLabel>(r.x + borderOffset, r.y + borderOffset, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::YELLOW, LIBRARY->generaltexth->allTexts[78]);
-	labelSpecialityName = std::make_shared<CLabel>(r.x + borderOffset, r.y + borderOffset + 20, FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, (*LIBRARY->heroh)[heroIdx]->getSpecialtyNameTranslated());
+	labelSpecialityName = std::make_shared<CMultiLineLabel>(Rect(r.x + borderOffset, r.y + borderOffset + 18, r.w - 2 * borderOffset, 22), FONT_SMALL, ETextAlignment::TOPLEFT, Colors::WHITE, (*LIBRARY->heroh)[heroIdx]->getSpecialtyNameTranslated());
 
 	// speciality image
 	r = Rect(borderOffset, 6 * borderOffset + yOffset + 278, 44, 44);

--- a/client/windows/CHeroWindow.cpp
+++ b/client/windows/CHeroWindow.cpp
@@ -139,7 +139,7 @@ CHeroWindow::CHeroWindow(const CGHeroInstance * hero)
 
 	specImage = std::make_shared<CAnimImage>(AnimationPath::builtin("UN44"), 0, 0, 18, 180);
 	specArea = std::make_shared<LRClickableAreaWText>(Rect(18, 180, 136, 42), LIBRARY->generaltexth->heroscrn[27]);
-	specName = std::make_shared<CLabel>(69, 205);
+	specName = std::make_shared<CMultiLineLabel>(Rect(64, 199, 88, 24), FONT_SMALL, ETextAlignment::TOPCENTER, Colors::WHITE);
 
 	expArea = std::make_shared<LRClickableAreaWText>(Rect(18, 228, 136, 42), LIBRARY->generaltexth->heroscrn[9]);
 	morale = std::make_shared<MoraleLuckBox>(true, Rect(175, 179, 53, 45));


### PR DESCRIPTION
### Motivation

- Long translated specialty names can be clipped or misaligned in various hero-related UI windows, so specialty labels need to support wrapping and precise layout.

### Description

- Replaced single-line `CLabel` instances with `CMultiLineLabel` for hero specialty name displays in `OptionsTab::CPlayerOptionTooltipBox::genHeroWindow`, `CHeroOverview::genControls`, and `CHeroWindow` constructors to enable multiline text and better alignment.
- Adjusted positioning and bounding rectangles for the new `CMultiLineLabel` instances to fit the existing UI panels (`Rect(...)` and alignment parameters updated accordingly).
- Kept specialty images and descriptions unchanged while ensuring the specialty name control supports top/center alignment and appropriate sizing.

### Testing

- Project was built successfully using the normal build system (`cmake --build`), producing the client binary without compile errors.
- The automated test suite was executed with `ctest` and completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0c57f520832db2ad179ff97b6da6)