### PR TITLE
Pass custom garrison title and refactor town-related helpers for Reinforcements

### DIFF
--- a/AI/EmptyAI/CEmptyAI.cpp
+++ b/AI/EmptyAI/CEmptyAI.cpp
@@ -60,7 +60,7 @@ void CEmptyAI::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID
 	cb->selectionMade(0, askID);
 }
 
-void CEmptyAI::showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID)
+void CEmptyAI::showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle)
 {
 	cb->selectionMade(0, queryID);
 }

--- a/AI/EmptyAI/CEmptyAI.h
+++ b/AI/EmptyAI/CEmptyAI.h
@@ -26,7 +26,7 @@ public:
 	void commanderGotLevel (const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override;
 	void showBlockingDialog(const std::string &text, const std::vector<Component> &components, QueryID askID, const int soundID, bool selection, bool cancel, bool safeToAutoaccept) override;
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
-	void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) override;
+	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	std::optional<BattleAction> makeSurrenderRetreatDecision(const BattleID & battleID, const BattleStateInfoForRetreat & battleState) override;
 };

--- a/AI/Nullkiller/AIGateway.cpp
+++ b/AI/Nullkiller/AIGateway.cpp
@@ -776,7 +776,7 @@ void AIGateway::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelI
 	});
 }
 
-void AIGateway::showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID)
+void AIGateway::showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle)
 {
 	LOG_TRACE_PARAMS(logAi, "removableUnits '%i', queryID '%i'", removableUnits % queryID);
 	NET_EVENT_HANDLER;

--- a/AI/Nullkiller/AIGateway.h
+++ b/AI/Nullkiller/AIGateway.h
@@ -97,7 +97,7 @@ public:
 	void heroGotLevel(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, QueryID queryID) override; //pskill is gained primary skill, interface has to choose one of given skills and call callback with selection id
 	void commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override; //TODO
 	void showBlockingDialog(const std::string & text, const std::vector<Component> & components, QueryID askID, const int soundID, bool selection, bool cancel, bool safeToAutoaccept) override; //Show a dialog, player must take decision. If selection then he has to choose between one of given components, if cancel he is allowed to not choose. After making choice, CCallback::selectionMade should be called with number of selected component (1 - n) or 0 for cancel (if allowed) and askID.
-	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID) override; //all stacks operations between these objects become allowed, interface has to call onEnd when done
+	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle) override; //all stacks operations between these objects become allowed, interface has to call onEnd when done
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	void finish() override;

--- a/AI/Nullkiller2/AIGateway.cpp
+++ b/AI/Nullkiller2/AIGateway.cpp
@@ -693,7 +693,7 @@ void AIGateway::showTeleportDialog(const CGHeroInstance * hero, TeleportChannelI
 	});
 }
 
-void AIGateway::showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID)
+void AIGateway::showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle)
 {
 	LOG_TRACE_PARAMS(logAi, "removableUnits '%i', queryID '%i'", removableUnits % queryID);
 	std::string s1 = up->nodeName();

--- a/AI/Nullkiller2/AIGateway.h
+++ b/AI/Nullkiller2/AIGateway.h
@@ -97,7 +97,7 @@ public:
 	void heroGotLevel(const CGHeroInstance * hero, PrimarySkill pskill, std::vector<SecondarySkill> & skills, QueryID queryID) override; //pskill is gained primary skill, interface has to choose one of given skills and call callback with selection id
 	void commanderGotLevel(const CCommanderInstance * commander, std::vector<ui32> skills, QueryID queryID) override; //TODO
 	void showBlockingDialog(const std::string & text, const std::vector<Component> & components, QueryID askID, const int soundID, bool selection, bool cancel, bool safeToAutoaccept) override; //Show a dialog, player must take decision. If selection then he has to choose between one of given components, if cancel he is allowed to not choose. After making choice, CCallback::selectionMade should be called with number of selected component (1 - n) or 0 for cancel (if allowed) and askID.
-	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID) override; //all stacks operations between these objects become allowed, interface has to call onEnd when done
+	void showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle) override; //all stacks operations between these objects become allowed, interface has to call onEnd when done
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	void finish() override;

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1268,7 +1268,7 @@ void CPlayerInterface::moveHero( const CGHeroInstance *h, const CGPath& path )
 	movementController->requestMovementStart(h, path);
 }
 
