### PR TITLE
Fix Android touch button pressed state feedback

### DIFF
--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -98,6 +98,7 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 			Point distance = convertTouchToMouse(tfinger) - lastTapPosition;
 			if ( std::abs(distance.x) > params.panningSensitivityThreshold || std::abs(distance.y) > params.panningSensitivityThreshold)
 			{
+				ENGINE->events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger), params.touchToleranceDistance);
 				state = state == TouchState::TAP_DOWN_SHORT ? TouchState::TAP_DOWN_PANNING : TouchState::TAP_DOWN_PANNING_POPUP;
 				ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			}
@@ -162,6 +163,7 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		{
 			lastTapPosition = convertTouchToMouse(tfinger);
 			ENGINE->input().setCursorPosition(lastTapPosition);
+			ENGINE->events().dispatchMouseLeftButtonPressed(lastTapPosition, params.touchToleranceDistance);
 			state = TouchState::TAP_DOWN_SHORT;
 			break;
 		}
@@ -227,7 +229,6 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 			}
 			else
 			{
-				ENGINE->events().dispatchMouseLeftButtonPressed(convertTouchToMouse(tfinger), params.touchToleranceDistance);
 				ENGINE->events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger), params.touchToleranceDistance);
 				lastLeftClickTimeTicks = tfinger.timestamp;
 				lastLeftClickPosition = convertTouchToMouse(tfinger);
@@ -281,6 +282,7 @@ void InputSourceTouch::handleUpdate()
 		uint32_t currentTime = SDL_GetTicks();
 		if (currentTime > lastTapTimeTicks + params.longTouchTimeMilliseconds)
 		{
+			ENGINE->events().dispatchMouseLeftButtonReleased(Point(-100000, -100000), params.touchToleranceDistance);
 			ENGINE->events().dispatchShowPopup(ENGINE->getCursorPosition(), params.touchToleranceDistance);
 
 			if (ENGINE->windows().isTopWindowPopup())

--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -32,6 +32,11 @@
 #include <SDL_hints.h>
 #include <SDL_timer.h>
 
+namespace
+{
+const Point TOUCH_CANCEL_POSITION(-1, -1);
+}
+
 InputSourceTouch::InputSourceTouch()
 	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0)
 {
@@ -170,6 +175,7 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		case TouchState::TAP_DOWN_SHORT:
 		{
 			ENGINE->input().setCursorPosition(convertTouchToMouse(tfinger));
+			ENGINE->events().dispatchMouseLeftButtonReleased(TOUCH_CANCEL_POSITION, params.touchToleranceDistance);
 			ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			state = TouchState::TAP_DOWN_DOUBLE;
 			break;
@@ -282,7 +288,7 @@ void InputSourceTouch::handleUpdate()
 		uint32_t currentTime = SDL_GetTicks();
 		if (currentTime > lastTapTimeTicks + params.longTouchTimeMilliseconds)
 		{
-			ENGINE->events().dispatchMouseLeftButtonReleased(Point(-100000, -100000), params.touchToleranceDistance);
+			ENGINE->events().dispatchMouseLeftButtonReleased(TOUCH_CANCEL_POSITION, params.touchToleranceDistance);
 			ENGINE->events().dispatchShowPopup(ENGINE->getCursorPosition(), params.touchToleranceDistance);
 
 			if (ENGINE->windows().isTopWindowPopup())


### PR DESCRIPTION
### Motivation
- On touch devices buttons never visually entered `PRESSED` because touch input sent the left-mouse press only on `finger up`, differing from desktop behavior. 
- This caused UI buttons (e.g. `IOKAY`) to not show a pressed state during a finger hold on Android. 
- The change aims to make touch-driven button state transitions match mouse interactions so `PRESSED` is shown while the finger is down.

### Description
- Dispatch a left-button press immediately on `finger down` in touchscreen idle mode by calling `ENGINE->events().dispatchMouseLeftButtonPressed(...)` in `InputSourceTouch::handleEventFingerDown` for `TouchState::IDLE`.
- Ensure `PRESSED` is cleared when switching into panning or popup flows by dispatching a left-button release in `handleEventFingerMotion` when movement exceeds the panning threshold and before starting panning.
- Avoid a duplicate synthetic press on quick taps by removing the extra `dispatchMouseLeftButtonPressed` at the tap-release branch and keep the release on finger-up so buttons transition to `NORMAL`/`HIGHLIGHTED` as on desktop.
- When a long-touch triggers the popup path, release any pending pressed state before showing the popup by dispatching a synthetic release from `handleUpdate` to prevent stuck visuals.

### Testing
- Ran `git diff --check` which produced no whitespace/errors and passed successfully.
- Verified the change is limited to touch input translation (`client/eventsSDL/InputSourceTouch.cpp`) and does not alter desktop mouse handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbcf29534832d86a1f3956253b602)