### PR TITLE
Show enemy hero threat level in right-click popup (extended hero tooltip background)

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -39,6 +39,7 @@ void AssetGenerator::initialize()
 	imageFiles[ImagePath::builtin("AdventureOptionsBackgroundClear.png")] = [this](){ return createAdventureOptionsCleanBackground();};
 	imageFiles[ImagePath::builtin("SpellBookLarge.png")] = [this](){ return createBigSpellBook();};
 	imageFiles[ImagePath::builtin("MuPopUpCustom.png")] = [this](){ return createMuPopUpCustom();};
+	imageFiles[ImagePath::builtin("HEROQVBK_EXTENDED.png")] = [this](){ return createHeroTooltipExtended();};
 
 	imageFiles[ImagePath::builtin("combatUnitNumberWindowDefault.png")]  = [this](){ return createCombatUnitNumberWindow(0.6f, 0.2f, 1.0f);};
 	imageFiles[ImagePath::builtin("combatUnitNumberWindowNeutral.png")]  = [this](){ return createCombatUnitNumberWindow(1.0f, 1.0f, 2.0f);};
@@ -239,6 +240,43 @@ AssetGenerator::CanvasPtr AssetGenerator::createMuPopUpCustom() const
 
 	canvas.draw(img, Point(0, 0), Rect(0, 0, 454, 449));
 	canvas.draw(img, Point(0, 420), Rect(0, img->dimensions().y - 29, 454, 29));
+
+	return image;
+}
+
+AssetGenerator::CanvasPtr AssetGenerator::createHeroTooltipExtended() const
+{
+	auto heroTooltipLocator = ImageLocator(ImagePath::builtin("HEROQVBK"), EImageBlitMode::OPAQUE);
+	auto dialogBackgroundLocator = ImageLocator(ImagePath::builtin("DIBOXBCK"), EImageBlitMode::OPAQUE);
+
+	std::shared_ptr<IImage> heroTooltip = ENGINE->renderHandler().loadImage(heroTooltipLocator);
+	std::shared_ptr<IImage> dialogBackground = ENGINE->renderHandler().loadImage(dialogBackgroundLocator);
+
+	const int targetWidth = heroTooltip->dimensions().x;
+	const int baseHeight = heroTooltip->dimensions().y;
+	const int extensionHeight = 40;
+	const int targetHeight = baseHeight + extensionHeight;
+
+	auto image = ENGINE->renderHandler().createImage(Point(targetWidth, targetHeight), CanvasScalingPolicy::IGNORE);
+	Canvas canvas = image->getCanvas();
+
+	canvas.draw(heroTooltip, Point(0, 0));
+
+	for(int y = baseHeight; y < targetHeight; y += dialogBackground->dimensions().y)
+	{
+		for(int x = 0; x < targetWidth; x += dialogBackground->dimensions().x)
+		{
+			const int drawWidth = std::min(dialogBackground->dimensions().x, targetWidth - x);
+			const int drawHeight = std::min(dialogBackground->dimensions().y, targetHeight - y);
+			canvas.draw(dialogBackground, Point(x, y), Rect(0, 0, drawWidth, drawHeight));
+		}
+	}
+
+	// Keep frame continuity from original tooltip for the extra area.
+	canvas.draw(heroTooltip, Point(0, baseHeight), Rect(0, baseHeight - 1, targetWidth, 1));
+	canvas.draw(heroTooltip, Point(0, baseHeight), Rect(0, 0, 1, extensionHeight));
+	canvas.draw(heroTooltip, Point(targetWidth - 1, baseHeight), Rect(targetWidth - 1, 0, 1, extensionHeight));
+	canvas.draw(heroTooltip, Point(0, targetHeight - 1), Rect(0, baseHeight - 1, targetWidth, 1));
 
 	return image;
 }

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -72,6 +72,7 @@ private:
 	CanvasPtr createHeroSlotsColored(PlayerColor backColor) const;
 	CanvasPtr createStackArtifactIndicator(const Point & size) const;
 	CanvasPtr createMuPopUpCustom() const;
+	CanvasPtr createHeroTooltipExtended() const;
 
 	void createPaletteShiftedSprites();
 	void generatePaletteShiftedAnimation(const AnimationPath & source, const std::vector<PaletteAnimation> & animation);

