### PR TITLE
Add status-bar spell research dialog with generated player-colored background

### DIFF
--- a/Mods/vcmi/Content/config/translations/czech.json
+++ b/Mods/vcmi/Content/config/translations/czech.json
@@ -1009,6 +1009,7 @@
 	"vcmi.spellResearch.pay": "Chceš nahradit {%SPELL1} za {%SPELL2}? Nebo zrušit toto kouzlo a pokračovat ve výzkumu dalších kouzel?",
 	"vcmi.spellResearch.research": "Prozkoumat toto kouzlo",
 	"vcmi.spellResearch.skip": "Přeskočit toto kouzlo",
+	"vcmi.spellResearch.title": "Výzkum kouzel",
 	"vcmi.stackExperience.description": "» P o d r o b n o s t i   z k u š e n o s t í   o d d í l u «\n\nDruh jednotky ................... : %s\nÚroveň hodnosti ................. : %s (%i)\nBody zkušeností ............... : %i\nZkušenostních bodů do další úrovně hodnosti .. : %i\nMaximum zkušeností na bitvu ... : %i%% (%i)\nPočet jednotek v oddílu .... : %i\nMaximum nových rekrutů\n bez ztráty současné hodnosti .... : %i\nNásobič zkušeností ........... : %.2f\nNásobič vylepšení .............. : %.2f\nZkušnosti po 10. úrovně hodnosti ........ : %i\nMaximální počet nových rekrutů pro zachování\n 10. úrovně hodnosti s maximálními zkušenostmi: %i",
 	"vcmi.stackExperience.rank.0": "Začátečník",
 	"vcmi.stackExperience.rank.1": "Učeň",

--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -1009,6 +1009,7 @@
 	"vcmi.spellResearch.pay": "Would you like to replace {%SPELL1} with {%SPELL2}? Or discard this spell and continue spell research?",
 	"vcmi.spellResearch.research": "Research this Spell",
 	"vcmi.spellResearch.skip": "Skip this Spell",
+	"vcmi.spellResearch.title": "Spell research",
 	"vcmi.stackExperience.description": "» S t a c k   E x p e r i e n c e   D e t a i l s «\n\nCreature Type ................... : %s\nExperience Rank ................. : %s (%i)\nExperience Points ............... : %i\nExperience Points to Next Rank .. : %i\nMaximum Experience per Battle ... : %i%% (%i)\nNumber of Creatures in stack .... : %i\nMaximum New Recruits\n without losing current Rank .... : %i\nExperience Multiplier ........... : %.2f\nUpgrade Multiplier .............. : %.2f\nExperience after Rank 10 ........ : %i\nMaximum New Recruits to remain at\n Rank 10 if at Maximum Experience : %i",
 	"vcmi.stackExperience.rank.0": "Basic",
 	"vcmi.stackExperience.rank.1": "Novice",

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -93,7 +93,7 @@ void AssetGenerator::initialize()
 	addUniversityBackground("UNIVRS7", Point(778, 388), 7);
 	addUniversityConfirmBackground("UNIVRSC1", Point(466, 388), 1);
 	addUniversityConfirmBackground("UNIVRSC2", Point(466, 388), 2);
-	addSpellResearchBackground("spellResearchDialog", Point(466, 420));
+	addSpellResearchBackground("spellResearchDialog", Point(352, 448));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -93,7 +93,7 @@ void AssetGenerator::initialize()
 	addUniversityBackground("UNIVRS7", Point(778, 388), 7);
 	addUniversityConfirmBackground("UNIVRSC1", Point(466, 388), 1);
 	addUniversityConfirmBackground("UNIVRSC2", Point(466, 388), 2);
-	addSpellResearchBackground("spellResearchDialog", Point(352, 454));
+	addSpellResearchBackground("spellResearchDialog", Point(352, 474));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -93,6 +93,7 @@ void AssetGenerator::initialize()
 	addUniversityBackground("UNIVRS7", Point(778, 388), 7);
 	addUniversityConfirmBackground("UNIVRSC1", Point(466, 388), 1);
 	addUniversityConfirmBackground("UNIVRSC2", Point(466, 388), 2);
