### PR TITLE
Use player-specific university backgrounds and adjust speech textbox bounds

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -87,7 +87,9 @@ void AssetGenerator::initialize()
 	addUniversityBackground("UNIVRS4", Point(466, 388), 4);
 	addUniversityBackground("UNIVRS5", Point(570, 388), 5);
 	addUniversityBackground("UNIVRS6", Point(674, 388), 6);
-	addUniversityConfirmBackground("UNIVRS2", Point(466, 388));
+	addUniversityBackground("UNIVRS7", Point(778, 388), 7);
+	addUniversityConfirmBackground("UNIVRSC1", Point(466, 388), 1);
+	addUniversityConfirmBackground("UNIVRSC2", Point(466, 388), 2);
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{
@@ -180,13 +182,13 @@ void AssetGenerator::addUniversityBackground(const std::string & fileName, const
 	}
 }
 
-void AssetGenerator::addUniversityConfirmBackground(const std::string & fileName, const Point & size)
+void AssetGenerator::addUniversityConfirmBackground(const std::string & fileName, const Point & size, int costElements)
 {
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{
 		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
 		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
-		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createUniversityConfirmDialogBackground(size, playerColor);};
+		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor, costElements](){ return createUniversityConfirmDialogBackground(size, playerColor, costElements);};
 	}
 }
 
@@ -1360,7 +1362,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 	return image;
 }
 
-AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor) const
+AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor, int costElements) const
 {
 	auto image = createDialogBackgroundWithStatusBar(size, playerColor);
 	Canvas canvas = image->getCanvas();
@@ -1375,12 +1377,27 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackgroun
 	};
 
 	// Text block: same geometry as UNIVRS4
-	drawPlate(Rect(26, 127, size.x - 52, 74));
+	drawPlate(Rect((size.x - 414) / 2, 127, 414, 74));
 
 	// Centered header/action plates
 	drawPlate(Rect((size.x - 105) / 2, 26, 105, 21));
 	drawPlate(Rect((size.x - 105) / 2, 95, 105, 21));
-	drawPlate(Rect((size.x - 71) / 2, 258, 71, 19));
+	const int costPlateWidth = 71;
+	const int costPlateHeight = 19;
+	const int costPlateY = 258;
+	const int costPlateGap = 10;
+
+	if(costElements <= 1)
+	{
+		drawPlate(Rect((size.x - costPlateWidth) / 2, costPlateY, costPlateWidth, costPlateHeight));
+	}
+	else
+	{
+		const int totalWidth = 2 * costPlateWidth + costPlateGap;
+		const int firstX = (size.x - totalWidth) / 2;
+		drawPlate(Rect(firstX, costPlateY, costPlateWidth, costPlateHeight));
+		drawPlate(Rect(firstX + costPlateWidth + costPlateGap, costPlateY, costPlateWidth, costPlateHeight));
+	}
 
 	return image;
 }

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -84,7 +84,9 @@ void AssetGenerator::initialize()
 	addRecruitmentBackground("TPRCRT4", Point(484, 394));
 	addRecruitmentBackground("TPRCRT5", Point(594, 394));
 	addRecruitmentBackground("TPRCRT6", Point(704, 394));
-	addUniversityBackground("UNIVRS4", Point(466, 388));
+	addUniversityBackground("UNIVRS4", Point(466, 388), 4);
+	addUniversityBackground("UNIVRS5", Point(570, 388), 5);
+	addUniversityBackground("UNIVRS6", Point(674, 388), 6);
 	addUniversityConfirmBackground("UNIVRS2", Point(466, 388));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
@@ -168,13 +170,13 @@ void AssetGenerator::addRecruitmentBackground(const std::string & fileName, cons
 	}
 }
 
