### PR TITLE
Persist level-up dialogs and prevent duplicate callbacks on selection

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -126,6 +126,13 @@
 
 #define BATTLE_EVENT_POSSIBLE_RETURN	if (GAME->interface() != this) return; if (isAutoFightOn && !battleInt) return
 
+namespace
+{
+	constexpr int LEVEL_UP_REQUEST_NONE = -1;
+	constexpr int LEVEL_UP_REQUEST_WAITING_FOR_REPLY = -2;
+	constexpr int LEVEL_UP_REQUEST_AUTO_RESOLVED = -3;
+}
+
 std::shared_ptr<BattleInterface> CPlayerInterface::battleInt;
 
 CPlayerInterface::CPlayerInterface(PlayerColor Player):
@@ -525,7 +532,7 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 	closePendingLevelUpDialog();
 
-	pendingLevelUpRequestID = -1;
+	pendingLevelUpRequestID = queryID < 0 ? LEVEL_UP_REQUEST_AUTO_RESOLVED : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
 	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
@@ -546,7 +553,8 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 	closePendingLevelUpDialog();
 
-	pendingLevelUpRequestID = -1;
+	const bool closeImmediately = queryID < 0 && skills.empty();
+	pendingLevelUpRequestID = queryID < 0 ? LEVEL_UP_REQUEST_AUTO_RESOLVED : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
 	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
@@ -554,8 +562,9 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(false);
-	pendingLevelUpDialog = levelWindow;
+	levelWindow->setCloseOnSelection(closeImmediately);
+	if(!closeImmediately)
+		pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }
 
@@ -1311,7 +1320,7 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 			closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
 	}
-	else if(pendingLevelUpDialog && pendingLevelUpRequestID < 0)
+	else if(pendingLevelUpDialog && pendingLevelUpRequestID == LEVEL_UP_REQUEST_AUTO_RESOLVED)
 	{
 		// Auto-resolved levelups (queryID < 0) have no QueryReply from client,
 		// so close pending window once current server request is fully applied.
@@ -1323,13 +1332,13 @@ void CPlayerInterface::closePendingLevelUpDialog()
 {
 	if(!pendingLevelUpDialog)
 	{
-		pendingLevelUpRequestID = -1;
+		pendingLevelUpRequestID = LEVEL_UP_REQUEST_NONE;
 		return;
 	}
 
 	pendingLevelUpDialog->close();
 	pendingLevelUpDialog.reset();
-	pendingLevelUpRequestID = -1;
+	pendingLevelUpRequestID = LEVEL_UP_REQUEST_NONE;
 }
 
 void CPlayerInterface::showHeroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -523,11 +523,7 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
 
-	if(pendingLevelUpDialog)
-	{
-		pendingLevelUpDialog->close();
-		pendingLevelUpDialog.reset();
-	}
+	closePendingLevelUpDialog();
 
 	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
 	{
@@ -541,17 +537,13 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 	ENGINE->windows().pushWindow(levelWindow);
 }
 
-void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
+void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
 
-	if(pendingLevelUpDialog)
-	{
-		pendingLevelUpDialog->close();
-		pendingLevelUpDialog.reset();
-	}
+	closePendingLevelUpDialog();
 
 	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
@@ -1313,11 +1305,18 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 
 	if(pa->packType == CTypeList::getInstance().getTypeID<QueryReply>(nullptr))
 	{
-		if(pendingLevelUpDialog)
-			pendingLevelUpDialog->close();
-		pendingLevelUpDialog.reset();
+		closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
 	}
+}
+
+void CPlayerInterface::closePendingLevelUpDialog()
+{
+	if(!pendingLevelUpDialog)
+		return;
+
+	pendingLevelUpDialog->close();
+	pendingLevelUpDialog.reset();
 }
 
 void CPlayerInterface::showHeroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -522,13 +522,23 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	ENGINE->windows().createAndPushWindow<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
+
+	if(pendingLevelUpDialog)
+	{
+		pendingLevelUpDialog->close();
+		pendingLevelUpDialog.reset();
+	}
+
+	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
 		cb->selectionMade(selection, queryID);
 	});
+	levelWindow->setCloseOnSelection(false);
+	pendingLevelUpDialog = levelWindow;
+	ENGINE->windows().pushWindow(levelWindow);
 }
 
 void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID)
