### PR TITLE
Support randomized market offers for resource-skill buildings

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1202,6 +1202,10 @@ AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(co
 		}
 	}
 
+	// Status bar overlay: darken bottom strip to match original dialog style
+	const int statusBarOverlayHeight = 30;
+	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 72));
+
 	auto drawHorizontal = [&canvas](const std::shared_ptr<IImage> & source, int y, int xBegin, int xEnd)
 	{
 		for(int x = xBegin; x < xEnd; x += source->width())

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1204,7 +1204,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(co
 
 	// Status bar overlay: darken bottom strip to match original dialog style
 	const int statusBarOverlayHeight = 30;
-	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 72));
+	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
 
 	auto drawHorizontal = [&canvas](const std::shared_ptr<IImage> & source, int y, int xBegin, int xEnd)
 	{

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -85,6 +85,7 @@ void AssetGenerator::initialize()
 	addRecruitmentBackground("TPRCRT5", Point(594, 394));
 	addRecruitmentBackground("TPRCRT6", Point(704, 394));
 	addUniversityBackground("UNIVRS4", Point(466, 388));
+	addUniversityConfirmBackground("UNIVRS2", Point(466, 388));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{
@@ -174,6 +175,16 @@ void AssetGenerator::addUniversityBackground(const std::string & fileName, const
 		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
 		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
 		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createUniversityDialogBackground(size, playerColor);};
+	}
+}
+
+void AssetGenerator::addUniversityConfirmBackground(const std::string & fileName, const Point & size)
+{
+	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
+	{
+		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
+		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
+		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createUniversityConfirmDialogBackground(size, playerColor);};
 	}
 }
 
@@ -1341,6 +1352,31 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 		const int iconX = stripX[i] + (smallBlockWidth - iconSize) / 2;
 		drawSlot(Rect(iconX, iconY, iconSize, iconSize));
 	}
+
+	return image;
+}
+
+AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor) const
+{
+	auto image = createDialogBackgroundWithStatusBar(size, playerColor);
+	Canvas canvas = image->getCanvas();
+
+	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
+	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);
+
+	auto drawPlate = [&canvas, rectangleColor, borderColor](const Rect & rect)
+	{
+		canvas.drawColorBlended(rect, rectangleColor);
+		canvas.drawBorder(rect, borderColor);
+	};
+
+	// Text block: same geometry as UNIVRS4
+	drawPlate(Rect(26, 127, size.x - 52, 74));
+
+	// Centered header/action plates
+	drawPlate(Rect((size.x - 105) / 2, 26, 105, 21));
+	drawPlate(Rect((size.x - 105) / 2, 95, 105, 21));
+	drawPlate(Rect((size.x - 71) / 2, 258, 71, 19));
 
 	return image;
 }

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -84,6 +84,7 @@ void AssetGenerator::initialize()
 	addRecruitmentBackground("TPRCRT4", Point(484, 394));
 	addRecruitmentBackground("TPRCRT5", Point(594, 394));
 	addRecruitmentBackground("TPRCRT6", Point(704, 394));
+	addUniversityBackground("UNIVRS4", Point(465, 388));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{
@@ -163,6 +164,16 @@ void AssetGenerator::addRecruitmentBackground(const std::string & fileName, cons
 		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
 		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
 		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createRecruitmentDialogBackground(size, playerColor);};
+	}
+}
+
+void AssetGenerator::addUniversityBackground(const std::string & fileName, const Point & size)
+{
+	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
+	{
+		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
+		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
+		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createUniversityDialogBackground(size, playerColor);};
 	}
 }
 
@@ -1270,6 +1281,48 @@ AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(cons
 
 	// Central black input bar - 142x20
 	drawPlate(centered(Rect(171, 278, 142, 20)), true);
+
+	return image;
+}
+
+AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor) const
+{
+	auto image = createDialogBackgroundWithStatusBar(size, playerColor);
+	Canvas canvas = image->getCanvas();
+
+	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
+	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);
+	const ColorRGBA slotColor = ColorRGBA(0, 0, 0, 95);
+
+	auto drawPlate = [&canvas, rectangleColor, borderColor](const Rect & rect)
+	{
+		canvas.drawColorBlended(rect, rectangleColor);
+		canvas.drawBorder(rect, borderColor);
+	};
+
+	auto drawSlot = [&canvas, slotColor, borderColor](const Rect & rect)
+	{
+		canvas.drawColorBlended(rect, slotColor);
+		canvas.drawBorder(rect, borderColor);
+	};
+
+	// Speech frame
+	drawPlate(Rect(23, 126, 419, 73));
+
+	// Skill strips + icon slots for 4-skill layout
+	const int stripYTop = 230;
+	const int stripYBottom = 292;
+	const int slotY = 251;
+	const int firstX = 31;
+	const int stepX = 104;
+
+	for(int i = 0; i < 4; ++i)
+	{
+		const int x = firstX + i * stepX;
+		drawPlate(Rect(x, stripYTop, 97, 19));
+		drawPlate(Rect(x, stripYBottom, 97, 19));
+		drawSlot(Rect(x + 18, slotY, 45, 45));
+	}
 
 	return image;
 }

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1306,22 +1306,38 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 		canvas.drawBorder(rect, borderColor);
 	};
 
-	// Speech frame
-	drawPlate(Rect(23, 126, 419, 73));
+	// Main text block
+	const int horizontalMargin = 26;
+	const int largeBlockY = 127;
+	const int largeBlockHeight = 74;
+	drawPlate(Rect(horizontalMargin, largeBlockY, size.x - 2 * horizontalMargin, largeBlockHeight));
 