-void CPlayerInterface::showGarrisonDialog( const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID)
+void CPlayerInterface::showGarrisonDialog(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, QueryID queryID, const MetaString & customTitle)
 {
 	EVENT_HANDLER_CALLED_BY_CLIENT;
 	auto onEnd = [this, queryID](){ cb->selectionMade(0, queryID); };
@@ -1281,7 +1281,7 @@ void CPlayerInterface::showGarrisonDialog( const CArmedInstance *up, const CGHer
 
 	waitForAllDialogs();
 
-	auto cgw = std::make_shared<CGarrisonWindow>(up, down, removableUnits);
+	auto cgw = std::make_shared<CGarrisonWindow>(up, down, removableUnits, customTitle);
 	cgw->quit->addCallback(onEnd);
 	ENGINE->windows().pushWindow(cgw);
 }

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -126,7 +126,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void showRecruitmentDialog(const CGDwelling *dwelling, const CArmedInstance *dst, int level, QueryID queryID) override;
 	void showBlockingDialog(const std::string &text, const std::vector<Component> &components, QueryID askID, const int soundID, bool selection, bool cancel, bool safeToAutoaccept) override; //Show a dialog, player must take decision. If selection then he has to choose between one of given components, if cancel he is allowed to not choose. After making choice, CCallback::selectionMade should be called with number of selected component (1 - n) or 0 for cancel (if allowed) and askID.
 	void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) override;
-	void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) override;
+	void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID, const MetaString & customTitle) override;
 	void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) override;
 	void showMarketWindow(const IMarket * market, const CGHeroInstance * visitor, QueryID queryID) override;
 	void showUniversityWindow(const IMarket *market, const CGHeroInstance *visitor, QueryID queryID) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -706,7 +706,7 @@ void ApplyClientNetPackVisitor::visitGarrisonDialog(GarrisonDialog & pack)
 	const CGHeroInstance *h = cl.gameInfo().getHero(pack.hid);
 	const CArmedInstance *obj = static_cast<const CArmedInstance*>(cl.gameInfo().getObj(pack.objid));
 
-	callOnlyThatInterface(cl, h->getOwner(), &CGameInterface::showGarrisonDialog, obj, h, pack.removableUnits, pack.queryID);
+	callOnlyThatInterface(cl, h->getOwner(), &CGameInterface::showGarrisonDialog, obj, h, pack.removableUnits, pack.queryID, pack.customTitle);
 }
 
 void ApplyClientNetPackVisitor::visitExchangeDialog(ExchangeDialog & pack)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1146,18 +1146,9 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	if(sourceHero == nullptr && sourceTown != nullptr)
 		sourceHero = sourceTown->getGarrisonHero();
 
-	const bool isReinforcementsDialog = sourceTown != nullptr && down->getVisitedTown() != sourceTown;
-
 	std::string titleText;
 	if(down->tempOwner == up->tempOwner)
-	{
-		if(!customTitle.empty())
-			titleText = customTitle.toString();
-		else if(isReinforcementsDialog)
-			titleText = LIBRARY->generaltexth->allTexts[709];
-		else
-			titleText = LIBRARY->generaltexth->allTexts[709];
-	}
+		titleText = !customTitle.empty() ? customTitle.toString() : LIBRARY->generaltexth->allTexts[709];
 	else
 	{
 		//assume that this is joining monsters dialog
@@ -1173,7 +1164,7 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	}
 	title = std::make_shared<CLabel>(275, 30, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 
-	if(isReinforcementsDialog && sourceHero != nullptr)
+	if(sourceTown != nullptr && down->getVisitedTown() != sourceTown && sourceHero != nullptr)
 		banner = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), sourceHero->getIconIndex(), 0, 27, 127);
 	else
 		banner = std::make_shared<CAnimImage>(AnimationPath::builtin("CREST58"), up->getOwner().getNum(), 0, 27, 127);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1126,7 +1126,7 @@ void CUnivConfirmWindow::makeDeal(SecondarySkill skill)
 	close();
 }
 
-CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits)
+CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, const MetaString & customTitle)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("GARRISON"))
 {
 	OBJECT_CONSTRUCTION;
@@ -1151,14 +1151,10 @@ CGarrisonWindow::CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance
 	std::string titleText;
 	if(down->tempOwner == up->tempOwner)
 	{
-		if(isReinforcementsDialog)
-		{
-			const auto * reinforcementsSpell = SpellID(SpellID::decode("vcmi:reinforcements")).toSpell();
-			if(reinforcementsSpell != nullptr)
-				titleText = LIBRARY->generaltexth->translate(reinforcementsSpell->getAdventureEffectTextID("reinforcements", "garrisonTitle"));
-			else
-				titleText = LIBRARY->generaltexth->allTexts[709];
-		}
+		if(!customTitle.empty())
+			titleText = customTitle.toString();
+		else if(isReinforcementsDialog)
+			titleText = LIBRARY->generaltexth->allTexts[709];
 		else
 			titleText = LIBRARY->generaltexth->allTexts[709];
 	}

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -20,6 +20,7 @@ class CGHeroInstance;
 class CGObjectInstance;
 class CGDwelling;
 class IMarket;
+class MetaString;
 
 VCMI_LIB_NAMESPACE_END
 
@@ -430,7 +431,7 @@ class CGarrisonWindow : public CWindowObject, public IGarrisonHolder
 public:
 	std::shared_ptr<CButton> quit;
 
-	CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits);
+	CGarrisonWindow(const CArmedInstance * up, const CGHeroInstance * down, bool removableUnits, const MetaString & customTitle);
 
 	void updateGarrisons() override;
 	bool holdsGarrison(const CArmedInstance * army) override;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -283,7 +283,7 @@ set(lib_MAIN_SRCS
 	spells/adventure/RemoveObjectEffect.cpp
 	spells/adventure/ReinforcementsEffect.cpp
 	spells/adventure/SummonBoatEffect.cpp
-	spells/adventure/TownRelatedSpellUtils.cpp
+	spells/adventure/TownRelatedAdventureSpellEffect.cpp
 	spells/adventure/TownPortalEffect.cpp
 	spells/adventure/ViewWorldEffect.cpp
 

--- a/lib/callback/CGameInterface.h
+++ b/lib/callback/CGameInterface.h
@@ -22,6 +22,7 @@ class CCallback;
 class CCommanderInstance;
 
 using TTeleportExitsList = std::vector<std::pair<ObjectInstanceID, int3>>;
+class MetaString;
 
 /// Central class for managing human player / AI interface logic
 class DLL_LINKAGE CGameInterface : public CBattleGameInterface, public IGameEventsReceiver
@@ -41,7 +42,7 @@ public:
 	virtual void showBlockingDialog(const std::string &text, const std::vector<Component> &components, QueryID askID, const int soundID, bool selection, bool cancel, bool safeToAutoaccept) = 0;
 
 	// all stacks operations between these objects become allowed, interface has to call onEnd when done
-	virtual void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID) = 0;
+	virtual void showGarrisonDialog(const CArmedInstance *up, const CGHeroInstance *down, bool removableUnits, QueryID queryID, const MetaString & customTitle) = 0;
 	virtual void showTeleportDialog(const CGHeroInstance * hero, TeleportChannelID channel, TTeleportExitsList exits, bool impassable, QueryID askID) = 0;
 	virtual void showMapObjectSelectDialog(QueryID askID, const Component & icon, const MetaString & title, const MetaString & description, const std::vector<ObjectInstanceID> & objects) = 0;
 	virtual void finish(){}; //if for some reason we want to end

--- a/lib/callback/IGameEventCallback.h
+++ b/lib/callback/IGameEventCallback.h
@@ -33,6 +33,7 @@ class CGTownInstance;
 class CCreatureSet;
 class CGObjectInstance;
 class IObjectInterface;
+class MetaString;
 
 using FowTilesType = std::set<int3>;
 enum class EOpenWindowMode : uint8_t;
@@ -71,7 +72,7 @@ public:
 	virtual void changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, ChangeValueMode mode)=0;
 	virtual void changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, ChangeValueMode mode)=0;
 	virtual void showBlockingDialog(const IObjectInterface * caller, BlockingDialog *iw) =0;