@@ -536,13 +546,23 @@ void CPlayerInterface::commanderGotLevel (const CCommanderInstance * commander, 
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	waitWhileDialog();
 	ENGINE->sound().playSound(soundBase::heroNewLevel);
-	ENGINE->windows().createAndPushWindow<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
+
+	if(pendingLevelUpDialog)
+	{
+		pendingLevelUpDialog->close();
+		pendingLevelUpDialog.reset();
+	}
+
+	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
 		cb->selectionMade(selection, queryID);
 	});
+	levelWindow->setCloseOnSelection(false);
+	pendingLevelUpDialog = levelWindow;
+	ENGINE->windows().pushWindow(levelWindow);
 }
 
 void CPlayerInterface::heroInGarrisonChange(const CGTownInstance *town)
@@ -1292,7 +1312,12 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 		movementController->onMoveHeroApplied();
 
 	if(pa->packType == CTypeList::getInstance().getTypeID<QueryReply>(nullptr))
+	{
+		if(pendingLevelUpDialog)
+			pendingLevelUpDialog->close();
+		pendingLevelUpDialog.reset();
 		movementController->onQueryReplyApplied();
+	}
 }
 
 void CPlayerInterface::showHeroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -525,15 +525,17 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 	closePendingLevelUpDialog();
 
+	const bool closeImmediately = queryID < 0;
 	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
-		cb->selectionMade(selection, queryID);
+		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(false);
-	pendingLevelUpDialog = levelWindow;
+	levelWindow->setCloseOnSelection(closeImmediately);
+	if(!closeImmediately)
+		pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }
 
@@ -545,15 +547,17 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 	closePendingLevelUpDialog();
 
+	const bool closeImmediately = queryID < 0;
 	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
 			return;
 
-		cb->selectionMade(selection, queryID);
+		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(false);
-	pendingLevelUpDialog = levelWindow;
+	levelWindow->setCloseOnSelection(closeImmediately);
+	if(!closeImmediately)
+		pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }
 
@@ -1305,7 +1309,8 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 
 	if(pa->packType == CTypeList::getInstance().getTypeID<QueryReply>(nullptr))
 	{
-		closePendingLevelUpDialog();
+		if(pendingLevelUpRequestID == static_cast<int>(pa->requestID))
+			closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
 	}
 }
@@ -1313,10 +1318,14 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 void CPlayerInterface::closePendingLevelUpDialog()
 {
 	if(!pendingLevelUpDialog)
+	{
+		pendingLevelUpRequestID = -1;
 		return;
+	}
 
 	pendingLevelUpDialog->close();
 	pendingLevelUpDialog.reset();
+	pendingLevelUpRequestID = -1;
 }
 
 void CPlayerInterface::showHeroExchange(ObjectInstanceID hero1, ObjectInstanceID hero2)

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -553,7 +553,8 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 	closePendingLevelUpDialog();
 
-	pendingLevelUpRequestID = queryID < 0 ? LEVEL_UP_REQUEST_AUTO_RESOLVED : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
+	const bool closeImmediately = queryID < 0;
+	pendingLevelUpRequestID = closeImmediately ? LEVEL_UP_REQUEST_NONE : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
 	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
@@ -561,8 +562,9 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(false);
-	pendingLevelUpDialog = levelWindow;
+	levelWindow->setCloseOnSelection(closeImmediately);
+	if(!closeImmediately)
+		pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -553,7 +553,6 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 	closePendingLevelUpDialog();
 
-	const bool closeImmediately = queryID < 0 && skills.empty();
 	pendingLevelUpRequestID = queryID < 0 ? LEVEL_UP_REQUEST_AUTO_RESOLVED : LEVEL_UP_REQUEST_WAITING_FOR_REPLY;
 	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
@@ -562,9 +561,8 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(closeImmediately);
-	if(!closeImmediately)
-		pendingLevelUpDialog = levelWindow;
+	levelWindow->setCloseOnSelection(false);
+	pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }
 

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -525,7 +525,7 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 	closePendingLevelUpDialog();
 
-	const bool closeImmediately = queryID < 0;
+	pendingLevelUpRequestID = -1;
 	auto levelWindow = std::make_shared<CLevelWindow>(hero, pskill, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
@@ -533,9 +533,8 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(closeImmediately);
-	if(!closeImmediately)
-		pendingLevelUpDialog = levelWindow;
+	levelWindow->setCloseOnSelection(false);
+	pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }
 
@@ -547,7 +546,7 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 	closePendingLevelUpDialog();
 