+	addSpellResearchBackground("spellResearchDialog", Point(466, 420));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{
@@ -163,6 +164,16 @@ void AssetGenerator::addAnimationFile(const AnimationPath & path, AnimationLayou
 void AssetGenerator::addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor)
 {
 	imageFiles[ImagePath::builtin(fileName)] = [this, size, playerColor](){ return createDialogBackgroundWithStatusBar(size, playerColor);};
+}
+
+void AssetGenerator::addSpellResearchBackground(const std::string & fileName, const Point & size)
+{
+	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
+	{
+		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
+		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
+		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createDialogBackgroundWithStatusBar(size, playerColor);};
+	}
 }
 
 void AssetGenerator::addRecruitmentBackground(const std::string & fileName, const Point & size)

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -93,7 +93,7 @@ void AssetGenerator::initialize()
 	addUniversityBackground("UNIVRS7", Point(778, 388), 7);
 	addUniversityConfirmBackground("UNIVRSC1", Point(466, 388), 1);
 	addUniversityConfirmBackground("UNIVRSC2", Point(466, 388), 2);
-	addSpellResearchBackground("spellResearchDialog", Point(352, 448));
+	addSpellResearchBackground("spellResearchDialog", Point(352, 454));
 
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -35,6 +35,7 @@ public:
 	void addImageFile(const ImagePath & path, ImageGenerationFunctor & img);
 	void addAnimationFile(const AnimationPath & path, AnimationLayoutMap & anim);
 	void addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor);
+	void addSpellResearchBackground(const std::string & fileName, const Point & size);
 	void addRecruitmentBackground(const std::string & fileName, const Point & size);
 	void addUniversityBackground(const std::string & fileName, const Point & size, int skillColumns);
 	void addUniversityConfirmBackground(const std::string & fileName, const Point & size, int costElements);

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -75,72 +75,60 @@ static bool useAvailableAmountAsCreatureLabel()
 	return settings["gameTweaks"]["availableCreaturesAsDwellingLabel"].Bool();
 }
 
-class CSpellResearchDialog : public CStatusbarWindow
+CSpellResearchDialog::CSpellResearchDialog(
+	const std::string & textToShow,
+	const std::vector<std::shared_ptr<CComponent>> & comps,
+	const CGTownInstance * town,
+	SpellID oldSpell,
+	bool canAfford)
+	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("spellResearchDialog"))
 {
-public:
-	CSpellResearchDialog(
-		const std::string & textToShow,
-		const std::vector<std::shared_ptr<CComponent>> & comps,
-		const CGTownInstance * town,
-		SpellID oldSpell,
-		bool canAfford)
-		: CWindowObject(PLAYER_COLORED, ImagePath::builtin("spellResearchDialog"))
-		{
-			OBJECT_CONSTRUCTION;
+	OBJECT_CONSTRUCTION;
 
-			const int sideMargin = 21;
-			const int topMargin = 18;
-			const int titleY = topMargin + 16;
-			const int textTop = 46;
-			const int textHeight = 88;
-			const int gapAfterText = 39;
-			const int componentsOffsetY = 10;
-			const int statusbarHeight = 26;
-			const int gapBeforeStatusbar = 12;
+	const int sideMargin = 21;
+	const int topMargin = 18;
+	const int titleY = topMargin + 16;
+	const int textTop = 46;
+	const int textHeight = 88;
+	const int gapAfterText = 39;
+	const int componentsOffsetY = 30;
+	const int statusbarHeight = 26;
+	const int gapBeforeStatusbar = 12;
 
-			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
-			title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
-			description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, 0));
+	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
+	title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
+	description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
+	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, 0));
 
-			// Keep original button row position and only extend the lower empty area of the dialog.
-			const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;
-			const int buttonSpacing = 22;
-			const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;
-			int buttonX = (pos.w - totalButtonsWidth) / 2;
+	// Keep original button row position and only extend the lower empty area of the dialog.
+	const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;
+	const int buttonSpacing = 22;
+	const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;
+	int buttonX = (pos.w - totalButtonsWidth) / 2;
 
-			acceptButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.research"), ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
-			acceptButton->setBorderColor(Colors::METALLIC_GOLD);
-			acceptButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/accept")));
-			acceptButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, true); });
-			acceptButton->setEnabled(canAfford);
-			acceptButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.research")); });
+	acceptButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.research"), ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
+	acceptButton->setBorderColor(Colors::METALLIC_GOLD);
+	acceptButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/accept")));
+	acceptButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, true); });
+	acceptButton->setEnabled(canAfford);
+	acceptButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.research")); });
 