-void AssetGenerator::addUniversityBackground(const std::string & fileName, const Point & size)
+void AssetGenerator::addUniversityBackground(const std::string & fileName, const Point & size, int skillColumns)
 {
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{
 		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
 		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
-		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createUniversityDialogBackground(size, playerColor);};
+		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor, skillColumns](){ return createUniversityDialogBackground(size, playerColor, skillColumns);};
 	}
 }
 
@@ -1300,7 +1302,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(cons
 	return image;
 }
 
-AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor) const
+AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor, int skillColumns) const
 {
 	auto image = createDialogBackgroundWithStatusBar(size, playerColor);
 	Canvas canvas = image->getCanvas();
@@ -1321,22 +1323,24 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 		canvas.drawBorder(rect, borderColor);
 	};
 
-	// Main text block
+	// Main text block - fixed size, centered horizontally for all variants
 	const int horizontalMargin = 26;
 	const int largeBlockY = 127;
 	const int largeBlockHeight = 74;
-	drawPlate(Rect(horizontalMargin, largeBlockY, size.x - 2 * horizontalMargin, largeBlockHeight));
+	const int largeBlockWidth = 414;
+	const int largeBlockX = (size.x - largeBlockWidth) / 2;
+	drawPlate(Rect(largeBlockX, largeBlockY, largeBlockWidth, largeBlockHeight));
 
-	// Four top/bottom strips distributed evenly between same left/right margins
+	// Skill rows (4/5/6 choices) distributed evenly between same left/right margins
 	const int smallBlockWidth = 102;
 	const int smallBlockHeight = 20;
 	const int firstRowY = largeBlockY + largeBlockHeight + 10; // 10px below large block
 	const int secondRowY = firstRowY + smallBlockHeight + 50; // 50px below first row (edge to edge)
 
-	std::array<int, 4> stripX;
-	for(int i = 0; i < 4; ++i)
+	std::vector<int> stripX(skillColumns);
+	for(int i = 0; i < skillColumns; ++i)
 	{
-		double t = (i / 3.0);
+		double t = skillColumns == 1 ? 0.0 : static_cast<double>(i) / static_cast<double>(skillColumns - 1);
 		double x = horizontalMargin + t * (size.x - 2 * horizontalMargin - smallBlockWidth);
 		stripX[i] = static_cast<int>(std::lround(x));
 
@@ -1344,10 +1348,10 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 		drawPlate(Rect(stripX[i], secondRowY, smallBlockWidth, smallBlockHeight));
 	}
 
-	// Four icon boxes centered in each strip column
+	// Icon boxes centered in each strip column
 	const int iconSize = 44;
 	const int iconY = firstRowY + smallBlockHeight + 3; // 3px below first row and 3px above second row
-	for(int i = 0; i < 4; ++i)
+	for(int i = 0; i < skillColumns; ++i)
 	{
 		const int iconX = stripX[i] + (smallBlockWidth - iconSize) / 2;
 		drawSlot(Rect(iconX, iconY, iconSize, iconSize));

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -84,6 +84,7 @@ void AssetGenerator::initialize()
 	addRecruitmentBackground("TPRCRT4", Point(484, 394));
 	addRecruitmentBackground("TPRCRT5", Point(594, 394));
 	addRecruitmentBackground("TPRCRT6", Point(704, 394));
+	addUniversityBackground("UNIVRS3", Point(466, 388), 3);
 	addUniversityBackground("UNIVRS4", Point(466, 388), 4);
 	addUniversityBackground("UNIVRS5", Point(570, 388), 5);
 	addUniversityBackground("UNIVRS6", Point(674, 388), 6);

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -36,7 +36,7 @@ public:
 	void addAnimationFile(const AnimationPath & path, AnimationLayoutMap & anim);
 	void addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor);
 	void addRecruitmentBackground(const std::string & fileName, const Point & size);
-	void addUniversityBackground(const std::string & fileName, const Point & size);
+	void addUniversityBackground(const std::string & fileName, const Point & size, int skillColumns);
 	void addUniversityConfirmBackground(const std::string & fileName, const Point & size);
 
 	AnimationLayoutMap createAdventureMapButton(const ImagePath & overlay, bool small);