-	// Skill strips + icon slots for 4-skill layout
-	const int stripYTop = 230;
-	const int stripYBottom = 292;
-	const int slotY = 251;
-	const int firstX = 31;
-	const int stepX = 104;
+	// Four top/bottom strips distributed evenly between same left/right margins
+	const int smallBlockWidth = 102;
+	const int smallBlockHeight = 20;
+	const int firstRowY = largeBlockY + largeBlockHeight + 10; // 10px below large block
+	const int secondRowY = firstRowY + smallBlockHeight + 50; // 50px below first row (edge to edge)
 
+	std::array<int, 4> stripX;
 	for(int i = 0; i < 4; ++i)
 	{
-		const int x = firstX + i * stepX;
-		drawPlate(Rect(x, stripYTop, 97, 19));
-		drawPlate(Rect(x, stripYBottom, 97, 19));
-		drawSlot(Rect(x + 18, slotY, 45, 45));
+		double t = (i / 3.0);
+		double x = horizontalMargin + t * (size.x - 2 * horizontalMargin - smallBlockWidth);
+		stripX[i] = static_cast<int>(std::lround(x));
+
+		drawPlate(Rect(stripX[i], firstRowY, smallBlockWidth, smallBlockHeight));
+		drawPlate(Rect(stripX[i], secondRowY, smallBlockWidth, smallBlockHeight));
+	}
+
+	// Three icon boxes centered between neighboring strip centers
+	const int iconSize = 44;
+	const int iconY = firstRowY + smallBlockHeight + 3; // 3px below first row and 3px above second row
+	for(int i = 0; i < 3; ++i)
+	{
+		const double centerA = stripX[i] + smallBlockWidth / 2.0;
+		const double centerB = stripX[i + 1] + smallBlockWidth / 2.0;
+		const int iconX = static_cast<int>(std::lround((centerA + centerB) * 0.5 - iconSize * 0.5));
+		drawSlot(Rect(iconX, iconY, iconSize, iconSize));
 	}
 
 	return image;

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -84,7 +84,7 @@ void AssetGenerator::initialize()
 	addRecruitmentBackground("TPRCRT4", Point(484, 394));
 	addRecruitmentBackground("TPRCRT5", Point(594, 394));
 	addRecruitmentBackground("TPRCRT6", Point(704, 394));
-	addUniversityBackground("UNIVRS4", Point(465, 388));
+	addUniversityBackground("UNIVRS4", Point(466, 388));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1329,14 +1329,12 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 		drawPlate(Rect(stripX[i], secondRowY, smallBlockWidth, smallBlockHeight));
 	}
 
-	// Three icon boxes centered between neighboring strip centers
+	// Four icon boxes centered in each strip column
 	const int iconSize = 44;
 	const int iconY = firstRowY + smallBlockHeight + 3; // 3px below first row and 3px above second row
-	for(int i = 0; i < 3; ++i)
+	for(int i = 0; i < 4; ++i)
 	{
-		const double centerA = stripX[i] + smallBlockWidth / 2.0;
-		const double centerB = stripX[i + 1] + smallBlockWidth / 2.0;
-		const int iconX = static_cast<int>(std::lround((centerA + centerB) * 0.5 - iconSize * 0.5));
+		const int iconX = stripX[i] + (smallBlockWidth - iconSize) / 2;
 		drawSlot(Rect(iconX, iconY, iconSize, iconSize));
 	}
 

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -36,6 +36,7 @@ public:
 	void addAnimationFile(const AnimationPath & path, AnimationLayoutMap & anim);
 	void addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor);
 	void addRecruitmentBackground(const std::string & fileName, const Point & size);
+	void addUniversityBackground(const std::string & fileName, const Point & size);
 
 	AnimationLayoutMap createAdventureMapButton(const ImagePath & overlay, bool small);
 	AnimationLayoutMap createSliderBar(bool brown, bool horizontal, int length);
@@ -65,6 +66,7 @@ private:
 	CanvasPtr createCreatureInfoPanel(int boxesAmount) const;
 	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const;
 	CanvasPtr createRecruitmentDialogBackground(const Point & size, const PlayerColor & playerColor) const;
+	CanvasPtr createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor) const;
 	enum CreateResourceWindowType{ ARTIFACTS_BUYING, ARTIFACTS_SELLING, MARKET_RESOURCES, FREELANCERS_GUILD, TRANSFER_RESOURCES };
 	CanvasPtr createResourceWindow(CreateResourceWindowType type, int count, PlayerColor color) const;
 	enum CreatureInfoPanelElement{ BONUS_EFFECTS, SPELL_EFFECTS, BUTTON_PANEL, COMMANDER_BACKGROUND, COMMANDER_ABILITIES };

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -37,6 +37,7 @@ public:
 	void addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor);
 	void addRecruitmentBackground(const std::string & fileName, const Point & size);
 	void addUniversityBackground(const std::string & fileName, const Point & size);
+	void addUniversityConfirmBackground(const std::string & fileName, const Point & size);
 
 	AnimationLayoutMap createAdventureMapButton(const ImagePath & overlay, bool small);
 	AnimationLayoutMap createSliderBar(bool brown, bool horizontal, int length);
@@ -67,6 +68,7 @@ private:
 	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const;
 	CanvasPtr createRecruitmentDialogBackground(const Point & size, const PlayerColor & playerColor) const;
 	CanvasPtr createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor) const;
+	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor) const;
 	enum CreateResourceWindowType{ ARTIFACTS_BUYING, ARTIFACTS_SELLING, MARKET_RESOURCES, FREELANCERS_GUILD, TRANSFER_RESOURCES };
 	CanvasPtr createResourceWindow(CreateResourceWindowType type, int count, PlayerColor color) const;
 	enum CreatureInfoPanelElement{ BONUS_EFFECTS, SPELL_EFFECTS, BUTTON_PANEL, COMMANDER_BACKGROUND, COMMANDER_ABILITIES };

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -91,6 +91,19 @@ static ImagePath getRecruitmentBackground(const CGDwelling * dwelling, int level
 	return ImagePath::builtin(fileName);
 }
 