-			buttonX += 80 + buttonSpacing;
-			rerollButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip"), ""), [this](){ close(); });
-			rerollButton->setBorderColor(Colors::METALLIC_GOLD);
-			rerollButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/reroll")));
-			rerollButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, false); });
-			rerollButton->setEnabled(canAfford);
-			rerollButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip")); });
+	buttonX += 80 + buttonSpacing;
+	rerollButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip"), ""), [this](){ close(); });
+	rerollButton->setBorderColor(Colors::METALLIC_GOLD);
+	rerollButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/reroll")));
+	rerollButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, false); });
+	rerollButton->setEnabled(canAfford);
+	rerollButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip")); });
 
-			buttonX += 80 + buttonSpacing;
-			closeButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort"), ""), [this](){ close(); }, EShortcut::GLOBAL_CANCEL);
-			closeButton->setBorderColor(Colors::METALLIC_GOLD);
-			closeButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/close")));
-			closeButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort")); });
+	buttonX += 80 + buttonSpacing;
+	closeButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort"), ""), [this](){ close(); }, EShortcut::GLOBAL_CANCEL);
+	closeButton->setBorderColor(Colors::METALLIC_GOLD);
+	closeButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/close")));
+	closeButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort")); });
 
-			statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
-	}
-
-private:
-	std::shared_ptr<CLabel> title;
-	std::shared_ptr<CTextBox> description;
-	std::shared_ptr<CComponentBox> components;
-	std::shared_ptr<CButton> acceptButton;
-	std::shared_ptr<CButton> rerollButton;
-	std::shared_ptr<CButton> closeButton;
-};
+	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
+}
 
 CBuildingRect::CBuildingRect(CCastleBuildings * Par, const CGTownInstance * Town, const CStructure * Str)
 	: CShowableAnim(0, 0, Str->defName, CShowableAnim::BASE, BUILDING_FRAME_TIME),

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -92,7 +92,7 @@ CSpellResearchDialog::CSpellResearchDialog(
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;
 	const int componentsTop = 175;
-	const int componentsHeight = 164;
+	const int componentsHeight = 144;
 
 	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 	title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -91,17 +91,18 @@ public:
 			const int sideMargin = 21;
 			const int topMargin = 18;
 			const int titleY = topMargin + 16;
-			const int textTop = 36;
-			const int textHeight = 98;
+			const int textTop = 46;
+			const int textHeight = 88;
 			const int gapAfterText = 39;
+			const int componentsOffsetY = 20;
 			const int statusbarHeight = 26;
 			const int gapBeforeStatusbar = 12;
-			const int costAreaHeight = 123;
+			const int costAreaHeight = 103;
 
 			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 			title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 			description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText, pos.w - 2 * sideMargin, costAreaHeight));
+			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, costAreaHeight), 42, 10, 27, 4);
 
 			// Keep original button row position and only extend the lower empty area of the dialog.
 			const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -87,7 +87,7 @@ CSpellResearchDialog::CSpellResearchDialog(
 
 	const int sideMargin = 21;
 	const int topMargin = 18;
-	const int titleY = topMargin + 16;
+	const int titleY = topMargin + 21;
 	const int textTop = 46;
 	const int textHeight = 88;
 	const int statusbarHeight = 26;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -87,7 +87,7 @@ CSpellResearchDialog::CSpellResearchDialog(
 
 	const int sideMargin = 21;
 	const int titleY = 39;
-	const int textTop = 36;
+	const int textTop = 41;
 	const int textHeight = 88;
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -87,7 +87,7 @@ CSpellResearchDialog::CSpellResearchDialog(
 
 	const int sideMargin = 21;
 	const int titleY = 39;
-	const int textTop = 46;
+	const int textTop = 36;
 	const int textHeight = 88;
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -91,12 +91,12 @@ public:
 			const int sideMargin = 16;
 			const int topMargin = 18;
 			const int titleY = topMargin + 16;
-			const int textTop = 56;
+			const int textTop = 51;
 			const int textHeight = 98;
-			const int gapAfterText = 24;
+			const int gapAfterText = 39;
 			const int statusbarHeight = 26;
 			const int gapBeforeStatusbar = 12;
-			const int costAreaHeight = 138;
+			const int costAreaHeight = 123;
 
 			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 			title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -92,13 +92,13 @@ CSpellResearchDialog::CSpellResearchDialog(
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;
 	const int componentsTop = 140;
+	const int componentsHeight = 164;
 
 	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 	title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 	description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, componentsTop, pos.w - 2 * sideMargin, 0));
+	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, componentsTop, pos.w - 2 * sideMargin, componentsHeight));
 