--- a/client/widgets/MiscWidgets.cpp
+++ b/client/widgets/MiscWidgets.cpp
@@ -350,7 +350,7 @@ CArmyTooltip::CArmyTooltip(Point pos, const CArmedInstance * army):
 	init(InfoAboutArmy(army, true));
 }
 
-void CHeroTooltip::init(const InfoAboutHero & hero)
+void CHeroTooltip::init(const InfoAboutHero & hero, const std::string & threatLevelText)
 {
 	OBJECT_CONSTRUCTION;
 	portrait = std::make_shared<CAnimImage>(AnimationPath::builtin("PortraitsLarge"), hero.getIconIndex(), 0, 3, 2);
@@ -368,18 +368,27 @@ void CHeroTooltip::init(const InfoAboutHero & hero)
 		morale = std::make_shared<CAnimImage>(AnimationPath::builtin("IMRL22"), std::clamp(hero.details->morale + 3, 0 , 6), 0, 5, 74);
 		luck = std::make_shared<CAnimImage>(AnimationPath::builtin("ILCK22"), std::clamp(hero.details->luck + 3, 0, 6), 0, 5, 91);
 	}
+
+	if(!threatLevelText.empty())
+		threatLevel = std::make_shared<CLabel>(83, 176, FONT_TINY, ETextAlignment::CENTER, Colors::WHITE, threatLevelText, 166);
 }
 
 CHeroTooltip::CHeroTooltip(Point pos, const InfoAboutHero &hero):
 	CArmyTooltip(pos, hero)
 {
-	init(hero);
+	init(hero, "");
 }
 
 CHeroTooltip::CHeroTooltip(Point pos, const CGHeroInstance * hero):
 	CArmyTooltip(pos, InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED))
 {
-	init(InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED));
+	init(InfoAboutHero(hero, InfoAboutHero::EInfoLevel::DETAILED), "");
+}
+
+CHeroTooltip::CHeroTooltip(Point pos, const InfoAboutHero & hero, const std::string & threatLevelText):
+	CArmyTooltip(pos, hero)
+{
+	init(hero, threatLevelText);
 }
 
 CInteractableHeroTooltip::CInteractableHeroTooltip(Point pos, const CGHeroInstance * hero)

--- a/client/widgets/MiscWidgets.h
+++ b/client/widgets/MiscWidgets.h
@@ -94,11 +94,13 @@ class CHeroTooltip : public CArmyTooltip
 	std::vector<std::shared_ptr<CLabel>> labels;
 	std::shared_ptr<CAnimImage> morale;
 	std::shared_ptr<CAnimImage> luck;
+	std::shared_ptr<CLabel> threatLevel;
 
-	void init(const InfoAboutHero & hero);
+	void init(const InfoAboutHero & hero, const std::string & threatLevelText);
 public:
 	CHeroTooltip(Point pos, const InfoAboutHero & hero);
 	CHeroTooltip(Point pos, const CGHeroInstance * hero);
+	CHeroTooltip(Point pos, const InfoAboutHero & hero, const std::string & threatLevelText);
 };
 
 /// Class for HD mod-like interactable infobox tooltip. Does not have any background!

--- a/client/windows/InfoWindows.cpp
+++ b/client/windows/InfoWindows.cpp
@@ -39,6 +39,74 @@
 #include "../../lib/mapObjects/MiscObjects.h"
 #include "../../lib/ConditionalWait.h"
 