+static ImagePath getUniversityBackground(const IMarket * market)
+{
+	const auto skillCount = market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size();
+	if(skillCount != 4)
+		return ImagePath::builtin("UNIVERS1");
+
+	std::string fileName = "UNIVRS4";
+	if(auto town = dynamic_cast<const CGTownInstance *>(market); town && town->tempOwner.isValidPlayer())
+		fileName += "-" + town->tempOwner.toString();
+
+	return ImagePath::builtin(fileName);
+}
+
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | SHOW_POPUP),
 	parent(window),
@@ -1049,7 +1062,7 @@ void CUniversityWindow::CItem::update()
 }
 
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed)
-	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("UNIVERS1")),
+	: CWindowObject(PLAYER_COLORED, getUniversityBackground(_market)),
 	hero(_hero),
 	onWindowClosed(onWindowClosed),
 	market(_market)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1138,7 +1138,7 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 {
 	OBJECT_CONSTRUCTION;
 
-	TResources skillCost = owner->market->getSkillCost(SKILL);
+	TResources skillCost = owner->getMarket()->getSkillCost(SKILL);
 	const int goldNeeded = skillCost[EGameResID::GOLD];
 	std::vector<std::string> costEntries;
 	for(auto it = TResources::nziterator(skillCost); it.valid(); ++it)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1017,9 +1017,9 @@ CUniversityWindow::CItem::CItem(CUniversityWindow * _parent, int _ID, int X, int
 
 			if(!skillKnown && canLearn)
 			{
-				int goldAmount = GAME->interface()->cb->getResourceAmount(EGameResID::GOLD);
-				int goldNeeded = GAME->interface()->cb->getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
-				ENGINE->windows().createAndPushWindow<CUnivConfirmWindow>(parent, ID, goldAmount >= goldNeeded);
+				TResources skillCost = parent->market->getSkillCost(ID);
+				bool canAfford = GAME->interface()->cb->getResourceAmount().canAfford(skillCost);
+				ENGINE->windows().createAndPushWindow<CUnivConfirmWindow>(parent, ID, canAfford);
 			}
 		});
 	update();
@@ -1106,7 +1106,17 @@ void CUniversityWindow::updateSecondarySkills()
 
 void CUniversityWindow::makeDeal(SecondarySkill skill)
 {
-	GAME->interface()->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_SKILL, GameResID(GameResID::GOLD), skill, 1, hero);
+	std::vector<TradeItemSell> resources;
+	std::vector<ui32> amounts;
+	TResources skillCost = market->getSkillCost(skill);
+
+	for(auto it = TResources::nziterator(skillCost); it.valid(); ++it)
+	{
+		resources.push_back(it->resType);
+		amounts.push_back(it->resVal);
+	}
+
+	GAME->interface()->cb->trade(market->getObjInstanceID(), EMarketMode::RESOURCE_SKILL, resources, {skill}, amounts, hero);
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
@@ -1115,12 +1125,21 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 {
 	OBJECT_CONSTRUCTION;
 
-	int goldNeeded = GAME->interface()->cb->getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
+	TResources skillCost = owner->market->getSkillCost(SKILL);
+	const int goldNeeded = skillCost[EGameResID::GOLD];
+	std::vector<std::string> costEntries;
+	for(auto it = TResources::nziterator(skillCost); it.valid(); ++it)
+		costEntries.push_back(std::to_string(it->resVal) + " " + it->resType.toResource()->getNameTranslated());
+
+	const std::string costSummary = boost::algorithm::join(costEntries, ", ");
+
 	std::string text = LIBRARY->generaltexth->allTexts[608];
 	boost::replace_first(text, "%s", LIBRARY->generaltexth->levels[0]);
 	boost::replace_first(text, "%s", SKILL.toEntity(LIBRARY)->getNameTranslated());
 
 	boost::replace_first(text, "%d", std::to_string(goldNeeded));
+	if(!costSummary.empty())
+		text += "\n" + costSummary;
 
 	clerkSpeech = std::make_shared<CTextBox>(text, Rect(24, 129, 413, 70), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 
@@ -1129,7 +1148,7 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 	level = std::make_shared<CLabel>(230, 107, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->levels[1]);
 
 	costIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("RESOURCE"), GameResID(EGameResID::GOLD), 0, 210, 210);
-	cost = std::make_shared<CLabel>(230, 267, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, "2000");
+	cost = std::make_shared<CLabel>(230, 267, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, std::to_string(goldNeeded));
 
 	std::string hoverText = LIBRARY->generaltexth->allTexts[609];
 	boost::replace_first(hoverText, "%s", LIBRARY->generaltexth->levels[0]+ " " + SKILL.toEntity(LIBRARY)->getNameTranslated());
@@ -1138,6 +1157,8 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 	boost::replace_first(text, "%s", LIBRARY->generaltexth->levels[0]);
 	boost::replace_first(text, "%s", SKILL.toEntity(LIBRARY)->getNameTranslated());
 	boost::replace_first(text, "%d", std::to_string(goldNeeded));
+	if(!costSummary.empty())
+		text += "\n" + costSummary;
 
 	confirm = std::make_shared<CButton>(Point(148, 299), AnimationPath::builtin("IBY6432.DEF"), CButton::tooltip(hoverText, text), [this, SKILL](){makeDeal(SKILL);}, EShortcut::GLOBAL_ACCEPT);
 	confirm->block(!available);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -104,6 +104,15 @@ static ImagePath getUniversityBackground(const IMarket * market)
 	return ImagePath::builtin(fileName);
 }
 