-	// Keep original button row position and only extend the lower empty area of the dialog.
 	const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;
 	const int buttonSpacing = 22;
 	const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -75,6 +75,63 @@ static bool useAvailableAmountAsCreatureLabel()
 	return settings["gameTweaks"]["availableCreaturesAsDwellingLabel"].Bool();
 }
 
+class CSpellResearchDialog : public CWindowObject
+{
+public:
+	CSpellResearchDialog(
+		const std::string & textToShow,
+		const std::vector<std::shared_ptr<CComponent>> & comps,
+		const CGTownInstance * town,
+		SpellID oldSpell,
+		bool canAfford)
+		: CWindowObject(PLAYER_COLORED, ImagePath::builtin("spellResearchDialog"))
+	{
+		OBJECT_CONSTRUCTION;
+
+		const int sideMargin = 24;
+		const int topMargin = 18;
+		const int textHeight = 108;
+		const int gapAfterText = 12;
+		const int gapAfterComponents = 14;
+
+		description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, topMargin, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
+		components = std::make_shared<CComponentBox>(comps, Rect(0, 0, 0, 0));
+		components->moveBy(Point((pos.w - components->pos.w) / 2, topMargin + textHeight + gapAfterText));
+
+		const int buttonY = topMargin + textHeight + gapAfterText + components->pos.h + gapAfterComponents;
+		const int buttonSpacing = 22;
+		const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;
+		int buttonX = (pos.w - totalButtonsWidth) / 2;
+
+		acceptButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.research"), ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
+		acceptButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/accept")));
+		acceptButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, true); });
+		acceptButton->setEnabled(canAfford);
+		acceptButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.research")); });
+
+		buttonX += 80 + buttonSpacing;
+		rerollButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip"), ""), [this](){ close(); });
+		rerollButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/reroll")));
+		rerollButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, false); });
+		rerollButton->setEnabled(canAfford);
+		rerollButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip")); });
+
+		buttonX += 80 + buttonSpacing;
+		closeButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort"), ""), [this](){ close(); }, EShortcut::GLOBAL_CANCEL);
+		closeButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/close")));
+		closeButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort")); });
+
+		statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
+	}
+
+private:
+	std::shared_ptr<CTextBox> description;
+	std::shared_ptr<CComponentBox> components;
+	std::shared_ptr<CButton> acceptButton;
+	std::shared_ptr<CButton> rerollButton;
+	std::shared_ptr<CButton> closeButton;
+};
+
 CBuildingRect::CBuildingRect(CCastleBuildings * Par, const CGTownInstance * Town, const CStructure * Str)
 	: CShowableAnim(0, 0, Str->defName, CShowableAnim::BASE, BUILDING_FRAME_TIME),
 	  parent(Par),
@@ -2306,25 +2363,10 @@ void CMageGuildScreen::Scroll::clickPressed(const Point & cursorPosition)
 			resComps.push_back(std::make_shared<CComponent>(ComponentType::RESOURCE, i->resType, i->resVal, CComponent::ESize::medium));
 		}
 
-		std::vector<std::pair<AnimationPath, CFunctionList<void()>>> pom;
-		for(int i = 0; i < 3; i++)
-			pom.emplace_back(AnimationPath::builtin("settingsWindow/button80"), nullptr);
-
 		auto text = LIBRARY->generaltexth->translate(GAME->interface()->cb->getResourceAmount().canAfford(cost) ? "vcmi.spellResearch.pay" : "vcmi.spellResearch.canNotAfford");
 		boost::replace_first(text, "%SPELL1", spell->id.toSpell()->getNameTranslated());
 		boost::replace_first(text, "%SPELL2", newSpell.toSpell()->getNameTranslated());