-	virtual void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) =0; //cb will be called when player closes garrison window
+	virtual void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle) =0; //cb will be called when player closes garrison window
 	virtual void showTeleportDialog(TeleportDialog *iw) =0;
 	virtual void showObjectWindow(const CGObjectInstance * object, EOpenWindowMode window, const CGHeroInstance * visitor, bool addQuery) = 0;
 	virtual void giveResource(PlayerColor player, GameResID which, int val)=0;

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -88,7 +88,7 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 
 	if(relations == PlayerRelations::SAME_PLAYER) //we're visiting our mine
 	{
-		gameEvents.showGarrisonDialog(id,h->id,true);
+		gameEvents.showGarrisonDialog(id, h->id, true, MetaString());
 		return;
 	}
 	else if (relations == PlayerRelations::ALLIES)//ally
@@ -912,7 +912,7 @@ void CGGarrison::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstan
 	if (relations == PlayerRelations::ENEMIES)
 		gameEvents.setOwner(this, h->tempOwner);
 
-	gameEvents.showGarrisonDialog(id, h->id, removableUnits);
+	gameEvents.showGarrisonDialog(id, h->id, removableUnits, MetaString());
 }
 
 bool CGGarrison::passableFor(PlayerColor player) const

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -1392,6 +1392,7 @@ struct DLL_LINKAGE GarrisonDialog : public Query
 	ObjectInstanceID objid;
 	ObjectInstanceID hid;
 	bool removableUnits = false;
+	MetaString customTitle;
 
 	void visitTyped(ICPackVisitor & visitor) override;
 
@@ -1401,6 +1402,7 @@ struct DLL_LINKAGE GarrisonDialog : public Query
 		h & objid;
 		h & hid;
 		h & removableUnits;
+		h & customTitle;
 	}
 };
 

--- a/lib/spells/ISpellMechanics.h
+++ b/lib/spells/ISpellMechanics.h
@@ -31,6 +31,7 @@ class CStack;
 class CGObjectInstance;
 class CGHeroInstance;
 class IAdventureSpellEffect;
+class MetaString;
 
 namespace spells
 {
@@ -65,7 +66,7 @@ public:
 
 	virtual void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) = 0;
 	virtual bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) = 0;	//TODO: remove
-	virtual void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) = 0;
+	virtual void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle) = 0;
 
 	virtual void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) = 0;//TODO: type safety on query, use generic query packet when implemented
 };

--- a/lib/spells/adventure/ReinforcementsEffect.cpp
+++ b/lib/spells/adventure/ReinforcementsEffect.cpp
@@ -11,8 +11,6 @@
 #include "StdInc.h"
 #include "ReinforcementsEffect.h"
 
-#include "TownRelatedSpellUtils.h"
-
 #include "../CSpellHandler.h"
 
 #include "../../CPlayerState.h"
