### PR TITLE
Prevent Reinforcements cast from heroes in towns and adjust garrison dialog/banner; add translations

### DIFF
--- a/Mods/vcmi/Content/config/translations/czech.json
+++ b/Mods/vcmi/Content/config/translations/czech.json
@@ -421,6 +421,7 @@
 	"vcmi.client.errors.invalidMap": "{Neplatná mapa nebo kampaň}\n\nChyba při startu hry! Vybraná mapa nebo kampaň může být neplatná nebo poškozená. Důvod:\n%s",
 	"vcmi.client.errors.modLoadingFailure": "{Chyba při načítání modifikací}\n\nPři načítání modifikací byly nalezeny kritické problémy! Hra nemusí fungovat správně nebo může spadnout! Aktualizujte nebo deaktivujte následující modifikace:\n\n",
 	"vcmi.client.screenShot": "Snímek obrazovky uložen do %s",
+	"vcmi.spells.reinforcements.casterInTown": "Posily nelze seslat, když je hrdina na návštěvě ve městě.",
 	"vcmi.commanderWindow.artifactMessage": "Chcete tento artefakt vrátit hrdinovi?",
 	"vcmi.creatureWindow.returnArtifact.help": "Klikněte na toto tlačítko pro vrácení artefaktu do batohu hrdiny.",
 	"vcmi.creatureWindow.returnArtifact.hover": "Vrátit artefakt",

--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -421,6 +421,7 @@
 	"vcmi.client.errors.invalidMap": "{Invalid map or campaign}\n\nFailed to start game! Selected map or campaign might be invalid or corrupted. Reason:\n%s",
 	"vcmi.client.errors.modLoadingFailure": "{Mod loading failure}\n\nCritical issues found when loading mods! Game may not work correctly or crash! Please update or disable following mods:\n\n",
 	"vcmi.client.screenShot": "Screenshot saved to %s",
+	"vcmi.spells.reinforcements.casterInTown": "Reinforcements cannot be cast while hero is visiting a town.",
 	"vcmi.commanderWindow.artifactMessage": "Do you want to return this artifact to the hero?",
 	"vcmi.creatureWindow.returnArtifact.help": "Click this button to return the artifact to the hero's backpack.",
 	"vcmi.creatureWindow.returnArtifact.hover": "Return artifact",

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1136,10 +1136,13 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	}
 	quit = std::make_shared<CButton>(Point(399, 314), AnimationPath::builtin("IOK6432.DEF"), CButton::tooltip(LIBRARY->generaltexth->tcommands[8], ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
 
-	const auto * sourceHero = dynamic_cast<const CGHeroInstance *>(up);
+	const CGHeroInstance * sourceHero = dynamic_cast<const CGHeroInstance *>(up);
 	const auto * sourceTown = dynamic_cast<const CGTownInstance *>(up);
 	if(sourceTown == nullptr && sourceHero != nullptr)
 		sourceTown = sourceHero->getVisitedTown();
+
+	if(sourceHero == nullptr && sourceTown != nullptr)
+		sourceHero = sourceTown->getGarrisonHero();
 
 	const bool isReinforcementsDialog = sourceTown != nullptr && down->getVisitedTown() != sourceTown;
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1136,12 +1136,16 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	}
 	quit = std::make_shared<CButton>(Point(399, 314), AnimationPath::builtin("IOK6432.DEF"), CButton::tooltip(LIBRARY->generaltexth->tcommands[8], ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
 
+	const auto * sourceHero = dynamic_cast<const CGHeroInstance *>(up);
+	const auto * sourceTown = dynamic_cast<const CGTownInstance *>(up);
+	if(sourceTown == nullptr && sourceHero != nullptr)
+		sourceTown = sourceHero->getVisitedTown();
+
+	const bool isReinforcementsDialog = sourceTown != nullptr && down->getVisitedTown() != sourceTown;
+
 	std::string titleText;
 	if(down->tempOwner == up->tempOwner)
 	{
-		const auto * town = dynamic_cast<const CGTownInstance *>(up);
-		const bool isReinforcementsDialog = town != nullptr && down->getVisitedTown() != town;
-
 		if(isReinforcementsDialog)
 			titleText = LIBRARY->generaltexth->translate("vcmi.spells.reinforcements.garrison.title");
 		else
@@ -1162,7 +1166,11 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	}
 	title = std::make_shared<CLabel>(275, 30, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 
-	banner = std::make_shared<CAnimImage>(AnimationPath::builtin("CREST58"), up->getOwner().getNum(), 0, 28, 124);
+	if(isReinforcementsDialog && sourceHero != nullptr)
+		banner = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), sourceHero->getIconIndex(), 0, 29, 124);
+	else
+		banner = std::make_shared<CAnimImage>(AnimationPath::builtin("CREST58"), up->getOwner().getNum(), 0, 28, 124);
+
 	portrait = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), down->getIconIndex(), 0, 29, 222);
 }
 

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -150,8 +150,7 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 		return ESpellCastResult::ERROR;
 	}
 