-		auto temp = std::make_shared<CInfoWindow>(text, GAME->interface()->playerID, resComps, pom);
-
-		temp->buttons[0]->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/accept")));
-		temp->buttons[0]->addCallback([this, town](){ GAME->interface()->cb->spellResearch(town, spell->id, true); });
-		temp->buttons[0]->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.research")); });
-		temp->buttons[0]->setEnabled(GAME->interface()->cb->getResourceAmount().canAfford(cost));
-		temp->buttons[1]->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/reroll")));
-		temp->buttons[1]->addCallback([this, town](){ GAME->interface()->cb->spellResearch(town, spell->id, false); });
-		temp->buttons[1]->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip")); });
-		temp->buttons[1]->setEnabled(GAME->interface()->cb->getResourceAmount().canAfford(cost));
-		temp->buttons[2]->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/close")));
-		temp->buttons[2]->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort")); });
+		auto temp = std::make_shared<CSpellResearchDialog>(text, resComps, town, spell->id, GAME->interface()->cb->getResourceAmount().canAfford(cost));
 
 		ENGINE->windows().pushWindow(temp);
 	}

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -86,8 +86,7 @@ CSpellResearchDialog::CSpellResearchDialog(
 	OBJECT_CONSTRUCTION;
 
 	const int sideMargin = 21;
-	const int topMargin = 18;
-	const int titleY = topMargin + 21;
+	const int titleY = 39;
 	const int textTop = 46;
 	const int textHeight = 88;
 	const int statusbarHeight = 26;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -94,7 +94,7 @@ public:
 			const int textTop = 46;
 			const int textHeight = 88;
 			const int gapAfterText = 39;
-			const int componentsOffsetY = 20;
+			const int componentsOffsetY = 25;
 			const int statusbarHeight = 26;
 			const int gapBeforeStatusbar = 12;
 			const int costAreaHeight = 103;
@@ -102,7 +102,7 @@ public:
 			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 			title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 			description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, costAreaHeight), 42, 10, 27, 4);
+			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, costAreaHeight), 42, 10, 37, 4);
 
 			// Keep original button row position and only extend the lower empty area of the dialog.
 			const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -87,11 +87,11 @@ CSpellResearchDialog::CSpellResearchDialog(
 
 	const int sideMargin = 21;
 	const int titleY = 39;
-	const int textTop = 41;
+	const int textTop = 44;
 	const int textHeight = 88;
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;
-	const int componentsTop = 140;
+	const int componentsTop = 160;
 	const int componentsHeight = 164;
 
 	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -92,12 +92,11 @@ CSpellResearchDialog::CSpellResearchDialog(
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;
 	const int componentsTop = 185;
-	const int componentsHeight = 124;
 
 	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 	title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 	description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, componentsTop, pos.w - 2 * sideMargin, componentsHeight));
+	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, componentsTop, pos.w - 2 * sideMargin, 0));
 
 	const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;
 	const int buttonSpacing = 22;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -75,7 +75,7 @@ static bool useAvailableAmountAsCreatureLabel()
 	return settings["gameTweaks"]["availableCreaturesAsDwellingLabel"].Bool();
 }
 
-class CSpellResearchDialog : public CWindowObject
+class CSpellResearchDialog : public CStatusbarWindow
 {
 public:
 	CSpellResearchDialog(

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -94,15 +94,14 @@ public:
 			const int textTop = 46;
 			const int textHeight = 88;
 			const int gapAfterText = 39;
-			const int componentsOffsetY = 25;
+			const int componentsOffsetY = 10;
 			const int statusbarHeight = 26;
 			const int gapBeforeStatusbar = 12;
-			const int costAreaHeight = 103;
 
 			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 			title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 			description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, costAreaHeight), 42, 10, 37, 4);
+			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, 0));
 
 			// Keep original button row position and only extend the lower empty area of the dialog.
 			const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -95,11 +95,13 @@ public:
 			const int statusbarHeight = 26;
 			const int gapBeforeStatusbar = 12;
 