@@ -29,6 +27,7 @@ ReinforcementsEffect::ReinforcementsEffect(const CSpell * s, const JsonNode & co
 	, casterInTownTextID(config["casterInTown"].String().starts_with("@") ? config["casterInTown"].String().substr(1) : s->getAdventureEffectTextID("reinforcements", "casterInTown"))
 	, selectTownTitleTextID(config["selectTownTitle"].String().starts_with("@") ? config["selectTownTitle"].String().substr(1) : s->getAdventureEffectTextID("reinforcements", "selectTownTitle"))
 	, selectTownDescriptionTextID(config["selectTownDescription"].String().starts_with("@") ? config["selectTownDescription"].String().substr(1) : s->getAdventureEffectTextID("reinforcements", "selectTownDescription"))
+	, garrisonTitleTextID(config["garrisonTitle"].String().starts_with("@") ? config["garrisonTitle"].String().substr(1) : s->getAdventureEffectTextID("reinforcements", "garrisonTitle"))
 {
 }
 
@@ -56,7 +55,7 @@ ESpellCastResult ReinforcementsEffect::beginCastExtraChecks(SpellCastEnvironment
 ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
 {
 	const CGTownInstance * destination = nullptr;
-	std::vector<const CGTownInstance *> towns = spells::adventure::getPlayerTeamTowns(env, parameters, false);
+	std::vector<const CGTownInstance *> towns = getPlayerTeamTowns(env, parameters);
 
 	const auto * casterHero = parameters.caster->getHeroCaster();
 	if(!casterHero)
@@ -70,7 +69,7 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 
 	if(!allowTownSelection)
 	{
-		destination = spells::adventure::findNearestTown(parameters, towns);
+		destination = findNearestTown(parameters, towns);
 	}
 	else if(env->getMap()->isInTheMap(parameters.pos))
 	{
@@ -90,7 +89,9 @@ ESpellCastResult ReinforcementsEffect::applyAdventureEffects(SpellCastEnvironmen
 	}
 
 	const auto * sourceArmy = destination->getUpperArmy();
-	env->showGarrisonDialog(sourceArmy->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true);
+	MetaString garrisonTitle;
+	garrisonTitle.appendTextID(garrisonTitleTextID);
+	env->showGarrisonDialog(sourceArmy->id, ObjectInstanceID(parameters.caster->getCasterUnitId()), true, garrisonTitle);
 
 	return ESpellCastResult::OK;
 }

--- a/lib/spells/adventure/ReinforcementsEffect.h
+++ b/lib/spells/adventure/ReinforcementsEffect.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "TownRelatedSpellUtils.h"
+#include "TownRelatedAdventureSpellEffect.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -21,6 +21,7 @@ class DLL_LINKAGE ReinforcementsEffect final : public spells::adventure::TownRel
 	std::string casterInTownTextID;
 	std::string selectTownTitleTextID;
 	std::string selectTownDescriptionTextID;
+	std::string garrisonTitleTextID;
 
 public:
 	ReinforcementsEffect(const CSpell * s, const JsonNode & config);

--- a/lib/spells/adventure/TownPortalEffect.cpp
+++ b/lib/spells/adventure/TownPortalEffect.cpp
@@ -11,7 +11,7 @@
 #include "StdInc.h"
 #include "TownPortalEffect.h"
 
-#include "TownRelatedSpellUtils.h"
+#include "TownRelatedAdventureSpellEffect.h"
 
 #include "../../CPlayerState.h"
 #include "../../IGameSettings.h"
@@ -67,8 +67,8 @@ ESpellCastResult TownPortalEffect::applyAdventureEffects(SpellCastEnvironment * 
 
 	if(!allowTownSelection)
 	{
-		std::vector<const CGTownInstance *> pool = spells::adventure::getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
-		destination = spells::adventure::findNearestTown(parameters, pool);
+		std::vector<const CGTownInstance *> pool = getPlayerTeamTowns(env, parameters);
+		destination = findNearestTown(parameters, pool);
 
 		if(nullptr == destination)
 			return ESpellCastResult::ERROR;
@@ -163,8 +163,8 @@ void TownPortalEffect::endCast(SpellCastEnvironment * env, const AdventureSpellC
 
 	if(!allowTownSelection)
 	{
-		std::vector<const CGTownInstance *> pool = spells::adventure::getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
-		destination = spells::adventure::findNearestTown(parameters, pool);
+		std::vector<const CGTownInstance *> pool = getPlayerTeamTowns(env, parameters);
+		destination = findNearestTown(parameters, pool);
 	}
 	else
 	{

--- a/lib/spells/adventure/TownPortalEffect.h
+++ b/lib/spells/adventure/TownPortalEffect.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "TownRelatedSpellUtils.h"
+#include "TownRelatedAdventureSpellEffect.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 

--- a/lib/spells/adventure/TownRelatedAdventureSpellEffect.cpp
+++ b/lib/spells/adventure/TownRelatedAdventureSpellEffect.cpp
@@ -1,5 +1,5 @@
 /*
- * TownRelatedSpellUtils.cpp, part of VCMI engine
+ * TownRelatedAdventureSpellEffect.cpp, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -9,7 +9,7 @@
  */
 
 #include "StdInc.h"
-#include "TownRelatedSpellUtils.h"
+#include "TownRelatedAdventureSpellEffect.h"
 
 #include "AdventureSpellMechanics.h"
 
@@ -27,7 +27,7 @@ namespace spells
 {
 namespace adventure
 {
-std::vector<const CGTownInstance *> getPlayerTeamTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, bool skipOccupiedTowns)
+std::vector<const CGTownInstance *> TownRelatedAdventureSpellEffect::getPlayerTeamTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const
 {
 	std::vector<const CGTownInstance *> result;
 
@@ -44,7 +44,7 @@ std::vector<const CGTownInstance *> getPlayerTeamTowns(SpellCastEnvironment * en
 	return result;
 }
 
-const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool)
+const CGTownInstance * TownRelatedAdventureSpellEffect::findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool) const
 {
 	if(pool.empty() || !parameters.caster->getHeroCaster())
 		return nullptr;
@@ -94,7 +94,7 @@ ESpellCastResult TownRelatedAdventureSpellEffect::onNoTownToSelect(SpellCastEnvi
 
 ESpellCastResult TownRelatedAdventureSpellEffect::beginCast(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, const AdventureSpellMechanics & mechanics) const
 {
-	std::vector<const CGTownInstance *> towns = getPlayerTeamTowns(env, parameters, skipOccupiedTowns);
+	std::vector<const CGTownInstance *> towns = getPlayerTeamTowns(env, parameters);
 
 	if(!parameters.caster->getHeroCaster())
 	{

--- a/lib/spells/adventure/TownRelatedAdventureSpellEffect.h
+++ b/lib/spells/adventure/TownRelatedAdventureSpellEffect.h
@@ -1,5 +1,5 @@
 /*
- * TownRelatedSpellUtils.h, part of VCMI engine
+ * TownRelatedAdventureSpellEffect.h, part of VCMI engine
  *
  * Authors: listed in file AUTHORS in main folder
  *
@@ -22,10 +22,7 @@ class MetaString;
 namespace spells
 {
 namespace adventure
-{
-std::vector<const CGTownInstance *> getPlayerTeamTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters, bool skipOccupiedTowns);
-const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool);
-
+{	
 class DLL_LINKAGE TownRelatedAdventureSpellEffect : public IAdventureSpellEffect
 {
 protected:
@@ -34,6 +31,8 @@ protected:
 	bool skipOccupiedTowns;
 
 	explicit TownRelatedAdventureSpellEffect(const CSpell * owner, bool allowTownSelection, bool skipOccupiedTowns);
+	std::vector<const CGTownInstance *> getPlayerTeamTowns(SpellCastEnvironment * env, const AdventureSpellCastParameters & parameters) const;
+	const CGTownInstance * findNearestTown(const AdventureSpellCastParameters & parameters, const std::vector<const CGTownInstance *> & pool) const;
 
 	virtual bool shouldOfferTownInDialog(const CGTownInstance * town) const;
 	virtual void configureDialogTitleAndDescription(MetaString & title, MetaString & description) const = 0;

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3421,7 +3421,7 @@ bool CGameHandler::complain(const std::string &problem)
 	return true;
 }
 
-void CGameHandler::showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits)
+void CGameHandler::showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle)
 {
 	const auto * upperArmy = dynamic_cast<const CArmedInstance*>(gameInfo().getObj(upobj));
 	const auto * lowerArmy = dynamic_cast<const CArmedInstance*>(gameInfo().getObj(hid));
@@ -3436,6 +3436,7 @@ void CGameHandler::showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID h
 	gd.hid = hid;
 	gd.objid = upobj;
 	gd.removableUnits = removableUnits;
+	gd.customTitle = customTitle;
 	gd.queryID = garrisonQuery->queryID;
 	sendAndApply(gd);
 }
@@ -4025,7 +4026,7 @@ void CGameHandler::tryJoiningArmy(const CArmedInstance *src, const CArmedInstanc
 				}
 			}
 		}
-		showGarrisonDialog(src->id, dst->id, true); //show garrison window and optionally remove ourselves from map when player ends
+		showGarrisonDialog(src->id, dst->id, true, MetaString()); //show garrison window and optionally remove ourselves from map when player ends
 	}
 	else //merge
 	{

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -128,7 +128,7 @@ public:
 
 	void showBlockingDialog(const IObjectInterface * caller, BlockingDialog *iw) override;
 	void showTeleportDialog(TeleportDialog *iw) override;
-	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override;
+	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle) override;
 	void showObjectWindow(const CGObjectInstance * object, EOpenWindowMode window, const CGHeroInstance * visitor, bool addQuery) override;
 	void giveResource(PlayerColor player, GameResID which, int val) override;
 	void giveResources(PlayerColor player, const ResourceSet & resources) override;

--- a/server/ServerSpellCastEnvironment.cpp
+++ b/server/ServerSpellCastEnvironment.cpp
@@ -99,9 +99,9 @@ void ServerSpellCastEnvironment::createBoat(const int3 & visitablePosition, Boat
 	return gh->createBoat(visitablePosition, type, initiator);
 }
 
-void ServerSpellCastEnvironment::showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits)
+void ServerSpellCastEnvironment::showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle)
 {
-	gh->showGarrisonDialog(upobj, hid, removableUnits);
+	gh->showGarrisonDialog(upobj, hid, removableUnits, customTitle);
 }
 
 void ServerSpellCastEnvironment::genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback)

--- a/server/ServerSpellCastEnvironment.h
+++ b/server/ServerSpellCastEnvironment.h
@@ -38,7 +38,7 @@ public:
 	const IGameInfoCallback * getCb() const override;
 	bool moveHero(ObjectInstanceID hid, int3 dst, EMovementMode mode) override;
 	void createBoat(const int3 & visitablePosition, BoatId type, PlayerColor initiator) override;
-	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override;
+	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle) override;
 	void genericQuery(Query * request, PlayerColor color, std::function<void(std::optional<int32_t>)> callback) override;
 private:
 	CGameHandler * gh;

--- a/test/game/CGameStateTest.cpp
+++ b/test/game/CGameStateTest.cpp
@@ -134,7 +134,7 @@ public:
 		return false;
 	}
 
-	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override
+	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle) override
 	{
 	}
 

--- a/test/mock/mock_IGameEventCallback.h
+++ b/test/mock/mock_IGameEventCallback.h
@@ -40,7 +40,7 @@ public:
 	void changePrimSkill(const CGHeroInstance * hero, PrimarySkill which, si64 val, ChangeValueMode mode) override {}
 	void changeSecSkill(const CGHeroInstance * hero, SecondarySkill which, int val, ChangeValueMode mode) override {}
 	void showBlockingDialog(const IObjectInterface * caller, BlockingDialog *iw) override {}
-	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits) override {} //cb will be called when player closes garrison window
+	void showGarrisonDialog(ObjectInstanceID upobj, ObjectInstanceID hid, bool removableUnits, const MetaString & customTitle) override {} //cb will be called when player closes garrison window
 	void showTeleportDialog(TeleportDialog *iw) override {}
 	void showObjectWindow(const CGObjectInstance * object, EOpenWindowMode window, const CGHeroInstance * visitor, bool addQuery) override {};
 	void giveResource(PlayerColor player, GameResID which, int val) override {}


### PR DESCRIPTION
### Motivation
- Address reviewer feedback to remove hardcoded Reinforcements title lookup in the client and make the garrison dialog title configurable by the spell/config. 
- Improve code organization by giving the town-related helper logic a clearer place (methods on the adventure spell base) instead of free helpers.

### Description
- Renamed `TownRelatedSpellUtils.{h,cpp}` to `TownRelatedAdventureSpellEffect.{h,cpp}` and moved the helper functions `getPlayerTeamTowns` and `findNearestTown` into `TownRelatedAdventureSpellEffect` as protected member methods. 
- Made Reinforcements configurable to provide a `garrisonTitle` text id and changed `ReinforcementsEffect` to build a `MetaString` and forward it when opening the garrison dialog. 
- Added a `MetaString customTitle` field to the `GarrisonDialog` network packet and threaded the title through `CGameHandler::showGarrisonDialog`, `ServerSpellCastEnvironment::showGarrisonDialog`, client packet visitor, `CPlayerInterface::showGarrisonDialog`, and finally into `CGarrisonWindow` which now uses the provided `customTitle` (with fallback to existing text). 
- Updated related APIs and implementations to accept the new title parameter (`SpellCastEnvironment::showGarrisonDialog`, `IGameEventCallback::showGarrisonDialog`, `CGameInterface::showGarrisonDialog`) and adjusted AI mocks/tests to match the new signatures; updated `lib/CMakeLists.txt` to include renamed file. 

### Testing
- Ran configuration step `cmake -S . -B build -G Ninja` to validate project integration which failed in this environment due to missing Boost headers/libs (so a full build was not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e362f5749c832da321c17df29e711a)