### PR TITLE
Refactor town-related adventure spell casting flow

### DIFF
--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1153,7 +1153,7 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	{
 		if(isReinforcementsDialog)
 		{
-			const auto * reinforcementsSpell = SpellID::decode("vcmi:reinforcements").toSpell();
+			const auto * reinforcementsSpell = SpellID(SpellID::decode("vcmi:reinforcements")).toSpell();
 			if(reinforcementsSpell != nullptr)
 				titleText = LIBRARY->generaltexth->translate(reinforcementsSpell->getAdventureEffectTextID("reinforcements", "garrisonTitle"));
 			else

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -67,6 +67,8 @@
 #include "../lib/CRandomGenerator.h"
 #include "../lib/CSkillHandler.h"
 #include "../lib/CSoundBase.h"
+#include "../lib/constants/EntityIdentifiers.h"
+#include "../lib/spells/CSpellHandler.h"
 
 #include <boost/lexical_cast.hpp>
 
@@ -1150,7 +1152,13 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	if(down->tempOwner == up->tempOwner)
 	{
 		if(isReinforcementsDialog)
-			titleText = LIBRARY->generaltexth->translate("vcmi.spells.reinforcements.garrison.title");
+		{
+			const auto * reinforcementsSpell = SpellID::decode("vcmi:reinforcements").toSpell();
+			if(reinforcementsSpell != nullptr)
+				titleText = LIBRARY->generaltexth->translate(reinforcementsSpell->getAdventureEffectTextID("reinforcements", "garrisonTitle"));
+			else
+				titleText = LIBRARY->generaltexth->allTexts[709];
+		}
 		else
 			titleText = LIBRARY->generaltexth->allTexts[709];
 	}

--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -139,7 +139,10 @@
 							"castsPerDayXL" : {},
 							"bonuses" : {},
 							"type" : {},
-							"allowTownSelection" : { "type" : "boolean" }
+							"allowTownSelection" : { "type" : "boolean" },
+							"casterInTown" : { "type" : "string" },
+							"selectTownTitle" : { "type" : "string" },
+							"selectTownDescription" : { "type" : "string" }
 						},
 						"additionalProperties" : false
 					}

--- a/config/schemas/spell.json
+++ b/config/schemas/spell.json
@@ -142,7 +142,8 @@
 							"allowTownSelection" : { "type" : "boolean" },
 							"casterInTown" : { "type" : "string" },
 							"selectTownTitle" : { "type" : "string" },
-							"selectTownDescription" : { "type" : "string" }
+							"selectTownDescription" : { "type" : "string" },
+							"garrisonTitle" : { "type" : "string" }
 						},
 						"additionalProperties" : false
 					}

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -163,6 +163,12 @@ std::string CSpell::getDescriptionTranslated(int32_t level) const
 	return LIBRARY->generaltexth->translate(getDescriptionTextID(level));
 }
 