-			description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, topMargin, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
+			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
+			description = std::make_shared<CTextBox>(CInfoWindow::genText(titleText, textToShow), Rect(sideMargin, topMargin, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
 			components = std::make_shared<CComponentBox>(comps, Rect(0, 0, 0, 0), 8, 4, 6, 5);
 			components->moveBy(Point((pos.w - components->pos.w) / 2, topMargin + textHeight + gapAfterText));
 
-			const int buttonY = pos.h - statusbarHeight - gapBeforeStatusbar - 32;
+			// Keep original button row position and only extend the lower empty area of the dialog.
+			const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;
 			const int buttonSpacing = 22;
 			const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;
 			int buttonX = (pos.w - totalButtonsWidth) / 2;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -90,13 +90,13 @@ public:
 
 			const int sideMargin = 16;
 			const int topMargin = 18;
-			const int titleY = topMargin + 6;
+			const int titleY = topMargin + 16;
 			const int textTop = 56;
 			const int textHeight = 98;
-			const int gapAfterText = 12;
+			const int gapAfterText = 24;
 			const int statusbarHeight = 26;
 			const int gapBeforeStatusbar = 12;
-			const int costAreaHeight = 150;
+			const int costAreaHeight = 138;
 
 			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 			title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -90,15 +90,18 @@ public:
 
 			const int sideMargin = 16;
 			const int topMargin = 18;
-			const int textHeight = 136;
+			const int titleY = topMargin + 6;
+			const int textTop = 56;
+			const int textHeight = 98;
 			const int gapAfterText = 12;
 			const int statusbarHeight = 26;
 			const int gapBeforeStatusbar = 12;
+			const int costAreaHeight = 150;
 
 			const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
-			description = std::make_shared<CTextBox>(CInfoWindow::genText(titleText, textToShow), Rect(sideMargin, topMargin, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-			components = std::make_shared<CComponentBox>(comps, Rect(0, 0, 0, 0), 8, 4, 6, 5);
-			components->moveBy(Point((pos.w - components->pos.w) / 2, topMargin + textHeight + gapAfterText));
+			title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
+			description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
+			components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText, pos.w - 2 * sideMargin, costAreaHeight));
 
 			// Keep original button row position and only extend the lower empty area of the dialog.
 			const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;
@@ -128,6 +131,7 @@ public:
 	}
 
 private:
+	std::shared_ptr<CLabel> title;
 	std::shared_ptr<CTextBox> description;
 	std::shared_ptr<CComponentBox> components;
 	std::shared_ptr<CButton> acceptButton;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -98,7 +98,7 @@ CSpellResearchDialog::CSpellResearchDialog(
 	description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
 	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, componentsTop, pos.w - 2 * sideMargin, 0));
 
-	const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;
+	const int buttonY = 468 - statusbarHeight - gapBeforeStatusbar - 32;
 	const int buttonSpacing = 22;
 	const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;
 	int buttonX = (pos.w - totalButtonsWidth) / 2;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -88,10 +88,10 @@ public:
 		{
 			OBJECT_CONSTRUCTION;
 
-			const int sideMargin = 16;
+			const int sideMargin = 21;
 			const int topMargin = 18;
 			const int titleY = topMargin + 16;
-			const int textTop = 51;
+			const int textTop = 36;
 			const int textHeight = 98;
 			const int gapAfterText = 39;
 			const int statusbarHeight = 26;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -90,15 +90,14 @@ CSpellResearchDialog::CSpellResearchDialog(
 	const int titleY = topMargin + 16;
 	const int textTop = 46;
 	const int textHeight = 88;
-	const int gapAfterText = 39;
-	const int componentsOffsetY = 30;
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;
+	const int componentsTop = 140;
 
 	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 	title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);
 	description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, textTop, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, textTop + textHeight + gapAfterText + componentsOffsetY, pos.w - 2 * sideMargin, 0));
+	components = std::make_shared<CComponentBox>(comps, Rect(sideMargin, componentsTop, pos.w - 2 * sideMargin, 0));
 
 	// Keep original button row position and only extend the lower empty area of the dialog.
 	const int buttonY = 448 - statusbarHeight - gapBeforeStatusbar - 32;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -110,6 +110,7 @@ public:
 			int buttonX = (pos.w - totalButtonsWidth) / 2;
 
 			acceptButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.research"), ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
