### PR TITLE
Fix LONG_WEAPON action semantics and priority

### DIFF
--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -300,7 +300,7 @@
 	"vcmi.adventureOptions.smoothDragging.hover": "Smooth Map Dragging",
 	"vcmi.artifact.charges": "Charges",
 	"vcmi.battle.action.attack": "Use melee attack",
-	"vcmi.battle.action.attackNoLongWeapon": "Use melee attack without Long Weapon",
+	"vcmi.battle.action.attackNoLongWeapon": "Use Long Weapon attack",
 	"vcmi.battle.action.genie": "Cast random beneficial spell",
 	"vcmi.battle.action.info": "Show unit information",
 	"vcmi.battle.action.move": "Move unit to specified location",

--- a/client/battle/BattleActionsController.cpp
+++ b/client/battle/BattleActionsController.cpp
@@ -363,34 +363,34 @@ void BattleActionsController::reorderPossibleActionsPriority(const CStack * stac
 			case PossiblePlayerBattleAction::ATTACK_AND_RETURN:
 				return 5;
 				break;
-			case PossiblePlayerBattleAction::ATTACK:
+			case PossiblePlayerBattleAction::LONG_WEAPON_ATTACK:
 				return 6;
 				break;
-			case PossiblePlayerBattleAction::WALK_AND_ATTACK:
+			case PossiblePlayerBattleAction::ATTACK:
 				return 7;
 				break;
-			case PossiblePlayerBattleAction::WALK_AND_SPELLCAST:
+			case PossiblePlayerBattleAction::WALK_AND_ATTACK:
 				return 8;
 				break;
-			case PossiblePlayerBattleAction::MOVE_STACK:
+			case PossiblePlayerBattleAction::WALK_AND_SPELLCAST:
 				return 9;
 				break;
-			case PossiblePlayerBattleAction::CATAPULT:
+			case PossiblePlayerBattleAction::MOVE_STACK:
 				return 10;
 				break;
-			case PossiblePlayerBattleAction::HEAL:
+			case PossiblePlayerBattleAction::CATAPULT:
 				return 11;
 				break;
-			case PossiblePlayerBattleAction::CREATURE_INFO:
+			case PossiblePlayerBattleAction::HEAL:
 				return 12;
 				break;
-			case PossiblePlayerBattleAction::HERO_INFO:
+			case PossiblePlayerBattleAction::CREATURE_INFO:
 				return 13;
 				break;
-			case PossiblePlayerBattleAction::TELEPORT:
+			case PossiblePlayerBattleAction::HERO_INFO:
 				return 14;
 				break;
-			case PossiblePlayerBattleAction::LONG_WEAPON_ATTACK:
+			case PossiblePlayerBattleAction::TELEPORT:
 				return 15;
 				break;
 			default:
@@ -616,7 +616,7 @@ std::string BattleActionsController::actionGetStatusMessage(PossiblePlayerBattle
 		case PossiblePlayerBattleAction::ATTACK_AND_RETURN: //TODO: allow to disable return
 			{
 				const auto * attacker = owner.stacksController->getActiveStack();
-				bool allowLongWeapon = action.get() != PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
+				bool allowLongWeapon = action.get() == PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
 				BattleHex attackFromHex = findAttackFromHex(owner, attacker, targetHex, allowLongWeapon);
 				assert(attackFromHex.isValid());
 				if(!attackFromHex.isValid())
@@ -796,7 +796,7 @@ bool BattleActionsController::actionIsLegal(PossiblePlayerBattleAction action, c
 		case PossiblePlayerBattleAction::ATTACK_AND_RETURN:
 			{
 				const CStack * currentStack = owner.stacksController->getActiveStack();
-				bool allowLongWeapon = action.get() != PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
+				bool allowLongWeapon = action.get() == PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
 				return currentStack &&
 					owner.getBattle()->battleCanAttackUnit(currentStack, targetStack) &&
 					owner.getBattle()->battleCanAttackHex(currentStack, targetHex) &&
@@ -902,7 +902,7 @@ void BattleActionsController::actionRealize(PossiblePlayerBattleAction action, c
 		case PossiblePlayerBattleAction::ATTACK_AND_RETURN: //TODO: allow to disable return
 		{
 			bool returnAfterAttack = action.get() == PossiblePlayerBattleAction::ATTACK_AND_RETURN;
-			bool allowLongWeapon = action.get() != PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
+			bool allowLongWeapon = action.get() == PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
 			auto attacker = owner.stacksController->getActiveStack();
 			BattleHex attackFromHex = findAttackFromHex(owner, attacker, targetHex, allowLongWeapon);
 			assert(attackFromHex.isValid());
@@ -1278,7 +1278,7 @@ bool BattleActionsController::currentActionUsesLongWeapon(const BattleHex & hove
 	if (!owner.stacksController->getActiveStack())
 		return true;
 
-	return selectAction(hoveredHex).get() != PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
+	return selectAction(hoveredHex).get() == PossiblePlayerBattleAction::LONG_WEAPON_ATTACK;
 }
 
 const std::vector<PossiblePlayerBattleAction> & BattleActionsController::getPossibleActions() const


### PR DESCRIPTION
### Motivation
- Adjust `LONG_WEAPON` action behavior to match reviewer request that the explicit `LONG_WEAPON_ATTACK` action enables long-weapon reach and has precedence over generic melee actions.

### Description
- Reordered selection priority so `PossiblePlayerBattleAction::LONG_WEAPON_ATTACK` is ranked before generic melee actions in `client/battle/BattleActionsController.cpp`.
- Inverted `allowLongWeapon` semantics so `LONG_WEAPON_ATTACK` explicitly enables long-weapon reach in status preview, legality checks, and action execution within `BattleActionsController` by changing the condition to check for `action.get() == PossiblePlayerBattleAction::LONG_WEAPON_ATTACK`.
- Updated `BattleActionsController::currentActionUsesLongWeapon` to reflect the new selection semantics so it returns true when the selected action is `LONG_WEAPON_ATTACK`.
- Updated English tooltip text in `Mods/vcmi/Content/config/translations/english.json` to match the new action meaning.

### Testing
- JSON validation was run with `python -m json.tool Mods/vcmi/Content/config/translations/english.json` and it succeeded.
- Code diff/whitespace checks were run and reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57f2684f8832db50c95ffcc92f11e)