### PR TITLE
Use ResourcePath for save/load and remove FileInfo dependency

### DIFF
--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -47,7 +47,6 @@
 #include "../lib/entities/faction/CTownHandler.h"
 #include "../lib/entities/hero/CHeroHandler.h"
 
-#include "../lib/filesystem/FileInfo.h"
 #include "../lib/filesystem/Filesystem.h"
 
 #include "../lib/gameState/CGameState.h"
@@ -1630,9 +1629,8 @@ bool CGameHandler::responseStatistic(PlayerColor player)
 void CGameHandler::save(const std::string & filename, PlayerColor playerToNotifyOnSuccess)
 {
 	logGlobal->info("Saving to %s", filename);
-	const auto stem	= FileInfo::GetPathStem(filename);
-	const auto savefname = stem.to_string() + ".vsgm1";
-	ResourcePath savePath(stem.to_string(), EResType::SAVEGAME);
+	ResourcePath savePath(filename, EResType::SAVEGAME);
+	const auto savefname = savePath.getOriginalName() + ".vsgm1";
 	CResourceHandler::get("local")->createResource(savefname);
 
 	std::string filenameWithoutPath;
@@ -1675,12 +1673,9 @@ void CGameHandler::save(const std::string & filename, PlayerColor playerToNotify
 void CGameHandler::load(const StartInfo &info)
 {
 	logGlobal->info("Loading from %s", info.mapname);
-	// No need to use the stem because info.mapname doesn't come with the file extension included
-	// const auto stem	= FileInfo::GetPathStem(info.mapname);
 
 	reinitScripting();
 
-	// CLoadFile lf(*CResourceHandler::get()->getResourceName(ResourcePath(stem.to_string(), EResType::SAVEGAME)), gs.get());
 	CLoadFile lf(*CResourceHandler::get()->getResourceName(ResourcePath(info.mapname, EResType::SAVEGAME)), gs.get());
 	gs = std::make_shared<CGameState>();
 	randomizer = std::make_unique<GameRandomizer>(*gs);


### PR DESCRIPTION
### Motivation

- Replace ad-hoc path-stem manipulations with the centralized `ResourcePath` handling for savegame resources to simplify path logic and remove dependency on `FileInfo`.

### Description

- Removed inclusion of `FileInfo.h` and switched save logic to construct `ResourcePath` directly with `filename` and `EResType::SAVEGAME` and obtain the original name via `getOriginalName()` when creating the resource file name.  
- Use `CResourceHandler::get("local")->createResource(savefname)` and write the save to the resource obtained from `getResourceName(savePath)` in `save`.  
- Adjusted `load` to use `CLoadFile` constructed from `CResourceHandler::get()->getResourceName(ResourcePath(info.mapname, EResType::SAVEGAME))` instead of deriving a stem.  
- Kept existing save/load flow and error handling while consolidating filename/path management through `ResourcePath`.

### Testing

- Built the project successfully with the updated includes and code changes (`make`), and the build completed without errors.  
- Ran the automated unit test suite (`ctest`) and all tests passed.  
- Executed automated save/load tests which exercised `save` and `load` code paths and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e936fb6f4c832dac0245d2503a3fa2)