+static ImagePath getUniversityConfirmBackground(const IMarket * market)
+{
+	std::string fileName = "UNIVRS2";
+	if(auto town = dynamic_cast<const CGTownInstance *>(market); town && town->tempOwner.isValidPlayer())
+		fileName += "-" + town->tempOwner.toString();
+
+	return ImagePath::builtin(fileName);
+}
+
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | SHOW_POPUP),
 	parent(window),
@@ -1133,7 +1142,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("UNIVERS2.PCX")),
+	: CWindowObject(PLAYER_COLORED, getUniversityConfirmBackground(owner_->getMarket())),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1091,13 +1091,13 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 
 	titlePic->center(Point(232 + pos.x, 76 + pos.y));
 
-	clerkSpeech = std::make_shared<CTextBox>(speechStr, Rect(24, 129, 413, 70), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
+	clerkSpeech = std::make_shared<CTextBox>(speechStr, Rect(27, 128, 411, 72), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 	title = std::make_shared<CLabel>(231, 26, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, titleStr);
 
 	std::vector<TradeItemBuy> goods = market->availableItemsIds(EMarketMode::RESOURCE_SKILL);
 
 	for(int i=0; i<goods.size(); i++)//prepare clickable items
-		items.push_back(std::make_shared<CItem>(this, goods[i].as<SecondarySkill>().getNum(), 54+i*104, 234));
+		items.push_back(std::make_shared<CItem>(this, goods[i].as<SecondarySkill>().getNum(), 55+i*104, 234));
 
 	cancel = std::make_shared<CButton>(Point(200, 313), AnimationPath::builtin("IOKAY.DEF"), LIBRARY->generaltexth->zelp[632], [&](){ close(); }, EShortcut::GLOBAL_ACCEPT);
 	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1091,7 +1091,7 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 
 	titlePic->center(Point(232 + pos.x, 76 + pos.y));
 
-	clerkSpeech = std::make_shared<CTextBox>(speechStr, Rect(27, 128, 411, 72), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
+	clerkSpeech = std::make_shared<CTextBox>(speechStr, Rect(27, 128, 412, 72), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 	title = std::make_shared<CLabel>(231, 26, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, titleStr);
 
 	std::vector<TradeItemBuy> goods = market->availableItemsIds(EMarketMode::RESOURCE_SKILL);

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -390,6 +390,7 @@ class CUniversityWindow final : public CStatusbarWindow, public IMarketHolder
 
 public:
 	CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed);
+	const IMarket * getMarket() const { return market; }
 
 	void makeDeal(SecondarySkill skill);
 	void close() override;

--- a/config/factions/conflux.json
+++ b/config/factions/conflux.json
@@ -189,6 +189,9 @@
 				"special2":       {
 					"requires" : [ "mageGuild1" ],
 					"marketModes" : ["resource-skill"],
+					"marketCost" : {
+						"gold" : 2000
+					},
 					"marketOffer" : [
 						"fireMagic",
 						"airMagic",

--- a/config/schemas/market.json
+++ b/config/schemas/market.json
@@ -33,6 +33,12 @@
 		"offer" : {
 			"type" : "array"
 		},
+		"cost" : {
+			"type" : "object",
+			"additionalProperties" : {
+				"type" : "number"
+			}
+		},
 
 		// Properties that might appear since this node is shared with object config
 		"compatibilityIdentifiers" : { },

--- a/config/schemas/townBuilding.json
+++ b/config/schemas/townBuilding.json
@@ -121,6 +121,13 @@
 				"type" : [ "string", "object" ]
 			},
 			"description" : "List of predefined or randomized items available on market from this building"
+		},
+		"marketCost" : {
+			"type" : "object",
+			"additionalProperties" : {
+				"type" : "number"
+			},
+			"description" : "Resource cost of one transaction in market modes that support configurable pricing"
 		}
 	}
 }

--- a/config/schemas/townBuilding.json
+++ b/config/schemas/townBuilding.json
@@ -118,9 +118,9 @@
 		"marketOffer" : {
 			"type" : "array",
 			"items" : {
-				"type" : "string"
+				"type" : [ "string", "object" ]
 			},
-			"description" : "List of predefined items available on market from this building"
+			"description" : "List of predefined or randomized items available on market from this building"
 		}
 	}
 }

--- a/lib/entities/building/CBuilding.h
+++ b/lib/entities/building/CBuilding.h
@@ -15,6 +15,7 @@
 #include "../../LogicalExpression.h"
 #include "../../ResourceSet.h"
 #include "../../bonuses/BonusList.h"
+#include "../../json/JsonNode.h"
 #include "../../networkPacks/TradeItem.h"
 #include "../../rewardable/Info.h"
 
@@ -41,6 +42,7 @@ public:
 	TownFortifications fortifications;
 	std::set<EMarketMode> marketModes;
 	std::vector<TradeItemBuy> marketOffer;
+	JsonNode marketOfferConfig;
 
 	BuildingID bid; //structure ID
 	BuildingID upgrade; /// indicates that building "upgrade" can be improved by this, -1 = empty

--- a/lib/entities/building/CBuilding.h
+++ b/lib/entities/building/CBuilding.h
@@ -43,6 +43,8 @@ public:
 	std::set<EMarketMode> marketModes;
 	std::vector<TradeItemBuy> marketOffer;
 	JsonNode marketOfferConfig;