-	const auto * sourceArmy = destination->getUpperArmy();
-	env->showGarrisonDialog(sourceArmy->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true);
+	env->showGarrisonDialog(destination->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true);
 	return ESpellCastResult::OK;
 }
 

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -35,10 +35,20 @@ ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, con
 {
 	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, false);
 
-	if(!parameters.caster->getHeroCaster())
+	const auto * casterHero = parameters.caster->getHeroCaster();
+	if(!casterHero)
 	{
 		env->complain("Not a hero caster!");
 		return ESpellCastResult::ERROR;
+	}
+
+	if(casterHero->getVisitedTown() != nullptr)
+	{
+		InfoWindow iw;
+		iw.player = parameters.caster->getCasterOwner();
+		iw.text.appendTextID("vcmi.spells.reinforcements.casterInTown");
+		env->apply(iw);
+		return ESpellCastResult::CANCEL;
 	}
 
 	if(towns.empty())
@@ -109,11 +119,15 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 	const CGTownInstance * destination = nullptr;
 	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, false);
 
-	if(!parameters.caster->getHeroCaster())
+	const auto * casterHero = parameters.caster->getHeroCaster();
+	if(!casterHero)
 	{
 		env->complain("Not a hero caster!");
 		return ESpellCastResult::ERROR;
 	}
+
+	if(casterHero->getVisitedTown() != nullptr)
+		return ESpellCastResult::CANCEL;
 
 	if(!allowTownSelection)
 	{
@@ -136,7 +150,8 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 		return ESpellCastResult::ERROR;
 	}
 
-	env->showGarrisonDialog(destination->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true);
+	const auto * sourceArmy = destination->getUpperArmy();
+	env->showGarrisonDialog(sourceArmy->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true);
 	return ESpellCastResult::OK;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent casting the `Reinforcements` adventure spell while the caster hero is currently visiting a town and show a user-friendly message instead of proceeding. 
- Fix garrison dialog logic to correctly detect reinforcements scenarios when the source is a visiting hero and show an appropriate banner (hero portrait) for that case. 
- Add missing translation strings for the new user-facing message about casting reinforcements from a town.

### Description
- Updated `ReinforcementsEffect::beginCast` and `applyAdventureEffects` to obtain the hero caster once via `getHeroCaster()`, cancel the cast when the hero is visiting a town, and display an info window with `vcmi.spells.reinforcements.casterInTown` when cancelling. 
- Changed `applyAdventureEffects` to call `env->showGarrisonDialog` with the actual source army id (`sourceArmy->id`) instead of passing the destination town id. 
- Adjusted garrison window construction in `CGarrisonWindow` to detect reinforcements dialogs when the `up` side is a hero visiting a town by checking `sourceHero->getVisitedTown()`, and to display the hero portrait banner for reinforcements cases instead of the owner's crest. 
- Added the translation entry `vcmi.spells.reinforcements.casterInTown` to both `english.json` and `czech.json`.

### Testing
- Performed a full project build which completed successfully. 
- Ran the unit test suite and integration checks relevant to spells and UI dialogs; tests passed without failures. 
- Verified that attempting to cast `Reinforcements` while a hero is visiting a town now shows the info window and cancels the cast (via automated integration checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd56eb15f0832d997205649bfa7556)