### PR TITLE
Refactor town lookup logic shared by Town Portal and Reinforcements

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -283,6 +283,7 @@ set(lib_MAIN_SRCS
 	spells/adventure/RemoveObjectEffect.cpp
 	spells/adventure/ReinforcementsEffect.cpp
 	spells/adventure/SummonBoatEffect.cpp
+	spells/adventure/TownRelatedSpellUtils.cpp
 	spells/adventure/TownPortalEffect.cpp
 	spells/adventure/ViewWorldEffect.cpp
 

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -12,6 +12,7 @@
 #include "ReinforcementsEffect.h"
 
 #include "AdventureSpellMechanics.h"
+#include "TownRelatedSpellUtils.h"
 
 #include "../CSpellHandler.h"
 
@@ -32,7 +33,7 @@ ReinforcementsEffect::ReinforcementsEffect(const CSpell * s, const JsonNode & co
 
 ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const
 {
-	std::vector<const CGTownInstance *> towns = getPossibleTowns(env, parameters);
+	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, false);
 
 	if(!parameters.caster->getHeroCaster())
 	{
@@ -106,7 +107,7 @@ ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, con
 ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
 {
 	const CGTownInstance * destination = nullptr;
-	std::vector<const CGTownInstance *> towns = getPossibleTowns(env, parameters);
+	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, false);
 
 	if(!parameters.caster->getHeroCaster())
 	{
@@ -116,7 +117,7 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 
 	if(!allowTownSelection)
 	{
-		destination = findNearestTown(parameters, towns);
+		destination = spells::adventure::findNearestTown(parameters, towns);
 	}
 	else if(env->getMap()->isInTheMap(parameters.pos))
 	{
@@ -137,42 +138,6 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 
 	env->showGarrisonDialog(destination->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true);
 	return ESpellCastResult::OK;
-}
-
-const CGTownInstance * ReinforcementsEffect::findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool) const
-{
-	if(pool.empty() || !parameters.caster->getHeroCaster())
-		return nullptr;
-
-	auto nearest = pool.cbegin();
-	si32 distance = (*nearest)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
-
-	for(auto iter = nearest + 1; iter != pool.cend(); ++iter)
-	{
-		si32 currentDistance = (*iter)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
-
-		if(currentDistance < distance)
-		{
-			nearest = iter;
-			distance = currentDistance;
-		}
-	}
-
-	return *nearest;
-}
-
-std::vector<const CGTownInstance *> ReinforcementsEffect::getPossibleTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
-{
-	std::vector<const CGTownInstance *> result;
-
-	const TeamState * team = env->getCb()->getPlayerTeam(parameters.caster->getCasterOwner());
-	for(const auto & color : team->players)
-	{
-		for(const auto * town : env->getCb()->getPlayerState(color)->getTowns())
-			result.push_back(town);
-	}
-
-	return result;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/ReinforcementsEffect.h
+++ b/lib/spells/adventure/ReinforcementsEffect.h
@@ -27,8 +27,6 @@ public:
 private:
 	ESpellCastResult applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const override;
 	ESpellCastResult beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const override;
-	const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool) const;
-	std::vector<const CGTownInstance *> getPossibleTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/TownPortalEffect.cpp
+++ b/lib/spells/adventure/TownPortalEffect.cpp
@@ -12,6 +12,7 @@
 #include "TownPortalEffect.h"
 
 #include "AdventureSpellMechanics.h"
+#include "TownRelatedSpellUtils.h"
 
 #include "../CSpellHandler.h"
 
@@ -46,8 +47,8 @@ ESpellCastResult TownPortalEffect::applyAdventureEffects(SpellCastEnvironment * 
 
 	if(!allowTownSelection)
 	{
-		std::vector<const CGTownInstance *> pool = getPossibleTowns(env, parameters);
-		destination = findNearestTown(env, parameters, pool);
+		std::vector<const CGTownInstance *> pool = spells::adventure::getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
+		destination = spells::adventure::findNearestTown(parameters, pool);
 
 		if(nullptr == destination)
 			return ESpellCastResult::ERROR;
@@ -142,8 +143,8 @@ void TownPortalEffect::endCast(SpellCastEnvironment * env, const AdventureSpellC
 
 	if(!allowTownSelection)
 	{
-		std::vector<const CGTownInstance *> pool = getPossibleTowns(env, parameters);
-		destination = findNearestTown(env, parameters, pool);
+		std::vector<const CGTownInstance *> pool = spells::adventure::getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
+		destination = spells::adventure::findNearestTown(parameters, pool);
 	}
 	else
 	{
@@ -168,7 +169,7 @@ void TownPortalEffect::endCast(SpellCastEnvironment * env, const AdventureSpellC
 
 ESpellCastResult TownPortalEffect::beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const
 {
-	std::vector<const CGTownInstance *> towns = getPossibleTowns(env, parameters);
+	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
 
 	if(!parameters.caster->getHeroCaster())
 	{
@@ -250,47 +251,6 @@ ESpellCastResult TownPortalEffect::beginCast(SpellCastEnvironment * env, const A
 	}
 
 	return ESpellCastResult::OK;
-}
-
-const CGTownInstance * TownPortalEffect::findNearestTown(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector <const CGTownInstance *> & pool) const
-{
-	if(pool.empty())
-		return nullptr;
-
-	if(!parameters.caster->getHeroCaster())
-		return nullptr;
-
-	auto nearest = pool.cbegin(); //nearest town's iterator
-	si32 dist = (*nearest)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
-
-	for(auto i = nearest + 1; i != pool.cend(); ++i)
-	{
-		si32 curDist = (*i)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
-
-		if(curDist < dist)
-		{
-			nearest = i;
-			dist = curDist;
-		}
-	}
-	return *nearest;
-}
-
-std::vector<const CGTownInstance *> TownPortalEffect::getPossibleTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
-{
-	std::vector<const CGTownInstance *> ret;
-
-	const TeamState * team = env->getCb()->getPlayerTeam(parameters.caster->getCasterOwner());
-
-	for(const auto & color : team->players)
-	{
-		for(auto currTown : env->getCb()->getPlayerState(color)->getTowns())
-		{
-			if (!skipOccupiedTowns || currTown->getVisitingHero() == nullptr)
-				ret.push_back(currTown);
-		}
-	}
-	return ret;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/TownPortalEffect.h
+++ b/lib/spells/adventure/TownPortalEffect.h
@@ -34,8 +34,6 @@ private:
 	ESpellCastResult applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const override;
 	ESpellCastResult beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const override;
 	void endCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const override;
-	const CGTownInstance * findNearestTown(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool) const;
-	std::vector<const CGTownInstance *> getPossibleTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/TownRelatedSpellUtils.cpp
+++ b/lib/spells/adventure/TownRelatedSpellUtils.cpp
@@ -1,0 +1,66 @@
+/*
+ * TownRelatedSpellUtils.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#include "StdInc.h"
+#include "TownRelatedSpellUtils.h"
+
+#include "../../CPlayerState.h"
+#include "../../callback/IGameInfoCallback.h"
+#include "../../mapObjects/CGHeroInstance.h"
+#include "../../mapObjects/CGTownInstance.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+namespace spells
+{
+namespace adventure
+{
+std::vector<const CGTownInstance *> getPlayerTeamTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, bool skipOccupiedTowns)
+{
+	std::vector<const CGTownInstance *> result;
+
+	const TeamState * team = env->getCb()->getPlayerTeam(parameters.caster->getCasterOwner());
+	for(const auto & color : team->players)
+	{
+		for(const auto * town : env->getCb()->getPlayerState(color)->getTowns())
+		{
+			if(!skipOccupiedTowns || town->getVisitingHero() == nullptr)
+				result.push_back(town);
+		}
+	}
+
+	return result;
+}
+
+const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool)
+{
+	if(pool.empty() || !parameters.caster->getHeroCaster())
+		return nullptr;
+
+	auto nearest = pool.cbegin();
+	si32 distance = (*nearest)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
+
+	for(auto iter = nearest + 1; iter != pool.cend(); ++iter)
+	{
+		si32 currentDistance = (*iter)->visitablePos().dist2dSQ(parameters.caster->getHeroCaster()->visitablePos());
+
+		if(currentDistance < distance)
+		{
+			nearest = iter;
+			distance = currentDistance;
+		}
+	}
+
+	return *nearest;
+}
+}
+}
+
+VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/TownRelatedSpellUtils.h
+++ b/lib/spells/adventure/TownRelatedSpellUtils.h
@@ -1,0 +1,28 @@
+/*
+ * TownRelatedSpellUtils.h, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+
+#pragma once
+
+#include "AdventureSpellEffect.h"
+
+VCMI_LIB_NAMESPACE_BEGIN
+
+class CGTownInstance;
+
+namespace spells
+{
+namespace adventure
+{
+std::vector<const CGTownInstance *> getPlayerTeamTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, bool skipOccupiedTowns);
+const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool);
+}
+}
+
+VCMI_LIB_NAMESPACE_END


### PR DESCRIPTION
### Motivation
- Review pointed out duplicated town-lookup logic between Reinforcements and Town Portal effects, so shared behavior should be consolidated to avoid divergence.
- Consolidation reduces code duplication and makes future behavior changes easier and safer to apply across both spells.

### Description
- Extracted shared town-related helpers into `lib/spells/adventure/TownRelatedSpellUtils.h` and `lib/spells/adventure/TownRelatedSpellUtils.cpp` providing `spells::adventure::getPlayerTeamTowns` and `spells::adventure::findNearestTown`.
- Updated `ReinforcementsEffect` to call `spells::adventure::getPlayerTeamTowns` and `spells::adventure::findNearestTown` and removed its redundant private helper declarations and implementations.
- Updated `TownPortalEffect` to call the same shared helpers (respecting `skipOccupiedTowns`) and removed its local duplicate helper implementations and declarations.
- Added the new source file to the library build by updating `lib/CMakeLists.txt` to include `spells/adventure/TownRelatedSpellUtils.cpp`.

### Testing
- Attempted to build the library with `cmake --build build -j2 --target VCMI_lib`, but the `build/` directory is not present in this environment so no compilation was performed.
- No other automated tests were run in this environment; the change is limited to refactoring calls and removing duplicate local helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfb1d6fe0832dbf2d1a9536d5a88d)