+			acceptButton->setBorderColor(Colors::METALLIC_GOLD);
 			acceptButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/accept")));
 			acceptButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, true); });
 			acceptButton->setEnabled(canAfford);
@@ -117,6 +118,7 @@ public:
 
 			buttonX += 80 + buttonSpacing;
 			rerollButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip"), ""), [this](){ close(); });
+			rerollButton->setBorderColor(Colors::METALLIC_GOLD);
 			rerollButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/reroll")));
 			rerollButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, false); });
 			rerollButton->setEnabled(canAfford);
@@ -124,6 +126,7 @@ public:
 
 			buttonX += 80 + buttonSpacing;
 			closeButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort"), ""), [this](){ close(); }, EShortcut::GLOBAL_CANCEL);
+			closeButton->setBorderColor(Colors::METALLIC_GOLD);
 			closeButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/close")));
 			closeButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort")); });
 

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -85,43 +85,44 @@ public:
 		SpellID oldSpell,
 		bool canAfford)
 		: CWindowObject(PLAYER_COLORED, ImagePath::builtin("spellResearchDialog"))
-	{
-		OBJECT_CONSTRUCTION;
+		{
+			OBJECT_CONSTRUCTION;
 
-		const int sideMargin = 24;
-		const int topMargin = 18;
-		const int textHeight = 108;
-		const int gapAfterText = 12;
-		const int gapAfterComponents = 14;
+			const int sideMargin = 16;
+			const int topMargin = 18;
+			const int textHeight = 136;
+			const int gapAfterText = 12;
+			const int statusbarHeight = 26;
+			const int gapBeforeStatusbar = 12;
 
-		description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, topMargin, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
-		components = std::make_shared<CComponentBox>(comps, Rect(0, 0, 0, 0));
-		components->moveBy(Point((pos.w - components->pos.w) / 2, topMargin + textHeight + gapAfterText));
+			description = std::make_shared<CTextBox>(textToShow, Rect(sideMargin, topMargin, pos.w - 2 * sideMargin, textHeight), 0, FONT_MEDIUM, ETextAlignment::CENTER, Colors::WHITE);
+			components = std::make_shared<CComponentBox>(comps, Rect(0, 0, 0, 0), 8, 4, 6, 5);
+			components->moveBy(Point((pos.w - components->pos.w) / 2, topMargin + textHeight + gapAfterText));
 
-		const int buttonY = topMargin + textHeight + gapAfterText + components->pos.h + gapAfterComponents;
-		const int buttonSpacing = 22;
-		const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;
-		int buttonX = (pos.w - totalButtonsWidth) / 2;
+			const int buttonY = pos.h - statusbarHeight - gapBeforeStatusbar - 32;
+			const int buttonSpacing = 22;
+			const int totalButtonsWidth = 3 * 80 + 2 * buttonSpacing;
+			int buttonX = (pos.w - totalButtonsWidth) / 2;
 
-		acceptButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.research"), ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
-		acceptButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/accept")));
-		acceptButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, true); });
-		acceptButton->setEnabled(canAfford);
-		acceptButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.research")); });
+			acceptButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.research"), ""), [this](){ close(); }, EShortcut::GLOBAL_ACCEPT);
+			acceptButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/accept")));
+			acceptButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, true); });
+			acceptButton->setEnabled(canAfford);
+			acceptButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.research")); });
 
-		buttonX += 80 + buttonSpacing;
-		rerollButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip"), ""), [this](){ close(); });
-		rerollButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/reroll")));
-		rerollButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, false); });
-		rerollButton->setEnabled(canAfford);
-		rerollButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip")); });
+			buttonX += 80 + buttonSpacing;
+			rerollButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip"), ""), [this](){ close(); });
+			rerollButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/reroll")));
+			rerollButton->addCallback([town, oldSpell](){ GAME->interface()->cb->spellResearch(town, oldSpell, false); });
+			rerollButton->setEnabled(canAfford);
+			rerollButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.skip")); });
 