+std::string CSpell::getAdventureEffectTextID(const std::string & effectType, const std::string & field) const
+{
+	TextIdentifier textID("spell", modScope, identifier, "adventureEffect", effectType, field);
+	return textID.get();
+}
+
 std::string CSpell::getJsonKey() const
 {
 	return modScope + ':' + identifier;
@@ -998,6 +1004,20 @@ std::shared_ptr<CSpell> CSpellHandler::loadFromJson(const std::string & scope, c
 		}
 
 		levelObject.adventureEffect = levelNode["adventureEffect"];
+
+		if(levelObject.adventureEffect["type"].String() == "reinforcements")
+		{
+			auto registerField = [&](const std::string & field)
+			{
+				const std::string & value = levelObject.adventureEffect[field].String();
+				if(!value.empty() && value.front() != '@')
+					LIBRARY->generaltexth->registerString(scope, spell->getAdventureEffectTextID("reinforcements", field), levelObject.adventureEffect[field]);
+			};
+
+			registerField("casterInTown");
+			registerField("selectTownTitle");
+			registerField("selectTownDescription");
+		}
 
 		if(!levelNode["battleEffects"].Struct().empty())
 		{

--- a/lib/spells/CSpellHandler.cpp
+++ b/lib/spells/CSpellHandler.cpp
@@ -1017,6 +1017,7 @@ std::shared_ptr<CSpell> CSpellHandler::loadFromJson(const std::string & scope, c
 			registerField("casterInTown");
 			registerField("selectTownTitle");
 			registerField("selectTownDescription");
+			registerField("garrisonTitle");
 		}
 
 		if(!levelNode["battleEffects"].Struct().empty())

--- a/lib/spells/CSpellHandler.h
+++ b/lib/spells/CSpellHandler.h
@@ -186,6 +186,7 @@ public:
 
 	std::string getDescriptionTextID(int32_t level) const override;
 	std::string getDescriptionTranslated(int32_t level) const override;
+	std::string getAdventureEffectTextID(const std::string & effectType, const std::string & field) const;
 
 	int32_t getLevel() const override;
 

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -13,6 +13,8 @@
 
 #include "TownRelatedSpellUtils.h"
 
+#include "../CSpellHandler.h"
+
 #include "../../CPlayerState.h"
 #include "../../callback/IGameInfoCallback.h"
 #include "../../mapObjects/CGHeroInstance.h"

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -11,10 +11,7 @@
 #include "StdInc.h"
 #include "ReinforcementsEffect.h"
 
-#include "AdventureSpellMechanics.h"
 #include "TownRelatedSpellUtils.h"
-
-#include "../CSpellHandler.h"
 
 #include "../../CPlayerState.h"
 #include "../../callback/IGameInfoCallback.h"
@@ -26,22 +23,19 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 ReinforcementsEffect::ReinforcementsEffect(const CSpell * s, const JsonNode & config)
-	: owner(s)
-	, allowTownSelection(config["allowTownSelection"].Bool())
+	: TownRelatedAdventureSpellEffect(s, config["allowTownSelection"].Bool(), false)
 {
 }
 
-ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const
+void ReinforcementsEffect::configureDialogTitleAndDescription(MetaString & title, MetaString & description) const
 {
-	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, false);
+	title.appendTextID("vcmi.spells.reinforcements.selectTown.title");
+	description.appendTextID("vcmi.spells.reinforcements.selectTown.description");
+}
 
+ESpellCastResult ReinforcementsEffect::beginCastExtraChecks(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> &) const
+{
 	const auto * casterHero = parameters.caster->getHeroCaster();
-	if(!casterHero)
-	{
-		env->complain("Not a hero caster!");
-		return ESpellCastResult::ERROR;
-	}
-
 	if(casterHero->getVisitedTown() != nullptr)
 	{
 		InfoWindow iw;
@@ -49,66 +43,6 @@ ESpellCastResult ReinforcementsEffect::beginCast(SpellCastEnvironment * env, con
 		iw.text.appendTextID("vcmi.spells.reinforcements.casterInTown");
 		env->apply(iw);
 		return ESpellCastResult::CANCEL;
-	}
-
-	if(towns.empty())
-	{
-		InfoWindow iw;
-		iw.player = parameters.caster->getCasterOwner();
-		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 124);
-		env->apply(iw);
-		return ESpellCastResult::CANCEL;
-	}
-
-	if(!parameters.pos.isValid() && allowTownSelection)
-	{
-		std::vector<ObjectInstanceID> offeredTownIDs;
-		offeredTownIDs.reserve(towns.size());
-
-		for(const auto * town : towns)
-			offeredTownIDs.push_back(town->id);
-
-		auto queryCallback = [&mechanics, env, parameters, offeredTownIDs](std::optional<int32_t> reply) -> void
-		{
-			if(reply.has_value())
-			{
-				ObjectInstanceID townId(*reply);
-				if(!vstd::contains(offeredTownIDs, townId))
-				{
-					env->complain("Invalid town selected in reinforcement dialog");
-					return;
-				}
-
-				const CGObjectInstance * object = env->getCb()->getObj(townId, true);
-				if(object == nullptr)
-				{
-					env->complain("Invalid object instance selected");
-					return;
-				}
-
-				if(!dynamic_cast<const CGTownInstance *>(object))
-				{
-					env->complain("Object instance is not town");
-					return;
-				}
-
-				AdventureSpellCastParameters nextCast;
-				nextCast.caster = parameters.caster;
-				nextCast.pos = object->visitablePos();
-				mechanics.performCast(env, nextCast);
-			}
-		};
-
-		MapObjectSelectDialog request;
-		request.player = parameters.caster->getCasterOwner();
-		request.title.appendTextID("vcmi.spells.reinforcements.selectTown.title");
-		request.description.appendTextID("vcmi.spells.reinforcements.selectTown.description");
-		request.icon = Component(ComponentType::SPELL, owner->id);
-
-		request.objects = offeredTownIDs;
-
-		env->genericQuery(&request, request.player, queryCallback);
-		return ESpellCastResult::PENDING;
 	}
 
 	return ESpellCastResult::OK;

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -24,13 +24,16 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 ReinforcementsEffect::ReinforcementsEffect(const CSpell * s, const JsonNode & config)
 	: TownRelatedAdventureSpellEffect(s, config["allowTownSelection"].Bool(), false)
+	, casterInTownTextID(config["casterInTown"].String().starts_with("@") ? config["casterInTown"].String().substr(1) : s->getAdventureEffectTextID("reinforcements", "casterInTown"))
+	, selectTownTitleTextID(config["selectTownTitle"].String().starts_with("@") ? config["selectTownTitle"].String().substr(1) : s->getAdventureEffectTextID("reinforcements", "selectTownTitle"))
+	, selectTownDescriptionTextID(config["selectTownDescription"].String().starts_with("@") ? config["selectTownDescription"].String().substr(1) : s->getAdventureEffectTextID("reinforcements", "selectTownDescription"))
 {
 }
 
 void ReinforcementsEffect::configureDialogTitleAndDescription(MetaString & title, MetaString & description) const
 {
-	title.appendTextID("vcmi.spells.reinforcements.selectTown.title");
-	description.appendTextID("vcmi.spells.reinforcements.selectTown.description");
+	title.appendTextID(selectTownTitleTextID);
+	description.appendTextID(selectTownDescriptionTextID);
 }
 
 ESpellCastResult ReinforcementsEffect::beginCastExtraChecks(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> &) const
@@ -40,7 +43,7 @@ ESpellCastResult ReinforcementsEffect::beginCastExtraChecks(SpellCastEnvironment
 	{
 		InfoWindow iw;
 		iw.player = parameters.caster->getCasterOwner();
-		iw.text.appendTextID("vcmi.spells.reinforcements.casterInTown");
+		iw.text.appendTextID(casterInTownTextID);
 		env->apply(iw);
 		return ESpellCastResult::CANCEL;
 	}

--- a/lib/spells/adventure/ReinforcementsEffect.h
+++ b/lib/spells/adventure/ReinforcementsEffect.h
@@ -10,23 +10,21 @@
 
 #pragma once
 
-#include "AdventureSpellEffect.h"
+#include "TownRelatedSpellUtils.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CGTownInstance;
 
-class DLL_LINKAGE ReinforcementsEffect final : public IAdventureSpellEffect
+class DLL_LINKAGE ReinforcementsEffect final : public spells::adventure::TownRelatedAdventureSpellEffect
 {
-	const CSpell * owner;
-	bool allowTownSelection;
-
 public:
 	ReinforcementsEffect(const CSpell * s, const JsonNode & config);
 
 private:
+	void configureDialogTitleAndDescription(MetaString & title, MetaString & description) const override;
+	ESpellCastResult beginCastExtraChecks(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & towns) const override;
 	ESpellCastResult applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const override;
-	ESpellCastResult beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const override;
 };
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/ReinforcementsEffect.h
+++ b/lib/spells/adventure/ReinforcementsEffect.h
@@ -18,6 +18,10 @@ class CGTownInstance;
 
 class DLL_LINKAGE ReinforcementsEffect final : public spells::adventure::TownRelatedAdventureSpellEffect
 {
+	std::string casterInTownTextID;
+	std::string selectTownTitleTextID;
+	std::string selectTownDescriptionTextID;
+
 public:
 	ReinforcementsEffect(const CSpell * s, const JsonNode & config);
 

--- a/lib/spells/adventure/TownPortalEffect.cpp
+++ b/lib/spells/adventure/TownPortalEffect.cpp
@@ -11,10 +11,7 @@
 #include "StdInc.h"
 #include "TownPortalEffect.h"
 
-#include "AdventureSpellMechanics.h"
 #include "TownRelatedSpellUtils.h"
-
-#include "../CSpellHandler.h"
 
 #include "../../CPlayerState.h"
 #include "../../IGameSettings.h"
@@ -27,12 +24,35 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 TownPortalEffect::TownPortalEffect(const CSpell * s, const JsonNode & config)
-	: owner(s)
+	: TownRelatedAdventureSpellEffect(s, config["allowTownSelection"].Bool(), config["skipOccupiedTowns"].Bool())
 	, movementPointsRequired(config["movementPointsRequired"].Integer())
 	, movementPointsTaken(config["movementPointsTaken"].Integer())
-	, allowTownSelection(config["allowTownSelection"].Bool())
-	, skipOccupiedTowns(config["skipOccupiedTowns"].Bool())
 {
+}
+
+bool TownPortalEffect::shouldOfferTownInDialog(const CGTownInstance * town) const
+{
+	return town->getVisitingHero() == nullptr;
+}
+
+void TownPortalEffect::configureDialogTitleAndDescription(MetaString & title, MetaString & description) const
+{
+	title.appendLocalString(EMetaText::JK_TXT, 40);
+	description.appendLocalString(EMetaText::JK_TXT, 41);
+}
+
+ESpellCastResult TownPortalEffect::beginCastExtraChecks(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> &) const
+{
+	if(static_cast<int>(parameters.caster->getHeroCaster()->movementPointsRemaining()) < movementPointsTaken)
+	{
+		InfoWindow iw;
+		iw.player = parameters.caster->getCasterOwner();
+		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 125);
+		env->apply(iw);
+		return ESpellCastResult::CANCEL;
+	}
+
+	return ESpellCastResult::OK;
 }
 
 ESpellCastResult TownPortalEffect::applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
@@ -165,92 +185,6 @@ void TownPortalEffect::endCast(SpellCastEnvironment * env, const AdventureSpellC
 			smp.val = 0;
 		env->apply(smp);
 	}
-}
-
-ESpellCastResult TownPortalEffect::beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const
-{
-	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
-
-	if(!parameters.caster->getHeroCaster())
-	{
-		env->complain("Not a hero caster!");
-		return ESpellCastResult::ERROR;
-	}
-
-	if(towns.empty())
-	{
-		InfoWindow iw;
-		iw.player = parameters.caster->getCasterOwner();
-		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 124);
-		env->apply(iw);
-		return ESpellCastResult::CANCEL;
-	}
-
-	if(static_cast<int>(parameters.caster->getHeroCaster()->movementPointsRemaining()) < movementPointsTaken)
-	{
-		InfoWindow iw;
-		iw.player = parameters.caster->getCasterOwner();
-		iw.text.appendLocalString(EMetaText::GENERAL_TXT, 125);
-		env->apply(iw);
-		return ESpellCastResult::CANCEL;
-	}
-
-	if(!parameters.pos.isValid() && allowTownSelection)
-	{
-		auto queryCallback = [&mechanics, env, parameters](std::optional<int32_t> reply) -> void
-		{
-			if(reply.has_value())
-			{
-				ObjectInstanceID townId(*reply);
-
-				const CGObjectInstance * o = env->getCb()->getObj(townId, true);
-				if(o == nullptr)
-				{
-					env->complain("Invalid object instance selected");
-					return;
-				}
-
-				if(!dynamic_cast<const CGTownInstance *>(o))
-				{
-					env->complain("Object instance is not town");
-					return;
-				}
-
-				AdventureSpellCastParameters p;
-				p.caster = parameters.caster;
-				p.pos = o->visitablePos();
-				mechanics.performCast(env, p);
-			}
-		};
-
-		MapObjectSelectDialog request;
-
-		for(const auto * t : towns)
-		{
-			if(t->getVisitingHero() == nullptr) //empty town
-				request.objects.push_back(t->id);
-		}
-
-		if(request.objects.empty())
-		{
-			InfoWindow iw;
-			iw.player = parameters.caster->getCasterOwner();
-			iw.text.appendLocalString(EMetaText::GENERAL_TXT, 124);
-			env->apply(iw);
-			return ESpellCastResult::CANCEL;
-		}
-
-		request.player = parameters.caster->getCasterOwner();
-		request.title.appendLocalString(EMetaText::JK_TXT, 40);
-		request.description.appendLocalString(EMetaText::JK_TXT, 41);
-		request.icon = Component(ComponentType::SPELL, owner->id);
-
-		env->genericQuery(&request, request.player, queryCallback);
-
-		return ESpellCastResult::PENDING;
-	}
-
-	return ESpellCastResult::OK;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/spells/adventure/TownPortalEffect.h
+++ b/lib/spells/adventure/TownPortalEffect.h
@@ -10,19 +10,16 @@
 
 #pragma once
 
-#include "AdventureSpellEffect.h"
+#include "TownRelatedSpellUtils.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CGTownInstance;
 
-class DLL_LINKAGE TownPortalEffect final : public IAdventureSpellEffect
+class DLL_LINKAGE TownPortalEffect final : public spells::adventure::TownRelatedAdventureSpellEffect
 {
-	const CSpell * owner;
 	int movementPointsRequired;
 	int movementPointsTaken;
-	bool allowTownSelection;
-	bool skipOccupiedTowns;
 
 public:
 	TownPortalEffect(const CSpell * s, const JsonNode & config);
@@ -31,8 +28,10 @@ public:
 	bool townSelectionAllowed() const { return allowTownSelection; }
 
 private:
+	bool shouldOfferTownInDialog(const CGTownInstance * town) const override;
+	void configureDialogTitleAndDescription(MetaString & title, MetaString & description) const override;
+	ESpellCastResult beginCastExtraChecks(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & towns) const override;
 	ESpellCastResult applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const override;
-	ESpellCastResult beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const override;
 	void endCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const override;
 };
 

--- a/lib/spells/adventure/TownRelatedSpellUtils.cpp
+++ b/lib/spells/adventure/TownRelatedSpellUtils.cpp
@@ -11,10 +11,15 @@
 #include "StdInc.h"
 #include "TownRelatedSpellUtils.h"
 
+#include "AdventureSpellMechanics.h"
+
+#include "../CSpellHandler.h"
+
 #include "../../CPlayerState.h"
 #include "../../callback/IGameInfoCallback.h"
 #include "../../mapObjects/CGHeroInstance.h"
 #include "../../mapObjects/CGTownInstance.h"
+#include "../../networkPacks/PacksForClient.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -59,6 +64,107 @@ const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & para
 	}
 
 	return *nearest;
+}
+
+TownRelatedAdventureSpellEffect::TownRelatedAdventureSpellEffect(const CSpell * owner_, bool allowTownSelection_, bool skipOccupiedTowns_)
+	: owner(owner_)
+	, allowTownSelection(allowTownSelection_)
+	, skipOccupiedTowns(skipOccupiedTowns_)
+{
+}
+
+bool TownRelatedAdventureSpellEffect::shouldOfferTownInDialog(const CGTownInstance * town) const
+{
+	return town != nullptr;
+}
+
+ESpellCastResult TownRelatedAdventureSpellEffect::beginCastExtraChecks(SpellCastEnvironment *, const AdventureSpellCastParameters &, const std::vector<const CGTownInstance *> &) const
+{
+	return ESpellCastResult::OK;
+}
+
+ESpellCastResult TownRelatedAdventureSpellEffect::onNoTownToSelect(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
+{
+	InfoWindow iw;
+	iw.player = parameters.caster->getCasterOwner();
+	iw.text.appendLocalString(EMetaText::GENERAL_TXT, 124);
+	env->apply(iw);
+	return ESpellCastResult::CANCEL;
+}
+
+ESpellCastResult TownRelatedAdventureSpellEffect::beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const
+{
+	std::vector<const CGTownInstance *> towns = getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
+
+	if(!parameters.caster->getHeroCaster())
+	{
+		env->complain("Not a hero caster!");
+		return ESpellCastResult::ERROR;
+	}
+
+	auto extraChecksResult = beginCastExtraChecks(env, parameters, towns);
+	if(extraChecksResult != ESpellCastResult::OK)
+		return extraChecksResult;
+
+	if(towns.empty())
+		return onNoTownToSelect(env, parameters);
+
+	if(!parameters.pos.isValid() && allowTownSelection)
+	{
+		std::vector<ObjectInstanceID> offeredTownIDs;
+		offeredTownIDs.reserve(towns.size());
+
+		for(const auto * town : towns)
+		{
+			if(shouldOfferTownInDialog(town))
+				offeredTownIDs.push_back(town->id);
+		}
+
+		if(offeredTownIDs.empty())
+			return onNoTownToSelect(env, parameters);
+
+		auto queryCallback = [&mechanics, env, parameters, offeredTownIDs](std::optional<int32_t> reply) -> void
+		{
+			if(reply.has_value())
+			{
+				ObjectInstanceID townId(*reply);
+				if(!vstd::contains(offeredTownIDs, townId))
+				{
+					env->complain("Invalid town selected in dialog");
+					return;
+				}
+
+				const CGObjectInstance * object = env->getCb()->getObj(townId, true);
+				if(object == nullptr)
+				{
+					env->complain("Invalid object instance selected");
+					return;
+				}
+
+				if(!dynamic_cast<const CGTownInstance *>(object))
+				{
+					env->complain("Object instance is not town");
+					return;
+				}
+
+				AdventureSpellCastParameters nextCast;
+				nextCast.caster = parameters.caster;
+				nextCast.pos = object->visitablePos();
+				mechanics.performCast(env, nextCast);
+			}
+		};
+
+		MapObjectSelectDialog request;
+		request.player = parameters.caster->getCasterOwner();
+		configureDialogTitleAndDescription(request.title, request.description);
+		request.icon = Component(ComponentType::SPELL, owner->id);
+		request.objects = offeredTownIDs;
+
+		env->genericQuery(&request, request.player, queryCallback);
+		return ESpellCastResult::PENDING;
+	}
+
+	return ESpellCastResult::OK;
 }
 }
 }

