### PR TITLE
Fix sticky highlight state in endgame statistic buttons

### DIFF
--- a/client/mainmenu/CStatisticScreen.cpp
+++ b/client/mainmenu/CStatisticScreen.cpp
@@ -56,10 +56,10 @@ CStatisticScreen::CStatisticScreen(const StatisticDataSet & stat)
 	layout.emplace_back(std::make_shared<TransparentFilledRectangle>(contentArea, ColorRGBA(0, 0, 0, 128), ColorRGBA(64, 80, 128, 255), 1));
 	layout.emplace_back(std::make_shared<CButton>(Point(725, 558), AnimationPath::builtin("MUBCHCK"), CButton::tooltip(), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT));
 
-	buttonSelect = std::make_shared<CToggleButton>(Point(10, 564), AnimationPath::builtin("GSPBUT2"), CButton::tooltip(), [this](bool on){ onSelectButton(); });
+	buttonSelect = std::make_shared<CButton>(Point(10, 564), AnimationPath::builtin("GSPBUT2"), CButton::tooltip(), [this](){ onSelectButton(); });
 	buttonSelect->setTextOverlay(LIBRARY->generaltexth->translate("vcmi.statisticWindow.selectView"), EFonts::FONT_SMALL, Colors::YELLOW);
 
-	buttonCsvSave = std::make_shared<CToggleButton>(Point(150, 564), AnimationPath::builtin("GSPBUT2"), CButton::tooltip(), [this](bool on){ ENGINE->input().copyToClipBoard(statistic.toCsv("\t"));	});
+	buttonCsvSave = std::make_shared<CButton>(Point(150, 564), AnimationPath::builtin("GSPBUT2"), CButton::tooltip(), [this](){ ENGINE->input().copyToClipBoard(statistic.toCsv("\t")); });
 	buttonCsvSave->setTextOverlay(LIBRARY->generaltexth->translate("vcmi.statisticWindow.tsvCopy"), EFonts::FONT_SMALL, Colors::YELLOW);
 
 	mainContent = getContent(OVERVIEW, EGameResID::NONE);
@@ -245,7 +245,7 @@ void StatisticSelector::update(int to)
 		if(i>=texts.size())
 			continue;
 
-		auto button = std::make_shared<CToggleButton>(Point(0, 10 + (i - to) * 40), AnimationPath::builtin("GSPBUT2"), CButton::tooltip(), [this, i](bool on){ close(); cb(i); });
+		auto button = std::make_shared<CButton>(Point(0, 10 + (i - to) * 40), AnimationPath::builtin("GSPBUT2"), CButton::tooltip(), [this, i](){ close(); cb(i); });
 		button->setTextOverlay(texts[i], EFonts::FONT_SMALL, Colors::WHITE);
 		buttons.emplace_back(button);
 	}

--- a/client/mainmenu/CStatisticScreen.h
+++ b/client/mainmenu/CStatisticScreen.h
@@ -12,7 +12,7 @@
 #include "../../lib/gameState/GameStatistics.h"
 
 class FilledTexturePlayerColored;
-class CToggleButton;
+class CButton;
 class GraphicalPrimitiveCanvas;
 class LineChart;
 class CGStatusBar;
@@ -60,8 +60,8 @@ class CStatisticScreen : public CWindowObject
 
 	std::shared_ptr<FilledTexturePlayerColored> filledBackground;
 	std::vector<std::shared_ptr<CIntObject>> layout;
-	std::shared_ptr<CToggleButton> buttonCsvSave;
-	std::shared_ptr<CToggleButton> buttonSelect;
+	std::shared_ptr<CButton> buttonCsvSave;
+	std::shared_ptr<CButton> buttonSelect;
 	StatisticDataSet statistic;
 	std::shared_ptr<CIntObject> mainContent;
 	Rect contentArea;
@@ -79,7 +79,7 @@ public:
 class StatisticSelector : public CWindowObject
 {
 	std::shared_ptr<FilledTexturePlayerColored> filledBackground;
-	std::vector<std::shared_ptr<CToggleButton>> buttons;
+	std::vector<std::shared_ptr<CButton>> buttons;
 	std::shared_ptr<CSlider> slider;
 
 	const int LINES = 10;


### PR DESCRIPTION
### Motivation
- Action-only controls on the endgame statistics screen used `CToggleButton`, which keeps a selected/highlighted visual state after activation (causing a sticky/hovered/pressed appearance, notably on Android), so they should be regular one-shot buttons instead.

### Description
- Replaced `CToggleButton` with `CButton` for `buttonSelect` and `buttonCsvSave` and for entries in `StatisticSelector`, updated member types and forward declaration in `CStatisticScreen.h`, and adjusted the callbacks to the non-toggle signature.

### Testing
- Ran repository checks and quick verifications: `git diff --check` succeeded, `git status --short` showed only the two modified files, and `rg -n "CToggleButton|std::shared_ptr<CButton>|buttonSelect|buttonCsvSave|StatisticSelector"` verified the replacements; changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3995bd974832da803510a6a89d1fb)