### PR TITLE
Refresh LAN lobby Start button when client joins

### DIFF
--- a/client/LobbyClientNetPackVisitors.h
+++ b/client/LobbyClientNetPackVisitors.h
@@ -53,6 +53,7 @@ public:
 	{
 	}
 
+	void visitLobbyClientConnected(LobbyClientConnected & pack) override;
 	void visitLobbyClientDisconnected(LobbyClientDisconnected & pack) override;
 	void visitLobbyChatMessage(LobbyChatMessage & pack) override;
 	void visitLobbyGuiAction(LobbyGuiAction & pack) override;

--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -51,7 +51,7 @@ void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyQuickLoadGame(LobbyQuickLoadGa
 
 void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyClientConnected(LobbyClientConnected & pack)
 {
-	result = false;
+	result = handler.getState() == EClientState::LOBBY;
 
 	// Check if it's LobbyClientConnected for our client
 	if(pack.uuid == handler.logicConnection->uuid)
@@ -91,6 +91,7 @@ void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyClientConnected(LobbyClientCon
 			ENGINE->windows().createAndPushWindow<CLobbyScreen>(handler.screenType, hideScreen);
 		}
 		handler.setState(EClientState::LOBBY);
+		result = true;
 	}
 }
 
@@ -110,6 +111,17 @@ void ApplyOnLobbyScreenNetPackVisitor::visitLobbyClientDisconnected(LobbyClientD
 	
 	if(ENGINE->windows().count() > 0)
 		ENGINE->windows().popWindows(1);
+}
+
+void ApplyOnLobbyScreenNetPackVisitor::visitLobbyClientConnected(LobbyClientConnected & pack)
+{
+	(void)pack;
+
+	if(!lobby)
+		return;
+
+	// Refresh host UI immediately when a remote client joins.
+	lobby->updateAfterStateChange();
 }
 
 void ApplyOnLobbyScreenNetPackVisitor::visitLobbyChatMessage(LobbyChatMessage & pack)


### PR DESCRIPTION
### Motivation
- Host UI could show a stale Start button state in LAN games because `LobbyClientConnected` events were not propagated to the lobby screen to re-evaluate `canStartLobbyGame()` immediately.

### Description
- Allow `LobbyClientConnected` to be considered by the handler visitor while already in `EClientState::LOBBY` by setting `result = handler.getState() == EClientState::LOBBY` in `ApplyOnLobbyHandlerNetPackVisitor::visitLobbyClientConnected` in `client/NetPacksLobbyClient.cpp`.
- Add a screen-side visitor override `ApplyOnLobbyScreenNetPackVisitor::visitLobbyClientConnected` (declared in `client/LobbyClientNetPackVisitors.h`) that calls `lobby->updateAfterStateChange()` to refresh UI (including Start button) when a remote client joins.

### Testing
- Ran repository checks to verify new visitor declaration and usage with `rg` and inspected modified files; these checks succeeded.
- Committed the changes with `git commit` which succeeded.
- Verified that the handler and screen-side visitor signatures match and that the new call to `updateAfterStateChange()` is present; verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e693e5a61c832d98bee9994d72f58a)