### PR TITLE
Enable long-weapon reach for attacks and harden attack-area calculations

### DIFF
--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -1270,6 +1270,17 @@ bool BattleActionsController::currentActionWalkAndCast(const BattleHex & hovered
 	return selectAction(hoveredHex).get() == PossiblePlayerBattleAction::WALK_AND_SPELLCAST;
 }
 
+bool BattleActionsController::currentActionUsesLongWeapon(const BattleHex & hoveredHex)
+{
+	if (heroSpellToCast)
+		return false;
+
+	if (!owner.stacksController->getActiveStack())
+		return true;
+
+	return selectAction(hoveredHex).get() != PossiblePlayerBattleAction::ATTACK_WITHOUT_LONG_WEAPON;
+}
+
 const std::vector<PossiblePlayerBattleAction> & BattleActionsController::getPossibleActions() const
 {
 	return possibleActions;

--- a/client/battle/BattleActionsController.h
+++ b/client/battle/BattleActionsController.h
@@ -101,6 +101,9 @@ public:
 	/// returns true if current hex action is "walk and spellcast" with active stack
 	bool currentActionWalkAndCast(const BattleHex& hoveredHex);
 
+	/// returns true if currently selected action allows long weapon reach for melee attacks
+	bool currentActionUsesLongWeapon(const BattleHex & hoveredHex);
+
 	/// enter targeted spellcasting mode for creature, e.g. via "F" hotkey
 	void enterCreatureCastingMode();
 

--- a/client/battle/BattleFieldController.cpp
+++ b/client/battle/BattleFieldController.cpp
@@ -399,7 +399,8 @@ BattleHexArray BattleFieldController::getHighlightedHexesForMovementTarget()
 
 	if(canAttack || canCastAdjacentSpell)
 	{
-		BattleHex fromHex = owner.getBattle()->fromWhichHexAttack(stack, hoveredHex, selectAttackDirection(hoveredHex));
+		const bool allowLongWeapon = owner.actionsController->currentActionUsesLongWeapon(hoveredHex);
+		BattleHex fromHex = owner.getBattle()->fromWhichHexAttack(stack, hoveredHex, selectAttackDirection(hoveredHex), allowLongWeapon);
 		assert(fromHex.isValid());
 		if(stack->doubleWide())
 			return {fromHex, stack->occupiedHex(fromHex)};

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -898,7 +898,8 @@ std::vector<const CStack *> BattleStacksController::selectHoveredStacks()
 	// affected units by multi-hex attacks
 	if(owner.getBattle()->battleCanAttackHex(activeStack, hoveredHex) && owner.getBattle()->battleCanAttackUnit(activeStack, target))
 	{
-		BattleHex fromHex = owner.getBattle()->fromWhichHexAttack(activeStack, hoveredHex, owner.fieldController->selectAttackDirection(hoveredHex));
+		const bool allowLongWeapon = owner.actionsController->currentActionUsesLongWeapon(hoveredHex);
+		BattleHex fromHex = owner.getBattle()->fromWhichHexAttack(activeStack, hoveredHex, owner.fieldController->selectAttackDirection(hoveredHex), allowLongWeapon);
 		auto stackHexes = owner.getBattle()->battleGetAttackedHexes(activeStack, hoveredHex, fromHex);
 		for(auto & stackHex : stackHexes)
 		{

--- a/lib/battle/CBattleInfoCallback.cpp
+++ b/lib/battle/CBattleInfoCallback.cpp
@@ -356,7 +356,15 @@ BattleHexArray CBattleInfoCallback::battleGetAttackedHexes(const battle::Unit * 
 	BattleHexArray attackedHexes;
 	RETURN_IF_NOT_BATTLE(attackedHexes);
 
-	AttackableTiles at = getPotentiallyAttackableHexes(attacker, destinationTile, attackerPos);
+	AttackableTiles at;
+	try
+	{
+		at = getPotentiallyAttackableHexes(attacker, destinationTile, attackerPos);
+	}
+	catch(const std::runtime_error &)
+	{
+		return attackedHexes;
+	}
 
 	for (const BattleHex & tile : at.hostileCreaturePositions)
 	{
@@ -694,40 +702,70 @@ BattleHex CBattleInfoCallback::fromWhichHexAttack(const battle::Unit * attacker,
 	bool isAttacker = attacker->unitSide() == BattleSide::ATTACKER;
 	if (attacker->doubleWide())
 	{
+		if(allowLongWeapon && attacker->hasBonusOfType(BonusType::LONG_WEAPON) && direction != BattleHex::TOP && direction != BattleHex::BOTTOM)
+		{
+			const auto longLine = getLongWeaponLineHexes(target, direction);
+			if(longLine)
+			{
+				const auto [middleHex, longAttackFrom] = *longLine;
+				if(isLongWeaponMiddleHexClear(*this, middleHex))
+				{
+					const auto availableHexes = battleGetAvailableHexes(attacker, false);
+					if(availableHexes.contains(longAttackFrom))
+						return longAttackFrom;
+				}
+			}
+		}
+
 		// We need to find position of right hex of double-hex creature (or left for defending side)
 		// | TOP_LEFT | TOP_RIGHT |  RIGHT  |BOTTOM_RIGHT|BOTTOM_LEFT|  LEFT   |  TOP   | BOTTOM
 		// |  o o -   |    - o o  |  - -    |   - -      |    - -    |    - -  |  o o   |   - -
 		// |   - x -  |   - x -   | - x o o |  - x -     |   - x -   | o o x - | - x -  |  - x -
 		// |    - -   |    - -    |  - -    |   - o o    |  o o -    |    - -  |  - -   |   o o
 
-		switch (direction)
+		try
 		{
-			case BattleHex::TOP_LEFT:
-			case BattleHex::LEFT:
-			case BattleHex::BOTTOM_LEFT:
-				return target.cloneInDirection(direction, false)
-					.cloneInDirection(isAttacker ? BattleHex::NONE : BattleHex::LEFT, false);
+			switch (direction)
+			{
+				case BattleHex::TOP_LEFT:
+				case BattleHex::LEFT:
+				case BattleHex::BOTTOM_LEFT:
+					return target.cloneInDirection(direction, false)
+						.cloneInDirection(isAttacker ? BattleHex::NONE : BattleHex::LEFT, false);
 
-			case BattleHex::TOP_RIGHT:
-			case BattleHex::RIGHT:
-			case BattleHex::BOTTOM_RIGHT:
-				return target.cloneInDirection(direction, false)
-					.cloneInDirection(isAttacker ? BattleHex::RIGHT : BattleHex::NONE, false);
+				case BattleHex::TOP_RIGHT:
+				case BattleHex::RIGHT:
+				case BattleHex::BOTTOM_RIGHT:
+					return target.cloneInDirection(direction, false)
+						.cloneInDirection(isAttacker ? BattleHex::RIGHT : BattleHex::NONE, false);
 
-			case BattleHex::TOP:
-				return target.cloneInDirection(isAttacker ? BattleHex::TOP_RIGHT : BattleHex::TOP_LEFT, false);
+				case BattleHex::TOP:
+					return target.cloneInDirection(isAttacker ? BattleHex::TOP_RIGHT : BattleHex::TOP_LEFT, false);
 
-			case BattleHex::BOTTOM:
-				return target.cloneInDirection(isAttacker ? BattleHex::BOTTOM_RIGHT : BattleHex::BOTTOM_LEFT, false);
+				case BattleHex::BOTTOM:
+					return target.cloneInDirection(isAttacker ? BattleHex::BOTTOM_RIGHT : BattleHex::BOTTOM_LEFT, false);
 
-			default:
-				return BattleHex::INVALID;
+				default:
+					return BattleHex::INVALID;
+			}
+		}
+		catch(const std::out_of_range &)
+		{
+			return BattleHex::INVALID;
 		}
 	}
 	if (direction == BattleHex::TOP || direction == BattleHex::BOTTOM)
 		return BattleHex::INVALID;
 
-	BattleHex adjacentAttackFrom = target.cloneInDirection(direction, false);
+	BattleHex adjacentAttackFrom = BattleHex::INVALID;
+	try
+	{
+		adjacentAttackFrom = target.cloneInDirection(direction, false);
+	}
+	catch(const std::out_of_range &)
+	{
+		return BattleHex::INVALID;
+	}
 
 	if(allowLongWeapon && attacker->hasBonusOfType(BonusType::LONG_WEAPON))
 	{
@@ -1861,7 +1899,16 @@ std::pair<std::set<const CStack*>, bool> CBattleInfoCallback::getAttackedCreatur
 	if(rangedAttack)
 		at = getPotentiallyShootableHexes(attacker, destinationTile, attackerPos);
 	else
-		at = getPotentiallyAttackableHexes(attacker, destinationTile, attackerPos);
+	{
+		try
+		{
+			at = getPotentiallyAttackableHexes(attacker, destinationTile, attackerPos);
+		}
+		catch(const std::runtime_error &)
+		{
+			return attackedCres;
+		}
+	}
 
 	for (const BattleHex & tile : at.hostileCreaturePositions) //all around & three-headed attack
 	{

--- a/test/battle/CBattleInfoCallbackTest.cpp
+++ b/test/battle/CBattleInfoCallbackTest.cpp
@@ -454,6 +454,33 @@ TEST_F(AttackableHexesTest, LongWeaponDoubleWideCanAttackWithOneEmptyHexGap)
 	EXPECT_TRUE(subject.battleCanAttackHex(availableHexes, &attacker, defender.getPosition(), BattleHex::LEFT));
 }
 
+TEST_F(AttackableHexesTest, LongWeaponDoubleWidePrefersLongReachWhenMoving)
+{
+	UnitFake & attacker = addLongWeaponDoubleWide(60, BattleSide::ATTACKER);
+	UnitFake & defender = addRegularMelee(attacker.getPosition().cloneInDirection(BattleHex::RIGHT).cloneInDirection(BattleHex::RIGHT).cloneInDirection(BattleHex::RIGHT), BattleSide::DEFENDER);
+
+	startBattle();
+	redirectUnitsToFake();
+	ON_CALL(battleMock, getAllObstacles()).WillByDefault(Return(IBattleInfo::ObstacleCList()));
+
+	const BattleHex longAttackFrom = defender.getPosition().cloneInDirection(BattleHex::LEFT).cloneInDirection(BattleHex::LEFT);
+	EXPECT_EQ(subject.fromWhichHexAttack(&attacker, defender.getPosition(), BattleHex::LEFT), longAttackFrom);
+}
+
+TEST_F(AttackableHexesTest, LongWeaponSingleWideInvalidDirectionReturnsInvalidHex)
+{
+	UnitFake & attacker = addLongWeaponUnit(60, BattleSide::ATTACKER);
+
+	startBattle();
+	redirectUnitsToFake();
+
+	EXPECT_NO_THROW(
+	{
+		const BattleHex attackFrom = subject.fromWhichHexAttack(&attacker, BattleHex(0), BattleHex::LEFT);
+		EXPECT_EQ(attackFrom, BattleHex::INVALID);
+	});
+}
+
 //// CERBERI 3-HEADED ATTACKS
 
 TEST_F(AttackableHexesTest, CerberiAttackerRight)

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -242,8 +242,8 @@ TEST_F(CGameStateTest, issue2765)
 {
 	startTestGame();
 
-	auto attacker = getHeroByOwner(PlayerColor::RED);
-	auto defender = getHeroByOwner(PlayerColor::BLUE);
+	auto attacker = getHeroByOwner(PlayerColor(0));
+	auto defender = getHeroByOwner(PlayerColor(1));
 
 	ASSERT_NE(attacker, nullptr);
 	ASSERT_NE(defender, nullptr);
@@ -326,8 +326,8 @@ TEST_F(CGameStateTest, battleResurrection)
 {
 	startTestGame();
 
-	auto attacker = getHeroByOwner(PlayerColor::RED);
-	auto defender = getHeroByOwner(PlayerColor::BLUE);
+	auto attacker = getHeroByOwner(PlayerColor(0));
+	auto defender = getHeroByOwner(PlayerColor(1));
 
 	ASSERT_NE(attacker, nullptr);
 	ASSERT_NE(defender, nullptr);
@@ -465,8 +465,8 @@ TEST_F(CGameStateTest, battleInterference)
 
 	startTestGame();
 
-	auto attacker = getHeroByOwner(PlayerColor::RED);
-	auto defender = getHeroByOwner(PlayerColor::BLUE);
+	auto attacker = getHeroByOwner(PlayerColor(0));
+	auto defender = getHeroByOwner(PlayerColor(1));
 
 	ASSERT_NE(attacker, nullptr);
 	ASSERT_NE(defender, nullptr);


### PR DESCRIPTION
### Motivation

- Ensure UI and movement/attack selection account for units with `LONG_WEAPON` reach so multi-hex attacks and movement highlighting prefer long reach when available. 
- Prevent runtime exceptions from propagating when computing potential attackable/shootable hexes or cloning hex directions.

### Description

- Added `BattleActionsController::currentActionUsesLongWeapon(const BattleHex&)` and declared it in the header to let UI logic know whether the current action should allow long-weapon reach. 
- Propagated the `allowLongWeapon` flag to attack position calculations by passing it to `fromWhichHexAttack` in `BattleFieldController::getHighlightedHexesForMovementTarget` and `BattleStacksController::selectHoveredStacks`. 
- Hardened `CBattleInfoCallback::fromWhichHexAttack` with long-weapon aware logic for double-wide and single-wide units and made it tolerate `cloneInDirection` out-of-range errors by catching `std::out_of_range`. 
- Wrapped calls to `getPotentiallyAttackableHexes` and `getPotentiallyAttackableHexes` usages in `CBattleInfoCallback` with `try/catch` to return safe defaults on `std::runtime_error`. 
- Added unit tests in `test/battle/CBattleInfoCallbackTest.cpp` to cover long-weapon double-wide long reach preference and safe handling of invalid directions, and updated some game tests to use `PlayerColor(0)`/`PlayerColor(1)`.

### Testing

- Ran the battle callback unit tests including `CBattleInfoCallbackTest`, and the new tests `LongWeaponDoubleWidePrefersLongReachWhenMoving` and `LongWeaponSingleWideInvalidDirectionReturnsInvalidHex`, and they passed. 
- Ran game state unit tests including `CGameStateTest` after adjusting `PlayerColor` usages, and they passed. 
- Executed the test suite via `ctest` and observed no regressions in the affected tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0074efc6c832d8c735b2d2209151c)