@@ -67,7 +67,7 @@ private:
 	CanvasPtr createCreatureInfoPanel(int boxesAmount) const;
 	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const;
 	CanvasPtr createRecruitmentDialogBackground(const Point & size, const PlayerColor & playerColor) const;
-	CanvasPtr createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor) const;
+	CanvasPtr createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor, int skillColumns) const;
 	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor) const;
 	enum CreateResourceWindowType{ ARTIFACTS_BUYING, ARTIFACTS_SELLING, MARKET_RESOURCES, FREELANCERS_GUILD, TRANSFER_RESOURCES };
 	CanvasPtr createResourceWindow(CreateResourceWindowType type, int count, PlayerColor color) const;

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -37,7 +37,7 @@ public:
 	void addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor);
 	void addRecruitmentBackground(const std::string & fileName, const Point & size);
 	void addUniversityBackground(const std::string & fileName, const Point & size, int skillColumns);
-	void addUniversityConfirmBackground(const std::string & fileName, const Point & size);
+	void addUniversityConfirmBackground(const std::string & fileName, const Point & size, int costElements);
 
 	AnimationLayoutMap createAdventureMapButton(const ImagePath & overlay, bool small);
 	AnimationLayoutMap createSliderBar(bool brown, bool horizontal, int length);
@@ -68,7 +68,7 @@ private:
 	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const;
 	CanvasPtr createRecruitmentDialogBackground(const Point & size, const PlayerColor & playerColor) const;
 	CanvasPtr createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor, int skillColumns) const;
-	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor) const;
+	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor, int costElements) const;
 	enum CreateResourceWindowType{ ARTIFACTS_BUYING, ARTIFACTS_SELLING, MARKET_RESOURCES, FREELANCERS_GUILD, TRANSFER_RESOURCES };
 	CanvasPtr createResourceWindow(CreateResourceWindowType type, int count, PlayerColor color) const;
 	enum CreatureInfoPanelElement{ BONUS_EFFECTS, SPELL_EFFECTS, BUTTON_PANEL, COMMANDER_BACKGROUND, COMMANDER_ABILITIES };

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -99,6 +99,33 @@ static ImagePath getUniversityBackground(const IMarket * market, std::string fil
 	return ImagePath::builtin(fileName);
 }
 
+static int getUniversitySkillColumns(const IMarket * market)
+{
+	const int skillColumns = static_cast<int>(market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size());
+	return std::clamp(skillColumns, 4, 6);
+}
+
+static int getUniversitySkillPositionX(int windowWidth, int skillColumns, int index)
+{
+	constexpr int horizontalMargin = 26;
+	constexpr int smallBlockWidth = 102;
+	constexpr int iconOffsetX = 28;
+
+	const double t = skillColumns == 1 ? 0.0 : static_cast<double>(index) / static_cast<double>(skillColumns - 1);
+	const double stripX = horizontalMargin + t * (windowWidth - 2 * horizontalMargin - smallBlockWidth);
+	return static_cast<int>(std::lround(stripX)) + iconOffsetX;
+}
+
+static Rect getUniversitySpeechTextBoxRect(int windowWidth)
+{
+	constexpr int largeBlockWidth = 414;
+	constexpr int largeBlockY = 127;
+	constexpr int largeBlockHeight = 74;
+	const int largeBlockX = (windowWidth - largeBlockWidth) / 2;
+
+	return Rect(largeBlockX + 1, largeBlockY + 1, largeBlockWidth - 2, largeBlockHeight - 2);
+}
+
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | SHOW_POPUP),
 	parent(window),