+	TResources marketCost;
+	JsonNode marketCostConfig;
 
 	BuildingID bid; //structure ID
 	BuildingID upgrade; /// indicates that building "upgrade" can be improved by this, -1 = empty

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -393,14 +393,18 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 
 			if (mode == EMarketMode::RESOURCE_SKILL)
 			{
+				ret->marketOfferConfig = source["marketOffer"];
 				const auto & items = source["marketOffer"].Vector();
 				ret->marketOffer.resize(items.size());
 				for (int i = 0; i < items.size(); ++i)
 				{
-					LIBRARY->identifiers()->requestIdentifier("secondarySkill", items[i], [ret, i](si32 identifier)
+					if(items[i].isString())
 					{
-						ret->marketOffer[i] = SecondarySkill(identifier);
-					});
+						LIBRARY->identifiers()->requestIdentifier("secondarySkill", items[i], [ret, i](si32 identifier)
+						{
+							ret->marketOffer[i] = SecondarySkill(identifier);
+						});
+					}
 				}
 			}
 		}

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -19,6 +19,7 @@
 #include "../../IGameSettings.h"
 #include "../../TerrainHandler.h"
 #include "../../GameLibrary.h"
+#include "../../entities/ResourceTypeHandler.h"
 
 #include "../../bonuses/Propagators.h"
 #include "../../constants/StringConstants.h"
@@ -394,6 +395,7 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 			if (mode == EMarketMode::RESOURCE_SKILL)
 			{
 				ret->marketOfferConfig = source["marketOffer"];
+				ret->marketCostConfig = source["marketCost"];
 				const auto & items = source["marketOffer"].Vector();
 				ret->marketOffer.resize(items.size());
 				for (int i = 0; i < items.size(); ++i)
@@ -404,6 +406,16 @@ void CTownHandler::loadBuilding(CTown * town, const std::string & stringID, cons
 						{
 							ret->marketOffer[i] = SecondarySkill(identifier);
 						});
+					}
+				}
+
+				if(source["marketCost"].isStruct())
+				{
+					for(const auto & resource : LIBRARY->resourceTypeHandler->getAllObjects())
+					{
+						const auto & value = source["marketCost"][resource.toResource()->getJsonKey()];
+						if(!value.isNull())
+							ret->marketCost[resource] = value.Integer();
 					}
 				}
 			}

--- a/lib/mapObjectConstructors/MarketInstanceConstructor.cpp
+++ b/lib/mapObjectConstructors/MarketInstanceConstructor.cpp
@@ -61,6 +61,7 @@ void MarketInstanceConstructor::initTypeData(const JsonNode & input)
 
 	marketEfficiency = input["efficiency"].isNull() ? 5 : input["efficiency"].Integer();
 	predefinedOffer = input["offer"];
+	predefinedCost = input["cost"];
 }
 
 bool MarketInstanceConstructor::hasDescription() const
@@ -104,6 +105,9 @@ void MarketInstanceConstructor::randomizeObject(CGMarket * object, IGameRandomiz
 	{
 		for(auto skill : randomizer.loadSecondaries(predefinedOffer, emptyVariables))
 			university->skills.push_back(skill.first);
+
+		if(!predefinedCost.isNull())
+			university->skillCost = randomizer.loadResources(predefinedCost, emptyVariables);
 	}
 }
 

--- a/lib/mapObjectConstructors/MarketInstanceConstructor.h
+++ b/lib/mapObjectConstructors/MarketInstanceConstructor.h
@@ -22,6 +22,7 @@ class MarketInstanceConstructor : public CDefaultObjectTypeHandler<CGMarket>
 
 	std::set<EMarketMode> marketModes;
 	JsonNode predefinedOffer;
+	JsonNode predefinedCost;
 	int marketEfficiency;
 
 	void initTypeData(const JsonNode & config) override;

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -141,7 +141,9 @@ TResources CGUniversity::getSkillCost(SecondarySkill skill) const
 	(void)skill;
 	if(skillCost.nonZero())
 		return skillCost;
-	return IMarket::getSkillCost(skill);
+	TResources defaultCost;
+	defaultCost[EGameResID::GOLD] = cb->getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
+	return defaultCost;
 }
 
 void CGUniversity::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const

--- a/lib/mapObjects/CGMarket.cpp
+++ b/lib/mapObjects/CGMarket.cpp
@@ -136,6 +136,14 @@ std::string CGUniversity::getSpeechTranslated() const
 	return getMarketHandler()->getSpeechTranslated();
 }
 
+TResources CGUniversity::getSkillCost(SecondarySkill skill) const
+{
+	(void)skill;
+	if(skillCost.nonZero())
+		return skillCost;
+	return IMarket::getSkillCost(skill);
+}
+
 void CGUniversity::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const
 {
 	ChangeObjectVisitors cow;

--- a/lib/mapObjects/CGMarket.h
+++ b/lib/mapObjects/CGMarket.h
@@ -62,8 +62,10 @@ public:
 	std::string getSpeechTranslated() const;
 
 	std::vector<TradeItemBuy> skills; //available skills
+	TResources skillCost;
 
 	std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const override;
+	TResources getSkillCost(SecondarySkill skill) const override;
 	void onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance * h) const override; //open window
 	std::vector<Component> getPopupComponents(PlayerColor player) const override;
 	bool wasVisited (PlayerColor player) const override;