-	const bool closeImmediately = queryID < 0;
+	pendingLevelUpRequestID = -1;
 	auto levelWindow = std::make_shared<CStackWindow>(commander, skills, [this, queryID](ui32 selection)
 	{
 		if(queryID < 0)
@@ -555,9 +554,8 @@ void CPlayerInterface::commanderGotLevel(const CCommanderInstance * commander, s
 
 		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(closeImmediately);
-	if(!closeImmediately)
-		pendingLevelUpDialog = levelWindow;
+	levelWindow->setCloseOnSelection(false);
+	pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }
 
@@ -1312,6 +1310,12 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 		if(pendingLevelUpRequestID == static_cast<int>(pa->requestID))
 			closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
+	}
+	else if(pendingLevelUpDialog && pendingLevelUpRequestID < 0)
+	{
+		// Auto-resolved levelups (queryID < 0) have no QueryReply from client,
+		// so close pending window once current server request is fully applied.
+		closePendingLevelUpDialog();
 	}
 }
 

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -67,6 +67,7 @@ class CPlayerInterface : public CGameInterface
 	const std::string QUICKSAVE_PATH = "Saves/Quicksave";
 
 	std::list<std::shared_ptr<CInfoWindow>> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
+	std::shared_ptr<CIntObject> pendingLevelUpDialog;
 
 	std::unique_ptr<HeroMovementController> movementController;
 	std::unique_ptr<PathfinderCache> pathfinderCache;

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -242,6 +242,7 @@ private:
 	};
 
 	void heroKilled(const CGHeroInstance* hero);
+	void closePendingLevelUpDialog();
 	void townRemoved(const CGTownInstance* town);
 	void garrisonsChanged(std::vector<const CArmedInstance *> objs);
 	void requestReturningToMainMenu(bool won);

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -67,7 +67,7 @@ class CPlayerInterface : public CGameInterface
 	const std::string QUICKSAVE_PATH = "Saves/Quicksave";
 
 	std::list<std::shared_ptr<CInfoWindow>> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
-	std::shared_ptr<CIntObject> pendingLevelUpDialog;
+	std::shared_ptr<WindowBase> pendingLevelUpDialog;
 	int pendingLevelUpRequestID = -1;
 
 	std::unique_ptr<HeroMovementController> movementController;

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -68,6 +68,7 @@ class CPlayerInterface : public CGameInterface
 
 	std::list<std::shared_ptr<CInfoWindow>> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
 	std::shared_ptr<CIntObject> pendingLevelUpDialog;
+	int pendingLevelUpRequestID = -1;
 
 	std::unique_ptr<HeroMovementController> movementController;
 	std::unique_ptr<PathfinderCache> pathfinderCache;

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -835,10 +835,26 @@ CStackWindow::CStackWindow(const CCommanderInstance * commander, std::vector<ui3
 
 CStackWindow::~CStackWindow() = default;
 
+void CStackWindow::setCloseOnSelection(bool value)
+{
+	closeOnSelection = value;
+}
+
 void CStackWindow::close()
 {
-	if(info->levelupInfo && !info->levelupInfo->skills.empty())
-		info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
+	if(!selectionSubmitted)
+	{
+		if(info->levelupInfo && !info->levelupInfo->skills.empty())
+			info->levelupInfo->callback(vstd::find_pos(info->levelupInfo->skills, selectedSkill));
+
+		selectionSubmitted = true;
+
+		if(!closeOnSelection)
+		{
+			deactivate();
+			return;
+		}
+	}
 
 	CWindowObject::close();
 }

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -542,6 +542,9 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 			icon->hoverText = abilityDescription;
 			icon->text = abilityDescription;
 
+			if(parent->selectedSkill == static_cast<si32>(skillID))
+				parent->setSelection(skillID, icon);
+
 			return icon;
 		};
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -132,6 +132,11 @@ void CCommanderSkillIcon::setObject(std::shared_ptr<CIntObject> newObject)
 void CCommanderSkillIcon::clickPressed(const Point & cursorPosition)
 {
 	callback();
+	select();
+}
+
+void CCommanderSkillIcon::select()
+{
 	isSelected = true;
 	redraw();
 }
@@ -1157,6 +1162,7 @@ void CStackWindow::setSelection(si32 newSkill, std::shared_ptr<CCommanderSkillIc
 			newIcon->text = getSkillDescription(newSkill, true); //update currently selected icon's message to show upgrade description
 		}
 	}
+	newIcon->select();
 }
 
 std::shared_ptr<CIntObject> CStackWindow::switchTab(size_t index)

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -47,6 +47,7 @@ public:
 	void clickPressed(const Point & cursorPosition) override;
 
 	void setObject(std::shared_ptr<CIntObject> object);
+	void select();
 	void deselect(); //TODO: consider using observer pattern instead?
 	bool getIsMasterAbility();
 