--- a/lib/spells/adventure/TownRelatedSpellUtils.h
+++ b/lib/spells/adventure/TownRelatedSpellUtils.h
@@ -16,7 +16,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CGTownInstance;
 class CSpell;
-class MapObjectSelectDialog;
+struct MapObjectSelectDialog;
 class MetaString;
 
 namespace spells

--- a/lib/spells/adventure/TownRelatedSpellUtils.h
+++ b/lib/spells/adventure/TownRelatedSpellUtils.h
@@ -15,6 +15,9 @@
 VCMI_LIB_NAMESPACE_BEGIN
 
 class CGTownInstance;
+class CSpell;
+class MapObjectSelectDialog;
+class MetaString;
 
 namespace spells
 {
@@ -22,6 +25,24 @@ namespace adventure
 {
 std::vector<const CGTownInstance *> getPlayerTeamTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, bool skipOccupiedTowns);
 const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool);
+
+class DLL_LINKAGE TownRelatedAdventureSpellEffect : public IAdventureSpellEffect
+{
+protected:
+	const CSpell * owner;
+	bool allowTownSelection;
+	bool skipOccupiedTowns;
+
+	explicit TownRelatedAdventureSpellEffect(const CSpell * owner, bool allowTownSelection, bool skipOccupiedTowns);
+
+	virtual bool shouldOfferTownInDialog(const CGTownInstance * town) const;
+	virtual void configureDialogTitleAndDescription(MetaString & title, MetaString & description) const = 0;
+	virtual ESpellCastResult beginCastExtraChecks(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & towns) const;
+	virtual ESpellCastResult onNoTownToSelect(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const;
+
+public:
+	ESpellCastResult beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const override;
+};
 }
 }
 