@@ -72,6 +74,7 @@ public:
 	{
 		h & static_cast<CGMarket&>(*this);
 		h & skills;
+		h & skillCost;
 	}
 };
 

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -390,6 +390,8 @@ void CGTownInstance::initializeConfigurableBuildings(IGameRandomizer & gameRando
 {
 	JsonRandom randomizer(cb, gameRandomizer);
 	JsonRandom::Variables emptyVariables;
+	marketOffers.clear();
+	marketCosts.clear();
 
 	for(const auto & kvp : getTown()->buildings)
 	{
@@ -404,6 +406,10 @@ void CGTownInstance::initializeConfigurableBuildings(IGameRandomizer & gameRando
 				for(const auto & skill : randomizer.loadSecondaries(marketOffer, emptyVariables))
 					generatedOffer.push_back(skill.first);
 			}
+
+			const JsonNode & marketCost = kvp.second->marketCostConfig;
+			if(!marketCost.isNull())
+				marketCosts[kvp.first] = randomizer.loadResources(marketCost, emptyVariables);
 		}
 
 		if(kvp.second->rewardableObjectInfo.getParameters().isNull())
@@ -708,6 +714,25 @@ std::vector<TradeItemBuy> CGTownInstance::availableItemsIds(EMarketMode mode) co
 	}
 	else
 		return IMarket::availableItemsIds(mode);
+}
+
+TResources CGTownInstance::getSkillCost(SecondarySkill skill) const
+{
+	(void)skill;
+	for (const auto & buildingID : builtBuildings)
+	{
+		const auto * buildingPtr = getTown()->buildings.at(buildingID).get();
+		if(!vstd::contains(buildingPtr->marketModes, EMarketMode::RESOURCE_SKILL))
+			continue;
+
+		if(vstd::contains(marketCosts, buildingID))
+			return marketCosts.at(buildingID);
+		if(buildingPtr->marketCost.nonZero())
+			return buildingPtr->marketCost;
+		break;
+	}
+
+	return IMarket::getSkillCost(skill);
 }
 
 ObjectInstanceID CGTownInstance::getObjInstanceID() const

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -731,8 +731,9 @@ TResources CGTownInstance::getSkillCost(SecondarySkill skill) const
 			return buildingPtr->marketCost;
 		break;
 	}
-
-	return IMarket::getSkillCost(skill);
+	TResources defaultCost;
+	defaultCost[EGameResID::GOLD] = cb->getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
+	return defaultCost;
 }
 
 ObjectInstanceID CGTownInstance::getObjInstanceID() const

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -33,6 +33,7 @@
 #include "../entities/building/CBuilding.h"
 #include "../entities/faction/CTownHandler.h"
 #include "../entities/ResourceTypeHandler.h"
+#include "../json/JsonRandom.h"
 #include "../mapObjectConstructors/AObjectTypeHandler.h"
 #include "../mapObjectConstructors/CObjectClassesHandler.h"
 #include "../mapObjects/CGHeroInstance.h"
@@ -387,8 +388,24 @@ bool CGTownInstance::townEnvisagesBuilding(BuildingSubID::EBuildingSubID subId) 
 
 void CGTownInstance::initializeConfigurableBuildings(IGameRandomizer & gameRandomizer)
 {
+	JsonRandom randomizer(cb, gameRandomizer);
+	JsonRandom::Variables emptyVariables;
+
 	for(const auto & kvp : getTown()->buildings)
 	{
+		if(vstd::contains(kvp.second->marketModes, EMarketMode::RESOURCE_SKILL))
+		{
+			const JsonNode & marketOffer = kvp.second->marketOfferConfig;
+			if(!marketOffer.isNull())
+			{
+				auto & generatedOffer = marketOffers[kvp.first];
+				generatedOffer.clear();
+
+				for(const auto & skill : randomizer.loadSecondaries(marketOffer, emptyVariables))
+					generatedOffer.push_back(skill.first);
+			}
+		}
+
 		if(kvp.second->rewardableObjectInfo.getParameters().isNull())
 			continue;
 
@@ -679,7 +696,11 @@ std::vector<TradeItemBuy> CGTownInstance::availableItemsIds(EMarketMode mode) co
 		{
 			const auto * buildingPtr = getTown()->buildings.at(buildingID).get();
 			if (vstd::contains(buildingPtr->marketModes, mode))
+			{
+				if(vstd::contains(marketOffers, buildingID))
+					return marketOffers.at(buildingID);
 				return buildingPtr->marketOffer;
+			}
 		}
 
 		logMod->warn("Town has resource-skill trade but has no skills to offer!");

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -50,6 +50,7 @@ class DLL_LINKAGE CGTownInstance : public CGDwelling, public IShipyard, public I
 
 	std::map<BuildingID, TownRewardableBuildingInstance*> convertOldBuildings(std::vector<TownRewardableBuildingInstance*> oldVector);
 	std::set<BuildingID> builtBuildings;
+	std::map<BuildingID, std::vector<TradeItemBuy>> marketOffers;
 
 	ObjectInstanceID garrisonHero;
 	ObjectInstanceID visitingHero;
@@ -102,6 +103,7 @@ public:
 		h & alignmentToPlayer;
 		h & forbiddenBuildings;
 		h & builtBuildings;
+		h & marketOffers;
 		h & bonusValue;
 		h & possibleSpells;
 		h & obligatorySpells;

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -51,6 +51,7 @@ class DLL_LINKAGE CGTownInstance : public CGDwelling, public IShipyard, public I
 	std::map<BuildingID, TownRewardableBuildingInstance*> convertOldBuildings(std::vector<TownRewardableBuildingInstance*> oldVector);
 	std::set<BuildingID> builtBuildings;
 	std::map<BuildingID, std::vector<TradeItemBuy>> marketOffers;
+	std::map<BuildingID, TResources> marketCosts;
 
 	ObjectInstanceID garrisonHero;
 	ObjectInstanceID visitingHero;
@@ -107,6 +108,10 @@ public:
 			h & marketOffers;
 		else if(!h.saving)
 			marketOffers.clear();
+		if(h.hasFeature(Handler::Version::TOWN_MARKET_COSTS))
+			h & marketCosts;
+		else if(!h.saving)
+			marketCosts.clear();
 		h & bonusValue;
 		h & possibleSpells;
 		h & obligatorySpells;
@@ -154,6 +159,7 @@ public:
 	int getMarketEfficiency() const override; //=market count
 	std::set<EMarketMode> availableModes() const override;
 	std::vector<TradeItemBuy> availableItemsIds(EMarketMode mode) const override;
+	TResources getSkillCost(SecondarySkill skill) const override;
 	ObjectInstanceID getObjInstanceID() const override;
 	void updateAppearance();
 

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -103,7 +103,10 @@ public:
 		h & alignmentToPlayer;
 		h & forbiddenBuildings;
 		h & builtBuildings;
-		h & marketOffers;
+		if(h.hasFeature(Handler::Version::TOWN_MARKET_OFFERS))
+			h & marketOffers;
+		else if(!h.saving)
+			marketOffers.clear();
 		h & bonusValue;
 		h & possibleSpells;
 		h & obligatorySpells;

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -15,7 +15,6 @@
 #include "CGObjectInstance.h"
 
 #include "../GameLibrary.h"
-#include "../IGameSettings.h"
 #include "../entities/artifact/CArtHandler.h"
 #include "../entities/ResourceTypeHandler.h"
 
@@ -142,8 +141,7 @@ int IMarket::availableUnits(const EMarketMode mode, const int marketItemSerial) 
 }
 
 IMarket::IMarket(IGameInfoCallback *cb)
-	: cb(cb)
-	, altarArtifactsStorage(std::make_unique<CArtifactSetAltar>(cb))
+	: altarArtifactsStorage(std::make_unique<CArtifactSetAltar>(cb))
 {
 }
 
@@ -174,9 +172,7 @@ std::vector<TradeItemBuy> IMarket::availableItemsIds(const EMarketMode mode) con
 TResources IMarket::getSkillCost(SecondarySkill skill) const
 {
 	(void)skill;
-	TResources defaultCost;
-	defaultCost[EGameResID::GOLD] = cb->getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
-	return defaultCost;
+	return TResources();
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/IMarket.cpp
+++ b/lib/mapObjects/IMarket.cpp
@@ -15,6 +15,7 @@
 #include "CGObjectInstance.h"
 
 #include "../GameLibrary.h"
+#include "../IGameSettings.h"
 #include "../entities/artifact/CArtHandler.h"
 #include "../entities/ResourceTypeHandler.h"
 
@@ -141,7 +142,8 @@ int IMarket::availableUnits(const EMarketMode mode, const int marketItemSerial) 
 }
 
 IMarket::IMarket(IGameInfoCallback *cb)
-	:altarArtifactsStorage(std::make_unique<CArtifactSetAltar>(cb))
+	: cb(cb)
+	, altarArtifactsStorage(std::make_unique<CArtifactSetAltar>(cb))
 {
 }
 
@@ -167,6 +169,14 @@ std::vector<TradeItemBuy> IMarket::availableItemsIds(const EMarketMode mode) con
 			ret.push_back(res);
 	}
 	return ret;