@@ -1057,13 +1084,14 @@ void CUniversityWindow::CItem::update()
 }
 
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed)
-	: CWindowObject(PLAYER_COLORED, getUniversityBackground(_market, "UNIVRS4")),
+	: CWindowObject(PLAYER_COLORED, getUniversityBackground(_market, "UNIVRS" + std::to_string(getUniversitySkillColumns(_market)))),
 	hero(_hero),
 	onWindowClosed(onWindowClosed),
 	market(_market)
 {
 	OBJECT_CONSTRUCTION;
 
+	const int centerX = pos.w / 2;
 
 	std::string titleStr = LIBRARY->generaltexth->allTexts[602];
 	std::string speechStr = LIBRARY->generaltexth->allTexts[603];
@@ -1084,19 +1112,18 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 		titlePic = std::make_shared<CPicture>(ImagePath::builtin("UNIVBLDG"));
 	}
 
-	titlePic->center(Point(232 + pos.x, 76 + pos.y));
+	titlePic->center(Point(centerX + pos.x, 76 + pos.y));
 
-	// University speech background block is 413x74 positioned at y=127.
-	// Keep 1px inner padding on each side to avoid text overlapping the frame.
-	clerkSpeech = std::make_shared<CTextBox>(speechStr, Rect(25, 128, 411, 72), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
-	title = std::make_shared<CLabel>(231, 26, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, titleStr);
+	clerkSpeech = std::make_shared<CTextBox>(speechStr, getUniversitySpeechTextBoxRect(pos.w), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
+	title = std::make_shared<CLabel>(centerX - 2, 26, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, titleStr);
 
 	std::vector<TradeItemBuy> goods = market->availableItemsIds(EMarketMode::RESOURCE_SKILL);
+	const int skillColumns = static_cast<int>(goods.size());
 
 	for(int i=0; i<goods.size(); i++)//prepare clickable items
-		items.push_back(std::make_shared<CItem>(this, goods[i].as<SecondarySkill>().getNum(), 54+i*104, 234));
+		items.push_back(std::make_shared<CItem>(this, goods[i].as<SecondarySkill>().getNum(), getUniversitySkillPositionX(pos.w, skillColumns, i), 234));
 
-	cancel = std::make_shared<CButton>(Point(200, 313), AnimationPath::builtin("IOKAY.DEF"), LIBRARY->generaltexth->zelp[632], [&](){ close(); }, EShortcut::GLOBAL_ACCEPT);
+	cancel = std::make_shared<CButton>(Point(centerX - 33, 313), AnimationPath::builtin("IOKAY.DEF"), LIBRARY->generaltexth->zelp[632], [&](){ close(); }, EShortcut::GLOBAL_ACCEPT);
 	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
 }
 
@@ -1129,6 +1156,7 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;
+	const int centerX = pos.w / 2;
 
 	int goldNeeded = GAME->interface()->cb->getSettings().getInteger(EGameSettings::MARKETS_UNIVERSITY_GOLD_COST);
 	std::string text = LIBRARY->generaltexth->allTexts[608];
@@ -1137,16 +1165,14 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 
 	boost::replace_first(text, "%d", std::to_string(goldNeeded));
 
-	// University speech background block is 413x74 positioned at y=127.
-	// Keep 1px inner padding on each side to avoid text overlapping the frame.
-	clerkSpeech = std::make_shared<CTextBox>(text, Rect(25, 128, 411, 72), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
+	clerkSpeech = std::make_shared<CTextBox>(text, getUniversitySpeechTextBoxRect(pos.w), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 
-	name = std::make_shared<CLabel>(230, 37,  FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, SKILL.toEntity(LIBRARY)->getNameTranslated());
-	icon = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSKILL"), SKILL.getNum()*3+3, 0, 211, 51);
-	level = std::make_shared<CLabel>(230, 107, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->levels[1]);
+	name = std::make_shared<CLabel>(centerX - 3, 37,  FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, SKILL.toEntity(LIBRARY)->getNameTranslated());
+	icon = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSKILL"), SKILL.getNum()*3+3, 0, centerX - 22, 51);
+	level = std::make_shared<CLabel>(centerX - 3, 107, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, LIBRARY->generaltexth->levels[1]);
 
-	costIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("RESOURCE"), GameResID(EGameResID::GOLD), 0, 210, 210);
-	cost = std::make_shared<CLabel>(230, 267, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, "2000");
+	costIcon = std::make_shared<CAnimImage>(AnimationPath::builtin("RESOURCE"), GameResID(EGameResID::GOLD), 0, centerX - 23, 210);
+	cost = std::make_shared<CLabel>(centerX - 3, 267, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, "2000");
 
 	std::string hoverText = LIBRARY->generaltexth->allTexts[609];
 	boost::replace_first(hoverText, "%s", LIBRARY->generaltexth->levels[0]+ " " + SKILL.toEntity(LIBRARY)->getNameTranslated());
@@ -1156,10 +1182,10 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 	boost::replace_first(text, "%s", SKILL.toEntity(LIBRARY)->getNameTranslated());
 	boost::replace_first(text, "%d", std::to_string(goldNeeded));
 
-	confirm = std::make_shared<CButton>(Point(148, 299), AnimationPath::builtin("IBY6432.DEF"), CButton::tooltip(hoverText, text), [this, SKILL](){makeDeal(SKILL);}, EShortcut::GLOBAL_ACCEPT);
+	confirm = std::make_shared<CButton>(Point(centerX - 85, 299), AnimationPath::builtin("IBY6432.DEF"), CButton::tooltip(hoverText, text), [this, SKILL](){makeDeal(SKILL);}, EShortcut::GLOBAL_ACCEPT);
 	confirm->block(!available);
 
-	cancel = std::make_shared<CButton>(Point(252,299), AnimationPath::builtin("ICANCEL.DEF"), LIBRARY->generaltexth->zelp[631], [&](){ close(); }, EShortcut::GLOBAL_CANCEL);
+	cancel = std::make_shared<CButton>(Point(centerX + 19,299), AnimationPath::builtin("ICANCEL.DEF"), LIBRARY->generaltexth->zelp[631], [&](){ close(); }, EShortcut::GLOBAL_CANCEL);
 	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
 }
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -102,7 +102,7 @@ static ImagePath getUniversityBackground(const IMarket * market, std::string fil
 static int getUniversitySkillColumns(const IMarket * market)
 {
 	const int skillColumns = static_cast<int>(market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size());
-	return std::clamp(skillColumns, 4, 7);
+	return std::clamp(skillColumns, 3, 7);
 }
 
 static int getUniversitySkillPositionX(int windowWidth, int skillColumns, int index)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -91,6 +91,14 @@ static ImagePath getRecruitmentBackground(const CGDwelling * dwelling, int level
 	return ImagePath::builtin(fileName);
 }
 
+static ImagePath getUniversityBackground(const IMarket * market, std::string fileName)
+{
+	if(const auto * object = dynamic_cast<const CGObjectInstance *>(market); object && object->tempOwner.isValidPlayer())
+		fileName += "-" + object->tempOwner.toString();
+
+	return ImagePath::builtin(fileName);
+}
+
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | SHOW_POPUP),
 	parent(window),
@@ -1049,7 +1057,7 @@ void CUniversityWindow::CItem::update()
 }
 
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed)
-	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("UNIVERS1")),
+	: CWindowObject(PLAYER_COLORED, getUniversityBackground(_market, "UNIVRS4")),
 	hero(_hero),
 	onWindowClosed(onWindowClosed),
 	market(_market)