### PR DESCRIPTION
### Motivation
- Remove duplicated `beginCast` logic shared by town-related adventure spells and provide a single extensible flow for town selection and validation.
- Allow individual spells to supply only the small, spell-specific pieces (dialog strings, filtering, extra checks) instead of reimplementing the whole selection flow.
- Address reviewer request to consolidate near-duplicate code in `TownPortalEffect` and `ReinforcementsEffect`.

### Description
- Added a new base class `TownRelatedAdventureSpellEffect` in `lib/spells/adventure/TownRelatedSpellUtils.h/.cpp` that encapsulates common town-selection and query handling and provides virtual hooks `shouldOfferTownInDialog`, `configureDialogTitleAndDescription`, and `beginCastExtraChecks`.
- Migrated `TownPortalEffect` to inherit from the new base and moved spell-specific behavior into overrides: `shouldOfferTownInDialog`, `configureDialogTitleAndDescription`, and `beginCastExtraChecks` (movement-point check); updated includes accordingly (`TownPortalEffect.h/.cpp`).
- Migrated `ReinforcementsEffect` to inherit from the same base and implemented `configureDialogTitleAndDescription` and `beginCastExtraChecks` (caster-in-town check) as overrides; removed its duplicated `beginCast` implementation (`ReinforcementsEffect.h/.cpp`).
- Centralized dialog construction to use the base class flow (dialog title/description configured via `configureDialogTitleAndDescription`) and unified validation/response handling for `MapObjectSelectDialog` in the new class.

### Testing
- Attempted to configure the project with `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo` to sanity-check compilation wiring, and configuration failed due to missing Boost development components (`date_time`, `filesystem`, `locale`, `program_options`, `iostreams`).
- No automated unit or integration tests were executed in this environment after the refactor because the build configuration failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08f3234e8832da68babc8cb3f7b26)