--- a/client/windows/CCreatureWindow.h
+++ b/client/windows/CCreatureWindow.h
@@ -212,6 +212,11 @@ public:
 	// for commanders & commander level-up dialog
 	CStackWindow(const CCommanderInstance * commander, bool popup);
 	CStackWindow(const CCommanderInstance * commander, std::vector<ui32> &skills, std::function<void(ui32)> callback);
+	void setCloseOnSelection(bool value);
 
 	~CStackWindow();
+
+private:
+	bool closeOnSelection = true;
+	bool selectionSubmitted = false;
 };

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -505,32 +505,47 @@ void CLevelWindow::createSkillBox()
 	redraw();
 }
 
+void CLevelWindow::setCloseOnSelection(bool value)
+{
+	closeOnSelection = value;
+}
+
 void CLevelWindow::close()
 {
-	int idx = -1;
-
-	if(box)
-		idx = box->selectedIndex();
-
-	// If there are skills available, we must not close without producing a valid choice
-	// For a single available option, auto-pick it
-	if(!skills.empty())
+	if(!selectionSubmitted)
 	{
-		if(idx == -1)
+		int idx = -1;
+
+		if(box)
+			idx = box->selectedIndex();
+
+		// If there are skills available, we must not close without producing a valid choice
+		// For a single available option, auto-pick it
+		if(!skills.empty())
 		{
-			if(skills.size() == 1)
-				idx = 0;
-			else
-				return; // require explicit selection
+			if(idx == -1)
+			{
+				if(skills.size() == 1)
+					idx = 0;
+				else
+					return; // require explicit selection
+			}
+
+			const auto & chosen = sortedSkills[(idx + skillViewOffset) % skills.size()];
+			auto it = std::find(skills.begin(), skills.end(), chosen);
+
+			cb(std::distance(skills.begin(), it));
 		}
 
-		const auto & chosen = sortedSkills[(idx + skillViewOffset) % skills.size()];
-		auto it = std::find(skills.begin(), skills.end(), chosen);
+		selectionSubmitted = true;
+		GAME->interface()->showingDialog->setFree();
 
-		cb(std::distance(skills.begin(), it));
+		if(!closeOnSelection)
+		{
+			deactivate();
+			return;
+		}
 	}
-
-	GAME->interface()->showingDialog->setFree();
 
 	CWindowObject::close();
 }

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -165,8 +165,13 @@ class CLevelWindow : public CWindowObject
 
 public:
 	CLevelWindow(const CGHeroInstance *hero, PrimarySkill pskill, std::vector<SecondarySkill> &skills, std::function<void(ui32)> callback);
+	void setCloseOnSelection(bool value);
 
 	void close() override;
+
+private:
+	bool closeOnSelection = true;
+	bool selectionSubmitted = false;
 };
 
 /// Town portal, castle gate window


### PR DESCRIPTION
### Motivation
- Prevent level-up windows from being prematurely closed or duplicated when multiple dialogs or query replies arrive and ensure a single selection callback is invoked for level-up choices.
- Allow the level-up window to remain open after a selection if desired, so UI control can manage closing order and dialog lifetime.

### Description
- Added `pendingLevelUpDialog` to `CPlayerInterface` to track and explicitly close/reset any existing pending level-up dialog before creating a new one, and to close it when a `QueryReply` is realized in `requestRealized`.
- Reworked `heroGotLevel` and `commanderGotLevel` to create shared window instances (`CLevelWindow` / `CStackWindow`), push them via `ENGINE->windows().pushWindow(...)`, set `setCloseOnSelection(false)`, and assign them to `pendingLevelUpDialog` for lifecycle control.
- Added `setCloseOnSelection(bool)` and private flags `closeOnSelection` and `selectionSubmitted` to both `CLevelWindow` and `CStackWindow` to control whether the window actually closes immediately on selection and to ensure the selection callback is only called once.
- Updated `close()` implementations in `CLevelWindow` and `CStackWindow` to perform callback invocation exactly once, auto-pick when only one skill is available, mark `selectionSubmitted`, free `showingDialog` and either deactivate (if `closeOnSelection` is false) or proceed with normal close.
- Minor API/header updates to expose the new `setCloseOnSelection` methods and introduce the new members.

### Testing
- Performed a full client build which completed successfully with the updated headers and sources.
- Exercised hero and commander level-up flows in an automated UI regression scenario that simulates `QueryReply` application and produced the expected single callback behavior and no crashes. All automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5d7a615c832dad1a8811c41cf54b)