+#include <algorithm>
+#include <cctype>
+
+namespace
+{
+int getThreatLevelFromRatio(double ratio)
+{
+	if (ratio < 0.1)
+		return 0;
+	if (ratio < 0.25)
+		return 1;
+	if (ratio < 0.6)
+		return 2;
+	if (ratio < 0.9)
+		return 3;
+	if (ratio < 1.1)
+		return 4;
+	if (ratio < 1.3)
+		return 5;
+	if (ratio < 1.8)
+		return 6;
+	if (ratio < 2.5)
+		return 7;
+	if (ratio < 4)
+		return 8;
+	if (ratio < 8)
+		return 9;
+	if (ratio < 20)
+		return 10;
+	return 11;
+}
+
+std::string trimLeadingWhitespaces(std::string value)
+{
+	value.erase(value.begin(), std::find_if(value.begin(), value.end(), [](unsigned char ch)
+	{
+		return !std::isspace(ch);
+	}));
+	return value;
+}
+
+std::string getEnemyHeroThreatText(const CGHeroInstance * enemyHero)
+{
+	if(!settings["general"]["enableUiEnhancements"].Bool() || enemyHero == nullptr)
+		return "";
+
+	auto localState = GAME->interface()->localState;
+	auto currentHero = localState ? localState->getCurrentHero() : nullptr;
+	if(currentHero == nullptr)
+		return "";
+
+	if(currentHero->tempOwner == enemyHero->tempOwner)
+		return "";
+
+	uint64_t localHeroStrength = currentHero->getTotalStrength();
+	if(localHeroStrength == 0)
+		return "";
+
+	double ratio = static_cast<double>(enemyHero->getTotalStrength()) / static_cast<double>(localHeroStrength);
+	int level = getThreatLevelFromRatio(ratio);
+
+	auto title = trimLeadingWhitespaces(LIBRARY->generaltexth->translate("vcmi.adventureMap.monsterThreat.title"));
+	auto threatDescription = LIBRARY->generaltexth->translate("vcmi.adventureMap.monsterThreat.levels." + std::to_string(level));
+
+	return title + threatDescription;
+}
+}
+
 CSelWindow::CSelWindow( const std::string & Text, PlayerColor player, int charperline, const std::vector<std::shared_ptr<CSelectableComponent>> & comps, const std::vector<std::pair<AnimationPath, CFunctionList<void()>>> & Buttons, QueryID askID)
 {
 	OBJECT_CONSTRUCTION;
@@ -306,13 +374,13 @@ CInfoBoxPopup::CInfoBoxPopup(Point position, const CGTownInstance * town)
 }
 
 CInfoBoxPopup::CInfoBoxPopup(Point position, const CGHeroInstance * hero)
-	: AdventureMapPopup(RCLICK_POPUP | PLAYER_COLORED, ImagePath::builtin("HEROQVBK"), position)
+	: AdventureMapPopup(RCLICK_POPUP | PLAYER_COLORED, ImagePath::builtin("HEROQVBK_EXTENDED.png"), position)
 {
 	InfoAboutHero iah;
 	GAME->interface()->cb->getHeroInfo(hero, iah, GAME->interface()->localState->getCurrentArmy()); //todo: should this be nearest hero?
 
 	OBJECT_CONSTRUCTION;
-	tooltip = std::make_shared<CHeroTooltip>(Point(9, 10), iah);
+	tooltip = std::make_shared<CHeroTooltip>(Point(9, 10), iah, getEnemyHeroThreatText(hero));
 
 	if(settings["general"]["enableUiEnhancements"].Bool())
 		background->setPlayerColor(hero->getOwner());


### PR DESCRIPTION
### Motivation
- Provide the same "threat / treat level" information shown for map monsters also in the right-click hero preview, so players can quickly see relative danger against their current hero.

### Description
- Generate an extended hero popup background by adding `HEROQVBK_EXTENDED.png` via a new `AssetGenerator::createHeroTooltipExtended()` and register it in `AssetGenerator::initialize()` so the hero popup can be taller by 40px and stay visually consistent with `HEROQVBK` and `DIBOXBCK`.
- Compute enemy-hero threat using the same ratio buckets as monster threat in a new helper `getEnemyHeroThreatText()` and trim leading whitespace from the localized title; this logic is added to `client/windows/InfoWindows.cpp` and reuses existing translation keys `vcmi.adventureMap.monsterThreat.*`.
- Extend `CHeroTooltip` to accept an optional threat string (new constructor and `init` signature) and render the threat label into the added lower area (`client/widgets/MiscWidgets.h` / `client/widgets/MiscWidgets.cpp`).
- Wire the hero right-click popup to use the extended background and pass the calculated threat text (`client/windows/InfoWindows.cpp`).

### Testing
- Ran `git diff --check` which returned clean results.
- Verified repository status with `git status --short` and inspected the last commit via `git show --stat` to confirm the changes were recorded and committed.
- Could not run a full build or runtime tests in this environment because the `build/` directory is not present, so compilation and visual verification were not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e959ecfb38832d8d890053e89faf06)