-		buttonX += 80 + buttonSpacing;
-		closeButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort"), ""), [this](){ close(); }, EShortcut::GLOBAL_CANCEL);
-		closeButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/close")));
-		closeButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort")); });
+			buttonX += 80 + buttonSpacing;
+			closeButton = std::make_shared<CButton>(Point(buttonX, buttonY), AnimationPath::builtin("settingsWindow/button80"), CButton::tooltip(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort"), ""), [this](){ close(); }, EShortcut::GLOBAL_CANCEL);
+			closeButton->setOverlay(std::make_shared<CPicture>(ImagePath::builtin("spellResearch/close")));
+			closeButton->addPopupCallback([](){ CRClickPopup::createAndPush(LIBRARY->generaltexth->translate("vcmi.spellResearch.abort")); });
 
-		statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
+			statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
 	}
 
 private:

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -85,13 +85,13 @@ CSpellResearchDialog::CSpellResearchDialog(
 {
 	OBJECT_CONSTRUCTION;
 
-	const int sideMargin = 21;
+	const int sideMargin = 23;
 	const int titleY = 39;
-	const int textTop = 44;
+	const int textTop = 47;
 	const int textHeight = 88;
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;
-	const int componentsTop = 160;
+	const int componentsTop = 175;
 	const int componentsHeight = 164;
 
 	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -91,8 +91,8 @@ CSpellResearchDialog::CSpellResearchDialog(
 	const int textHeight = 88;
 	const int statusbarHeight = 26;
 	const int gapBeforeStatusbar = 12;
-	const int componentsTop = 175;
-	const int componentsHeight = 144;
+	const int componentsTop = 185;
+	const int componentsHeight = 124;
 
 	const std::string titleText = LIBRARY->generaltexth->translate("vcmi.spellResearch.title");
 	title = std::make_shared<CLabel>(pos.w / 2, titleY, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, titleText);

--- a/client/windows/CCastleInterface.h
+++ b/client/windows/CCastleInterface.h
@@ -380,6 +380,24 @@ public:
 	void creaturesChangedEventHandler();
 };
 
+class CSpellResearchDialog : public CStatusbarWindow
+{
+	std::shared_ptr<CLabel> title;
+	std::shared_ptr<CTextBox> description;
+	std::shared_ptr<CComponentBox> components;
+	std::shared_ptr<CButton> acceptButton;
+	std::shared_ptr<CButton> rerollButton;
+	std::shared_ptr<CButton> closeButton;
+
+public:
+	CSpellResearchDialog(
+		const std::string & textToShow,
+		const std::vector<std::shared_ptr<CComponent>> & components,
+		const CGTownInstance * town,
+		SpellID oldSpell,
+		bool canAfford);
+};
+
 /// The mage guild screen where you can see which spells you have
 class CMageGuildScreen : public CStatusbarWindow
 {


### PR DESCRIPTION
### Motivation
- Spell Research dialog lacked an embedded status bar and player-colored generated background like other dialogs, so UI consistency and hover descriptions in the status bar were missing.
- The intent is to reuse the existing asset generator pattern (player-colored dialog backgrounds) and provide hover-to-statusbar descriptions for the Spell Research actions.

### Description
- Added `addSpellResearchBackground` to `AssetGenerator` and registered a generated player-colored background named `spellResearchDialog` sized `466x420` to match existing dialog generation patterns (`client/render/AssetGenerator.h/.cpp`).
- Introduced `CSpellResearchDialog` in `CCastleInterface.cpp` which uses the new generated `spellResearchDialog` background, contains the description, components, three action buttons (research/reroll/abort) and an embedded `CGStatusBar` instance.
- Replaced the previous ad-hoc `CInfoWindow` usage for spell research with the new `CSpellResearchDialog` and preserved original affordance logic, callbacks (`GAME->interface()->cb->spellResearch`) and enabled/disabled gating based on affordability.
- Wired button hover text/tooltips to surface descriptions into the dialog status bar while keeping existing right-click popup behavior and original button overlays (`spellResearch/accept`, `reroll`, `close`).

### Testing
- Ran `git diff --check` which reported no whitespace/format issues (success).
- Verified repository status and committed the changes (commit created successfully).
- Checked for a build directory with `test -d build` and found none in this environment, so no full build or runtime UI tests were executed here (no automated build/test run available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf4915388832da9aa772f9f068abf)