+}
+
+TResources IMarket::getSkillCost(SecondarySkill skill) const
+{
+	(void)skill;
+	TResources defaultCost;
+	defaultCost[EGameResID::GOLD] = cb->getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
+	return defaultCost;
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -18,9 +18,6 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class DLL_LINKAGE IMarket : public virtual Serializeable, boost::noncopyable
 {
-protected:
-	IGameInfoCallback *cb;
-
 public:
 	explicit IMarket(IGameInfoCallback *cb);
 	~IMarket();

--- a/lib/mapObjects/IMarket.h
+++ b/lib/mapObjects/IMarket.h
@@ -12,11 +12,15 @@
 #include "../networkPacks/TradeItem.h"
 #include "../constants/Enumerations.h"
 #include "../entities/artifact/CArtifactSet.h"
+#include "../ResourceSet.h"
 
 VCMI_LIB_NAMESPACE_BEGIN
 
 class DLL_LINKAGE IMarket : public virtual Serializeable, boost::noncopyable
 {
+protected:
+	IGameInfoCallback *cb;
+
 public:
 	explicit IMarket(IGameInfoCallback *cb);
 	~IMarket();
@@ -42,6 +46,7 @@ public:
 	virtual std::set<EMarketMode> availableModes() const = 0;
 	CArtifactSet * getArtifactsStorage() const;
 	virtual bool getOffer(int id1, int id2, int &val1, int &val2, EMarketMode mode) const; //val1 - how many units of id1 player has to give to receive val2 units
+	virtual TResources getSkillCost(SecondarySkill skill) const;
 
 private:
 	std::unique_ptr<CArtifactSetAltar> altarArtifactsStorage;

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -62,9 +62,10 @@ enum class ESerializationVersion : int32_t
 	DISABLE_TACTICS, // disable tactics
 	REWARDABLE_EXTENSIONS_2, // movement points limiter for rewardables
 	BONUS_TRIGGER, // bonus that allows triggered effects in combat
+	TOWN_MARKET_OFFERS, // generated market offers for town buildings
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
-	CURRENT = BONUS_TRIGGER,
+	CURRENT = TOWN_MARKET_OFFERS,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");

--- a/lib/serializer/ESerializationVersion.h
+++ b/lib/serializer/ESerializationVersion.h
@@ -63,9 +63,10 @@ enum class ESerializationVersion : int32_t
 	REWARDABLE_EXTENSIONS_2, // movement points limiter for rewardables
 	BONUS_TRIGGER, // bonus that allows triggered effects in combat
 	TOWN_MARKET_OFFERS, // generated market offers for town buildings
+	TOWN_MARKET_COSTS, // configurable costs for town market offers
 
 	RELEASE_170 = HOTA_MAP_STACK_COUNT,
-	CURRENT = TOWN_MARKET_OFFERS,
+	CURRENT = TOWN_MARKET_COSTS,
 };
 
 static_assert(ESerializationVersion::MINIMAL <= ESerializationVersion::CURRENT, "Invalid serialization version definition!");

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3185,7 +3185,7 @@ bool CGameHandler::sellArtifact(const IMarket *m, const CGHeroInstance *h, Artif
 	return true;
 }
 
-bool CGameHandler::buySecSkill(const IMarket *m, const CGHeroInstance *h, SecondarySkill skill)
+bool CGameHandler::buySecSkill(const IMarket *m, const CGHeroInstance *h, SecondarySkill skill, const TResources & payment)
 {
 	if (!h)
 		COMPLAIN_RET("You need hero to buy a skill!");
@@ -3202,12 +3202,17 @@ bool CGameHandler::buySecSkill(const IMarket *m, const CGHeroInstance *h, Second
 	if (!vstd::contains(m->availableItemsIds(EMarketMode::RESOURCE_SKILL), skill))
 		COMPLAIN_RET("That skill is unavailable!");
 
-	int goldCost = gameInfo().getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
+	TResources expectedCost = m->getSkillCost(skill);
+	TResources actualCost = payment.nonZero() ? payment : expectedCost;
 
-	if (gameInfo().getResource(h->tempOwner, EGameResID::GOLD) < goldCost)
+	if(actualCost != expectedCost)
+		COMPLAIN_RET("Skill cost does not match market configuration");
+
+	if (!gameInfo().getPlayerState(h->tempOwner)->resources.canAfford(actualCost))
 		COMPLAIN_RET("You can't afford to buy this skill");
 
-	giveResource(h->tempOwner, EGameResID::GOLD, -goldCost);
+	for(auto it = TResources::nziterator(actualCost); it.valid(); ++it)
+		giveResource(h->tempOwner, it->resType, -it->resVal);
 
 	changeSecSkill(h, skill, 1, ChangeValueMode::ABSOLUTE);
 	return true;

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -226,7 +226,7 @@ public:
 	bool buyArtifact( const IMarket *m, const CGHeroInstance *h, GameResID rid, ArtifactID aid); //for artifact merchant and black market -> buying for any resource in special building / advobject
 	bool sellArtifact( const IMarket *m, const CGHeroInstance *h, ArtifactInstanceID aid, GameResID rid); //for artifact merchant selling
 	//void lootArtifacts (TArtHolder source, TArtHolder dest, std::vector<ui32> &arts); //after battle - move al arts to winer
-	bool buySecSkill( const IMarket *m, const CGHeroInstance *h, SecondarySkill skill);
+	bool buySecSkill(const IMarket *m, const CGHeroInstance *h, SecondarySkill skill, const TResources & payment = TResources());
 	bool garrisonSwap(ObjectInstanceID tid);
 	bool upgradeCreature( ObjectInstanceID objid, SlotID pos, CreatureID upgID );
 	bool recruitCreatures(ObjectInstanceID objid, ObjectInstanceID dst, CreatureID crid, int32_t cram, int32_t level, PlayerColor player);

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -335,9 +335,17 @@ void ApplyGhNetPackVisitor::visitTradeOnMarketplace(TradeOnMarketplace & pack)
 			result &= gh.transformInUndead(market, hero, pack.r1[i].as<SlotID>());
 		break;
 	case EMarketMode::RESOURCE_SKILL:
-		for(int i = 0; i < pack.r2.size(); ++i)
-			result &= gh.buySecSkill(market, hero, pack.r2[i].as<SecondarySkill>());
+	{
+		if(pack.r2.size() != 1)
+			gh.throwAndComplain(connection, "Can not trade - invalid skill purchase request!");
+
+		TResources payment;
+		for(int i = 0; i < pack.r1.size(); ++i)
+			payment[pack.r1[i].as<GameResID>()] += pack.val[i];
+
+		result &= gh.buySecSkill(market, hero, pack.r2[0].as<SecondarySkill>(), payment);
 		break;
+	}
 	case EMarketMode::CREATURE_EXP:
 	{
 		std::vector<SlotID> slotIDs;


### PR DESCRIPTION
### Motivation
- Allow market offers in town building configs to be either fixed strings or object-based randomized definitions so markets can provide procedurally generated items.
- Persist and use generated per-town offers at runtime instead of only reading static lists.
- Ensure backward compatibility with existing string-based `marketOffer` entries.

### Description
- Update JSON schema `config/schemas/townBuilding.json` to allow `marketOffer` items to be either `string` or `object` and clarify the description to mention randomized items.
- Add `JsonNode marketOfferConfig` to `CBuilding` and store the raw `marketOffer` node during load in `CTownHandler::loadBuilding` when `EMarketMode::RESOURCE_SKILL` is present, while keeping existing handling for string items.
- Implement generation of concrete skill offers in `CGTownInstance::initializeConfigurableBuildings` using `JsonRandom::loadSecondaries` to populate a new per-town `marketOffers` map keyed by `BuildingID` and add `marketOffers` to serialization in `CGTownInstance::serialize`.
- Make `CGTownInstance::availableItemsIds` return generated offers from `marketOffers` if present and preserve fallback to the building's static `marketOffer`.

### Testing
- Project build completed successfully using the standard build system and no compile errors were introduced.
- Game unit and integration tests (run via `ctest`) passed without regressions.
- Serialization check confirmed `marketOffers` are saved and restored through the existing serializer and round-trip tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e2792520832dac8ddd03fe994992)