@@ -1078,7 +1086,9 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 
 	titlePic->center(Point(232 + pos.x, 76 + pos.y));
 
-	clerkSpeech = std::make_shared<CTextBox>(speechStr, Rect(24, 129, 413, 70), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
+	// University speech background block is 413x74 positioned at y=127.
+	// Keep 1px inner padding on each side to avoid text overlapping the frame.
+	clerkSpeech = std::make_shared<CTextBox>(speechStr, Rect(25, 128, 411, 72), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 	title = std::make_shared<CLabel>(231, 26, FONT_MEDIUM, ETextAlignment::CENTER, Colors::YELLOW, titleStr);
 
 	std::vector<TradeItemBuy> goods = market->availableItemsIds(EMarketMode::RESOURCE_SKILL);
@@ -1098,6 +1108,11 @@ void CUniversityWindow::close()
 	CStatusbarWindow::close();
 }
 
+const IMarket * CUniversityWindow::getMarket() const
+{
+	return market;
+}
+
 void CUniversityWindow::updateSecondarySkills()
 {
 	for (auto const & item : items)
@@ -1110,7 +1125,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("UNIVERS2.PCX")),
+	: CWindowObject(PLAYER_COLORED, getUniversityBackground(owner_->getMarket(), "UNIVRS2")),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;
@@ -1122,7 +1137,9 @@ CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkil
 
 	boost::replace_first(text, "%d", std::to_string(goldNeeded));
 
-	clerkSpeech = std::make_shared<CTextBox>(text, Rect(24, 129, 413, 70), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
+	// University speech background block is 413x74 positioned at y=127.
+	// Keep 1px inner padding on each side to avoid text overlapping the frame.
+	clerkSpeech = std::make_shared<CTextBox>(text, Rect(25, 128, 411, 72), 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
 
 	name = std::make_shared<CLabel>(230, 37,  FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, SKILL.toEntity(LIBRARY)->getNameTranslated());
 	icon = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSKILL"), SKILL.getNum()*3+3, 0, 211, 51);

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -102,7 +102,7 @@ static ImagePath getUniversityBackground(const IMarket * market, std::string fil
 static int getUniversitySkillColumns(const IMarket * market)
 {
 	const int skillColumns = static_cast<int>(market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size());
-	return std::clamp(skillColumns, 4, 6);
+	return std::clamp(skillColumns, 4, 7);
 }
 
 static int getUniversitySkillPositionX(int windowWidth, int skillColumns, int index)
@@ -1152,7 +1152,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(PLAYER_COLORED, getUniversityBackground(owner_->getMarket(), "UNIVRS2")),
+	: CWindowObject(PLAYER_COLORED, getUniversityBackground(owner_->getMarket(), "UNIVRSC1")),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -390,6 +390,7 @@ class CUniversityWindow final : public CStatusbarWindow, public IMarketHolder
 
 public:
 	CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed);
+	const IMarket * getMarket() const;
 
 	void makeDeal(SecondarySkill skill);
 	void close() override;


### PR DESCRIPTION
### Motivation
- Ensure university windows use the same player-suffixed background convention as recruitment windows so interiors show the correct player color/variant when the market object has a `tempOwner`.
- Prevent speech text from overlapping the background frame by tightening the textbox rectangle and adding inner padding.
- Expose the market pointer from `CUniversityWindow` to allow callers to query the market when building related windows.

### Description
- Added helper `getUniversityBackground(const IMarket * market, std::string fileName)` to append `-<player>` suffix when the market object has a valid `tempOwner` and return `ImagePath::builtin` for that file name.
- Replaced hardcoded background images in `CUniversityWindow` and `CUnivConfirmWindow` constructors with calls to `getUniversityBackground` using `"UNIVRS4"` and `"UNIVRS2"` respectively.
- Adjusted the university speech textbox rectangles from `Rect(24, 129, 413, 70)` to `Rect(25, 128, 411, 72)` in both windows and added a comment explaining the 1px inner padding rationale.
- Added `const IMarket * getMarket() const;` to `CUniversityWindow` header and implemented it to return the stored `market` pointer.

### Testing
- Built the project successfully (`make` / normal build), with no compilation errors after the changes.
- Ran automated unit tests (`ctest` / project's test suite) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea87f44a24832dbc6089e984cbcd5e)