### PR TITLE
Align university title graphic with map-object appearances

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1321,8 +1321,6 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
 		}
 	}
-	const int statusBarOverlayHeight = 30;
-	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
 	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);
@@ -1390,8 +1388,6 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackgroun
 			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
 		}
 	}
-	const int statusBarOverlayHeight = 30;
-	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
 	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -168,22 +168,25 @@ void AssetGenerator::addDialogBackgroundWithStatusBar(const std::string & fileNa
 
 void AssetGenerator::addSpellResearchBackground(const std::string & fileName, const Point & size)
 {
-	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
+	imageFiles[ImagePath::builtin(fileName)] = [this, size]()
 	{
-		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
-		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
-		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createDialogBackgroundWithStatusBar(size, playerColor);};
-	}
+		auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
+		Canvas canvas = image->getCanvas();
+		auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+		for(int y = 0; y < size.y; y += background->height())
+		{
+			for(int x = 0; x < size.x; x += background->width())
+			{
+				canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
+			}
+		}
+		return image;
+	};
 }
 
 void AssetGenerator::addRecruitmentBackground(const std::string & fileName, const Point & size)
 {
-	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
-	{
-		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
-		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
-		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor](){ return createRecruitmentDialogBackground(size, playerColor);};
-	}
+	imageFiles[ImagePath::builtin(fileName)] = [this, size](){ return createRecruitmentDialogBackground(size);};
 }
 
 void AssetGenerator::addUniversityBackground(const std::string & fileName, const Point & size, int skillColumns)
@@ -1265,10 +1268,19 @@ AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(co
 	return image;
 }
 
-AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(const Point & size, const PlayerColor & playerColor) const
+AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(const Point & size) const
 {
-	auto image = createDialogBackgroundWithStatusBar(size, playerColor);
+	auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
 	Canvas canvas = image->getCanvas();
+
+	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+	for(int y = 0; y < size.y; y += background->height())
+	{
+		for(int x = 0; x < size.x; x += background->width())
+		{
+			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
+		}
+	}
 
 	// Additional overlays used by original TPRCRT (semi-transparent plates and central black input area).
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -188,22 +188,12 @@ void AssetGenerator::addRecruitmentBackground(const std::string & fileName, cons
 
 void AssetGenerator::addUniversityBackground(const std::string & fileName, const Point & size, int skillColumns)
 {
-	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
-	{
-		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
-		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
-		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor, skillColumns](){ return createUniversityDialogBackground(size, playerColor, skillColumns);};
-	}
+	imageFiles[ImagePath::builtin(fileName)] = [this, size, skillColumns](){ return createUniversityDialogBackground(size, skillColumns);};
 }
 
 void AssetGenerator::addUniversityConfirmBackground(const std::string & fileName, const Point & size, int costElements)
 {
-	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
-	{
-		const std::string name = fileName + (color == -1 ? "" : "-" + color.toString());
-		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
-		imageFiles[ImagePath::builtin(name)] = [this, size, playerColor, costElements](){ return createUniversityConfirmDialogBackground(size, playerColor, costElements);};
-	}
+	imageFiles[ImagePath::builtin(fileName)] = [this, size, costElements](){ return createUniversityConfirmDialogBackground(size, costElements);};
 }
 
 auto getColorFilters()
@@ -1318,10 +1308,21 @@ AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(cons
 	return image;
 }
 
-AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor, int skillColumns) const
+AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const Point & size, int skillColumns) const
 {
-	auto image = createDialogBackgroundWithStatusBar(size, playerColor);
+	auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
 	Canvas canvas = image->getCanvas();
+
+	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+	for(int y = 0; y < size.y; y += background->height())
+	{
+		for(int x = 0; x < size.x; x += background->width())
+		{
+			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
+		}
+	}
+	const int statusBarOverlayHeight = 30;
+	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
 	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);
@@ -1376,10 +1377,21 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 	return image;
 }
 
-AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor, int costElements) const
+AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackground(const Point & size, int costElements) const
 {
-	auto image = createDialogBackgroundWithStatusBar(size, playerColor);
+	auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
 	Canvas canvas = image->getCanvas();
+
+	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+	for(int y = 0; y < size.y; y += background->height())
+	{
+		for(int x = 0; x < size.x; x += background->width())
+		{
+			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
+		}
+	}
+	const int statusBarOverlayHeight = 30;
+	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
 	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -168,20 +168,7 @@ void AssetGenerator::addDialogBackgroundWithStatusBar(const std::string & fileNa
 
 void AssetGenerator::addSpellResearchBackground(const std::string & fileName, const Point & size)
 {
-	imageFiles[ImagePath::builtin(fileName)] = [size]()
-	{
-		auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
-		Canvas canvas = image->getCanvas();
-		auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
-		for(int y = 0; y < size.y; y += background->height())
-		{
-			for(int x = 0; x < size.x; x += background->width())
-			{
-				canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
-			}
-		}
-		return image;
-	};
+	imageFiles[ImagePath::builtin(fileName)] = [this, size](){ return createDialogBackgroundWithStatusBar(size, PlayerColor(1));};
 }
 
 void AssetGenerator::addRecruitmentBackground(const std::string & fileName, const Point & size)
@@ -1206,14 +1193,12 @@ AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(co
 {
 	// Generic compositing helper:
 	// 1) tile DiBoxBck over full target size
-	// 2) build border and status-bar frame from DIALGBOX pieces
+	// 2) add darkened status-bar strip at the bottom
 	auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
 	Canvas canvas = image->getCanvas();
 
 	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
-	auto dialogBox = ENGINE->renderHandler().loadAnimation(AnimationPath::builtin("DIALGBOX"), EImageBlitMode::COLORKEY);
-	if (playerColor.isValidPlayer() && playerColor != PlayerColor(1))
-		dialogBox->playerColored(playerColor);
+	(void)playerColor;
 
 	// Fill whole area with DiBoxBck texture first.
 	for (int y = 0; y < size.y; y += background->height())
@@ -1228,59 +1213,13 @@ AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(co
 	const int statusBarOverlayHeight = 30;
 	canvas.drawColorBlended(Rect(0, size.y - statusBarOverlayHeight, size.x, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
 
-	auto drawHorizontal = [&canvas](const std::shared_ptr<IImage> & source, int y, int xBegin, int xEnd)
-	{
-		for(int x = xBegin; x < xEnd; x += source->width())
-		{
-			int width = std::min(source->width(), xEnd - x);
-			canvas.draw(source, Point(x, y), Rect(0, 0, width, source->height()));
-		}
-	};
-
-	auto drawVertical = [&canvas](const std::shared_ptr<IImage> & source, int x, int yBegin, int yEnd)
-	{
-		for(int y = yBegin; y < yEnd; y += source->height())
-		{
-			int height = std::min(source->height(), yEnd - y);
-			canvas.draw(source, Point(x, y), Rect(0, 0, source->width(), height));
-		}
-	};
-
-	auto topLeft = dialogBox->getImage(0, 0);
-	auto topRight = dialogBox->getImage(1, 0);
-	auto leftEdge = dialogBox->getImage(4, 0);
-	auto rightEdge = dialogBox->getImage(5, 0);
-	auto topEdge = dialogBox->getImage(6, 0);
-	auto bottomLeft = dialogBox->getImage(8, 0);
-	auto bottomRight = dialogBox->getImage(9, 0);
-	auto bottomEdge = dialogBox->getImage(10, 0);
-
-	drawHorizontal(topEdge, 0, topLeft->width(), size.x - topRight->width());
-	drawHorizontal(bottomEdge, size.y - bottomEdge->height(), bottomLeft->width(), size.x - bottomRight->width());
-	drawVertical(leftEdge, 0, topLeft->height(), size.y - bottomLeft->height());
-	drawVertical(rightEdge, size.x - rightEdge->width(), topRight->height(), size.y - bottomRight->height());
-
-	canvas.draw(topLeft, Point(0, 0));
-	canvas.draw(topRight, Point(size.x - topRight->width(), 0));
-	canvas.draw(bottomLeft, Point(0, size.y - bottomLeft->height()));
-	canvas.draw(bottomRight, Point(size.x - bottomRight->width(), size.y - bottomRight->height()));
-
 	return image;
 }
 
 AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(const Point & size) const
 {
-	auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
+	auto image = createDialogBackgroundWithStatusBar(size, PlayerColor(1));
 	Canvas canvas = image->getCanvas();
-
-	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
-	for(int y = 0; y < size.y; y += background->height())
-	{
-		for(int x = 0; x < size.x; x += background->width())
-		{
-			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
-		}
-	}
 
 	// Additional overlays used by original TPRCRT (semi-transparent plates and central black input area).
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
@@ -1322,17 +1261,8 @@ AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(cons
 
 AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const Point & size, int skillColumns) const
 {
-	auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
+	auto image = createDialogBackgroundWithStatusBar(size, PlayerColor(1));
 	Canvas canvas = image->getCanvas();
-
-	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
-	for(int y = 0; y < size.y; y += background->height())
-	{
-		for(int x = 0; x < size.x; x += background->width())
-		{
-			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
-		}
-	}
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
 	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);
@@ -1389,17 +1319,8 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 
 AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackground(const Point & size, int costElements) const
 {
-	auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
+	auto image = createDialogBackgroundWithStatusBar(size, PlayerColor(1));
 	Canvas canvas = image->getCanvas();
-
-	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
-	for(int y = 0; y < size.y; y += background->height())
-	{
-		for(int x = 0; x < size.x; x += background->width())
-		{
-			canvas.draw(background, Point(x, y), Rect(0, 0, std::min(background->width(), size.x - x), std::min(background->height(), size.y - y)));
-		}
-	}
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
 	const ColorRGBA borderColor = ColorRGBA(128, 100, 75);

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -98,8 +98,7 @@ void AssetGenerator::initialize()
 	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
 	{
 		const std::string name = "heroBackpackDialog" + (color == -1 ? "" : "-" + color.toString());
-		const PlayerColor playerColor = color == -1 ? PlayerColor(1) : std::max(PlayerColor(0), color);
-		addDialogBackgroundWithStatusBar(name, Point(426, 465), playerColor);
+		addDialogBackgroundWithStatusBar(name, Point(426, 465));
 	}
 
 	imageFiles[ImagePath::builtin("questDialog.png")] = [this](){ return createQuestWindow();};
@@ -161,14 +160,14 @@ void AssetGenerator::addAnimationFile(const AnimationPath & path, AnimationLayou
 	animationFiles[path] = anim;
 }
 
-void AssetGenerator::addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor)
+void AssetGenerator::addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size)
 {
-	imageFiles[ImagePath::builtin(fileName)] = [this, size, playerColor](){ return createDialogBackgroundWithStatusBar(size, playerColor);};
+	imageFiles[ImagePath::builtin(fileName)] = [this, size](){ return createDialogBackgroundWithStatusBar(size);};
 }
 
 void AssetGenerator::addSpellResearchBackground(const std::string & fileName, const Point & size)
 {
-	imageFiles[ImagePath::builtin(fileName)] = [this, size](){ return createDialogBackgroundWithStatusBar(size, PlayerColor(1));};
+	imageFiles[ImagePath::builtin(fileName)] = [this, size](){ return createDialogBackgroundWithStatusBar(size);};
 }
 
 void AssetGenerator::addRecruitmentBackground(const std::string & fileName, const Point & size)
@@ -1189,7 +1188,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createStackArtifactIndicator(const Poi
 	return image;
 }
 
-AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const
+AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(const Point & size) const
 {
 	// Generic compositing helper:
 	// 1) tile DiBoxBck over full target size
@@ -1198,8 +1197,6 @@ AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(co
 	Canvas canvas = image->getCanvas();
 
 	auto background = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
-	(void)playerColor;
-
 	// Fill whole area with DiBoxBck texture first.
 	for (int y = 0; y < size.y; y += background->height())
 	{
@@ -1218,7 +1215,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createDialogBackgroundWithStatusBar(co
 
 AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(const Point & size) const
 {
-	auto image = createDialogBackgroundWithStatusBar(size, PlayerColor(1));
+	auto image = createDialogBackgroundWithStatusBar(size);
 	Canvas canvas = image->getCanvas();
 
 	// Additional overlays used by original TPRCRT (semi-transparent plates and central black input area).
@@ -1261,7 +1258,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createRecruitmentDialogBackground(cons
 
 AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const Point & size, int skillColumns) const
 {
-	auto image = createDialogBackgroundWithStatusBar(size, PlayerColor(1));
+	auto image = createDialogBackgroundWithStatusBar(size);
 	Canvas canvas = image->getCanvas();
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);
@@ -1319,7 +1316,7 @@ AssetGenerator::CanvasPtr AssetGenerator::createUniversityDialogBackground(const
 
 AssetGenerator::CanvasPtr AssetGenerator::createUniversityConfirmDialogBackground(const Point & size, int costElements) const
 {
-	auto image = createDialogBackgroundWithStatusBar(size, PlayerColor(1));
+	auto image = createDialogBackgroundWithStatusBar(size);
 	Canvas canvas = image->getCanvas();
 
 	const ColorRGBA rectangleColor = ColorRGBA(0, 0, 0, 75);

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -95,11 +95,7 @@ void AssetGenerator::initialize()
 	addUniversityConfirmBackground("UNIVRSC2", Point(466, 388), 2);
 	addSpellResearchBackground("spellResearchDialog", Point(328, 474));
 
-	for(PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
-	{
-		const std::string name = "heroBackpackDialog" + (color == -1 ? "" : "-" + color.toString());
-		addDialogBackgroundWithStatusBar(name, Point(426, 465));
-	}
+	addDialogBackgroundWithStatusBar("heroBackpackDialog", Point(426, 465));
 
 	imageFiles[ImagePath::builtin("questDialog.png")] = [this](){ return createQuestWindow();};
 	imageFiles[ImagePath::builtin("stackArtifactIndicatorSmall.png")] = [this](){ return createStackArtifactIndicator(Point(14, 14));};

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -168,7 +168,7 @@ void AssetGenerator::addDialogBackgroundWithStatusBar(const std::string & fileNa
 
 void AssetGenerator::addSpellResearchBackground(const std::string & fileName, const Point & size)
 {
-	imageFiles[ImagePath::builtin(fileName)] = [this, size]()
+	imageFiles[ImagePath::builtin(fileName)] = [size]()
 	{
 		auto image = ENGINE->renderHandler().createImage(size, CanvasScalingPolicy::IGNORE);
 		Canvas canvas = image->getCanvas();

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -68,8 +68,8 @@ private:
 	CanvasPtr createCreatureInfoPanel(int boxesAmount) const;
 	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const;
 	CanvasPtr createRecruitmentDialogBackground(const Point & size, const PlayerColor & playerColor) const;
-	CanvasPtr createUniversityDialogBackground(const Point & size, const PlayerColor & playerColor, int skillColumns) const;
-	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, const PlayerColor & playerColor, int costElements) const;
+	CanvasPtr createUniversityDialogBackground(const Point & size, int skillColumns) const;
+	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, int costElements) const;
 	enum CreateResourceWindowType{ ARTIFACTS_BUYING, ARTIFACTS_SELLING, MARKET_RESOURCES, FREELANCERS_GUILD, TRANSFER_RESOURCES };
 	CanvasPtr createResourceWindow(CreateResourceWindowType type, int count, PlayerColor color) const;
 	enum CreatureInfoPanelElement{ BONUS_EFFECTS, SPELL_EFFECTS, BUTTON_PANEL, COMMANDER_BACKGROUND, COMMANDER_ABILITIES };

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -67,7 +67,7 @@ private:
 	CanvasPtr createAdventureMapButtonClear(const PlayerColor & player, bool small) const;
 	CanvasPtr createCreatureInfoPanel(int boxesAmount) const;
 	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const;
-	CanvasPtr createRecruitmentDialogBackground(const Point & size, const PlayerColor & playerColor) const;
+	CanvasPtr createRecruitmentDialogBackground(const Point & size) const;
 	CanvasPtr createUniversityDialogBackground(const Point & size, int skillColumns) const;
 	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, int costElements) const;
 	enum CreateResourceWindowType{ ARTIFACTS_BUYING, ARTIFACTS_SELLING, MARKET_RESOURCES, FREELANCERS_GUILD, TRANSFER_RESOURCES };

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -34,7 +34,7 @@ public:
 
 	void addImageFile(const ImagePath & path, ImageGenerationFunctor & img);
 	void addAnimationFile(const AnimationPath & path, AnimationLayoutMap & anim);
-	void addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size, const PlayerColor & playerColor);
+	void addDialogBackgroundWithStatusBar(const std::string & fileName, const Point & size);
 	void addSpellResearchBackground(const std::string & fileName, const Point & size);
 	void addRecruitmentBackground(const std::string & fileName, const Point & size);
 	void addUniversityBackground(const std::string & fileName, const Point & size, int skillColumns);
@@ -66,7 +66,7 @@ private:
 	CanvasPtr createPaletteShiftedImage(const AnimationPath & source, const std::vector<PaletteAnimation> & animation, int frameIndex, int paletteShiftCounter) const;
 	CanvasPtr createAdventureMapButtonClear(const PlayerColor & player, bool small) const;
 	CanvasPtr createCreatureInfoPanel(int boxesAmount) const;
-	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size, const PlayerColor & playerColor) const;
+	CanvasPtr createDialogBackgroundWithStatusBar(const Point & size) const;
 	CanvasPtr createRecruitmentDialogBackground(const Point & size) const;
 	CanvasPtr createUniversityDialogBackground(const Point & size, int skillColumns) const;
 	CanvasPtr createUniversityConfirmDialogBackground(const Point & size, int costElements) const;

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -76,7 +76,7 @@ static bool useAvailableAmountAsCreatureLabel()
 }
 
 CSpellResearchDialog::CSpellResearchDialog(const std::string & textToShow, const std::vector<std::shared_ptr<CComponent>> & comps, const CGTownInstance * town, SpellID oldSpell, bool canAfford)
-	: CWindowObject(PLAYER_COLORED_STATUSBAR, ImagePath::builtin("spellResearchDialog"))
+	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, ImagePath::builtin("spellResearchDialog"))
 {
 	OBJECT_CONSTRUCTION;
 

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -76,7 +76,7 @@ static bool useAvailableAmountAsCreatureLabel()
 }
 
 CSpellResearchDialog::CSpellResearchDialog(const std::string & textToShow, const std::vector<std::shared_ptr<CComponent>> & comps, const CGTownInstance * town, SpellID oldSpell, bool canAfford)
-	: CWindowObject(PLAYER_COLORED, ImagePath::builtin("spellResearchDialog"))
+	: CWindowObject(PLAYER_COLORED_STATUSBAR, ImagePath::builtin("spellResearchDialog"))
 {
 	OBJECT_CONSTRUCTION;
 

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -76,7 +76,7 @@ static bool useAvailableAmountAsCreatureLabel()
 }
 
 CSpellResearchDialog::CSpellResearchDialog(const std::string & textToShow, const std::vector<std::shared_ptr<CComponent>> & comps, const CGTownInstance * town, SpellID oldSpell, bool canAfford)
-	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, ImagePath::builtin("spellResearchDialog"))
+	: CWindowObject(PLAYER_COLORED | BORDERED_STATUSBAR, ImagePath::builtin("spellResearchDialog"))
 {
 	OBJECT_CONSTRUCTION;
 

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -27,14 +27,11 @@
 #include "../../lib/texts/CGeneralTextHandler.h"
 
 CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets)
-	: CWindowWithArtifacts(&artsSets)
+	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, ImagePath::builtin("heroBackpackDialog"))
+	, CWindowWithArtifacts(&artsSets)
 {
 	OBJECT_CONSTRUCTION;
 	addUsedEvents(KEYBOARD);
-
-	const PlayerColor playerColor = GAME->interface()->playerID;
-	const std::string backgroundName = "heroBackpackDialog" + (playerColor.isValidPlayer() ? "-" + playerColor.toString() : "");
-	setBackground(ImagePath::builtin(backgroundName));
 
 	const Point artifactsOffset(17, 18);
 	arts = std::make_shared<CArtifactsOfHeroBackpack>();
@@ -76,7 +73,7 @@ CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std:
 		buttonPos += Point(button->pos.w + 10, 0);
 	}
 
-	statusbar = CGStatusBar::create(std::make_shared<CPicture>(ImagePath::builtin(backgroundName), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
+	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
 
 	addUsedEvents(LCLICK);
 	center();

--- a/client/windows/CHeroBackpackWindow.cpp
+++ b/client/windows/CHeroBackpackWindow.cpp
@@ -27,7 +27,7 @@
 #include "../../lib/texts/CGeneralTextHandler.h"
 
 CHeroBackpackWindow::CHeroBackpackWindow(const CGHeroInstance * hero, const std::vector<CArtifactsOfHeroPtr> & artsSets)
-	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, ImagePath::builtin("heroBackpackDialog"))
+	: CWindowObject(PLAYER_COLORED | BORDERED_STATUSBAR, ImagePath::builtin("heroBackpackDialog"))
 	, CWindowWithArtifacts(&artsSets)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -91,7 +91,7 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, i
 
 	if(windowOptions & PLAYER_COLORED_BORDERED_STATUSBAR)
 	{
-		return createPlayerColoredBorderedStatusbarBg(image, playerColor);
+		return createPlayerColoredBorderedStatusbar(image, playerColor);
 	}
 	if(windowOptions & PLAYER_COLORED)
 	{
@@ -101,7 +101,7 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, i
 	return image;
 }
 
-std::shared_ptr<CPicture> CWindowObject::createPlayerColoredBorderedStatusbarBg(const std::shared_ptr<CPicture> & image, PlayerColor playerColor)
+std::shared_ptr<CPicture> CWindowObject::createPlayerColoredBorderedStatusbar(const std::shared_ptr<CPicture> & image, PlayerColor playerColor)
 {
 	auto composited = ENGINE->renderHandler().createImage(image->getSurface()->dimensions(), CanvasScalingPolicy::AUTO);
 	Canvas canvas = composited->getCanvas();

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -105,8 +105,6 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, i
 
 		const int width = composited->width();
 		const int height = composited->height();
-		const int statusBarOverlayHeight = 30;
-		canvas.drawColorBlended(Rect(0, height - statusBarOverlayHeight, width, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
 
 		auto drawHorizontal = [&canvas](const std::shared_ptr<IImage> & source, int y, int xBegin, int xEnd)
 		{

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -89,19 +89,18 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, i
 	auto image = std::make_shared<CPicture>(imageName, Point(0,0), EImageBlitMode::OPAQUE);
 	PlayerColor playerColor = GAME->interface() ? GAME->interface()->playerID : PlayerColor(1);
 
-	if(windowOptions & PLAYER_COLORED_BORDERED_STATUSBAR)
+	if(windowOptions & BORDERED_STATUSBAR)
 	{
-		return createPlayerColoredBorderedStatusbar(image, playerColor);
+		const PlayerColor frameColor = (windowOptions & PLAYER_COLORED) ? playerColor : PlayerColor(1);
+		return createBorderedStatusbar(image, frameColor);
 	}
 	if(windowOptions & PLAYER_COLORED)
-	{
 		image->setPlayerColor(playerColor);
-	}
 
 	return image;
 }
 
-std::shared_ptr<CPicture> CWindowObject::createPlayerColoredBorderedStatusbar(const std::shared_ptr<CPicture> & image, PlayerColor playerColor)
+std::shared_ptr<CPicture> CWindowObject::createBorderedStatusbar(const std::shared_ptr<CPicture> & image, PlayerColor playerColor)
 {
 	auto composited = ENGINE->renderHandler().createImage(image->getSurface()->dimensions(), CanvasScalingPolicy::AUTO);
 	Canvas canvas = composited->getCanvas();

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -89,63 +89,68 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, i
 	auto image = std::make_shared<CPicture>(imageName, Point(0,0), EImageBlitMode::OPAQUE);
 	PlayerColor playerColor = GAME->interface() ? GAME->interface()->playerID : PlayerColor(1);
 
+	if(windowOptions & PLAYER_COLORED_BORDERED_STATUSBAR)
+	{
+		return createPlayerColoredBorderedStatusbarBg(image, playerColor);
+	}
 	if(windowOptions & PLAYER_COLORED)
 	{
 		image->setPlayerColor(playerColor);
 	}
-	else if(windowOptions & PLAYER_COLORED_STATUSBAR)
-	{
-		auto composited = ENGINE->renderHandler().createImage(image->getSurface()->dimensions(), CanvasScalingPolicy::AUTO);
-		Canvas canvas = composited->getCanvas();
-		canvas.draw(image->getSurface(), Point(0, 0));
-
-		auto dialogBox = ENGINE->renderHandler().loadAnimation(AnimationPath::builtin("DIALGBOX"), EImageBlitMode::COLORKEY);
-		if(playerColor.isValidPlayer() && playerColor != PlayerColor(1))
-			dialogBox->playerColored(playerColor);
-
-		const int width = composited->width();
-		const int height = composited->height();
-
-		auto drawHorizontal = [&canvas](const std::shared_ptr<IImage> & source, int y, int xBegin, int xEnd)
-		{
-			for(int x = xBegin; x < xEnd; x += source->width())
-			{
-				int blitWidth = std::min(source->width(), xEnd - x);
-				canvas.draw(source, Point(x, y), Rect(0, 0, blitWidth, source->height()));
-			}
-		};
-		auto drawVertical = [&canvas](const std::shared_ptr<IImage> & source, int x, int yBegin, int yEnd)
-		{
-			for(int y = yBegin; y < yEnd; y += source->height())
-			{
-				int blitHeight = std::min(source->height(), yEnd - y);
-				canvas.draw(source, Point(x, y), Rect(0, 0, source->width(), blitHeight));
-			}
-		};
-
-		auto topLeft = dialogBox->getImage(0, 0);
-		auto topRight = dialogBox->getImage(1, 0);
-		auto leftEdge = dialogBox->getImage(4, 0);
-		auto rightEdge = dialogBox->getImage(5, 0);
-		auto topEdge = dialogBox->getImage(6, 0);
-		auto bottomLeft = dialogBox->getImage(8, 0);
-		auto bottomRight = dialogBox->getImage(9, 0);
-		auto bottomEdge = dialogBox->getImage(10, 0);
-
-		drawHorizontal(topEdge, 0, topLeft->width(), width - topRight->width());
-		drawHorizontal(bottomEdge, height - bottomEdge->height(), bottomLeft->width(), width - bottomRight->width());
-		drawVertical(leftEdge, 0, topLeft->height(), height - bottomLeft->height());
-		drawVertical(rightEdge, width - rightEdge->width(), topRight->height(), height - bottomRight->height());
-
-		canvas.draw(topLeft, Point(0, 0));
-		canvas.draw(topRight, Point(width - topRight->width(), 0));
-		canvas.draw(bottomLeft, Point(0, height - bottomLeft->height()));
-		canvas.draw(bottomRight, Point(width - bottomRight->width(), height - bottomRight->height()));
-
-		return std::make_shared<CPicture>(composited, Point(0,0));
-	}
 
 	return image;
+}
+
+std::shared_ptr<CPicture> CWindowObject::createPlayerColoredBorderedStatusbarBg(const std::shared_ptr<CPicture> & image, PlayerColor playerColor)
+{
+	auto composited = ENGINE->renderHandler().createImage(image->getSurface()->dimensions(), CanvasScalingPolicy::AUTO);
+	Canvas canvas = composited->getCanvas();
+	canvas.draw(image->getSurface(), Point(0, 0));
+
+	auto dialogBox = ENGINE->renderHandler().loadAnimation(AnimationPath::builtin("DIALGBOX"), EImageBlitMode::COLORKEY);
+	if(playerColor.isValidPlayer() && playerColor != PlayerColor(1))
+		dialogBox->playerColored(playerColor);
+
+	const int width = composited->width();
+	const int height = composited->height();
+
+	auto drawHorizontal = [&canvas](const std::shared_ptr<IImage> & source, int y, int xBegin, int xEnd)
+	{
+		for(int x = xBegin; x < xEnd; x += source->width())
+		{
+			int blitWidth = std::min(source->width(), xEnd - x);
+			canvas.draw(source, Point(x, y), Rect(0, 0, blitWidth, source->height()));
+		}
+	};
+	auto drawVertical = [&canvas](const std::shared_ptr<IImage> & source, int x, int yBegin, int yEnd)
+	{
+		for(int y = yBegin; y < yEnd; y += source->height())
+		{
+			int blitHeight = std::min(source->height(), yEnd - y);
+			canvas.draw(source, Point(x, y), Rect(0, 0, source->width(), blitHeight));
+		}
+	};
+
+	auto topLeft = dialogBox->getImage(0, 0);
+	auto topRight = dialogBox->getImage(1, 0);
+	auto leftEdge = dialogBox->getImage(4, 0);
+	auto rightEdge = dialogBox->getImage(5, 0);
+	auto topEdge = dialogBox->getImage(6, 0);
+	auto bottomLeft = dialogBox->getImage(8, 0);
+	auto bottomRight = dialogBox->getImage(9, 0);
+	auto bottomEdge = dialogBox->getImage(10, 0);
+
+	drawHorizontal(topEdge, 0, topLeft->width(), width - topRight->width());
+	drawHorizontal(bottomEdge, height - bottomEdge->height(), bottomLeft->width(), width - bottomRight->width());
+	drawVertical(leftEdge, 0, topLeft->height(), height - bottomLeft->height());
+	drawVertical(rightEdge, width - rightEdge->width(), topRight->height(), height - bottomRight->height());
+
+	canvas.draw(topLeft, Point(0, 0));
+	canvas.draw(topRight, Point(width - topRight->width(), 0));
+	canvas.draw(bottomLeft, Point(0, height - bottomLeft->height()));
+	canvas.draw(bottomRight, Point(width - bottomRight->width(), height - bottomRight->height()));
+
+	return std::make_shared<CPicture>(composited, Point(0,0));
 }
 
 void CWindowObject::setBackground(const ImagePath & filename)

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -22,6 +22,7 @@
 #include "../render/IImage.h"
 #include "../render/IScreenHandler.h"
 #include "../render/IRenderHandler.h"
+#include "../render/CAnimation.h"
 #include "../render/Canvas.h"
 #include "../render/CanvasImage.h"
 
@@ -35,7 +36,7 @@
 CWindowObject::CWindowObject(int options_, const ImagePath & imageName, Point centerAt):
 	WindowBase(0, Point()),
 	options(options_),
-	background(createBg(imageName, options & PLAYER_COLORED))
+	background(createBg(imageName, options_))
 {
 	if(!(options & NEEDS_ANIMATED_BACKGROUND)) //currently workaround for highscores (currently uses window as normal control, because otherwise videos are not played in background yet)
 		assert(parent == nullptr); //Safe to remove, but windows should not have parent
@@ -55,7 +56,7 @@ CWindowObject::CWindowObject(int options_, const ImagePath & imageName, Point ce
 CWindowObject::CWindowObject(int options_, const ImagePath & imageName):
 	WindowBase(0, Point()),
 	options(options_),
-	background(createBg(imageName, options_ & PLAYER_COLORED))
+	background(createBg(imageName, options_))
 {
 	if(!(options & NEEDS_ANIMATED_BACKGROUND)) //currently workaround for highscores (currently uses window as normal control, because otherwise videos are not played in background yet)
 		assert(parent == nullptr); //Safe to remove, but windows should not have parent
@@ -78,7 +79,7 @@ CWindowObject::~CWindowObject()
 		ENGINE->cursor().show();
 }
 
-std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, bool playerColored)
+std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, int windowOptions)
 {
 	OBJECT_CONSTRUCTION;
 
@@ -86,10 +87,66 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, b
 		return nullptr;
 
 	auto image = std::make_shared<CPicture>(imageName, Point(0,0), EImageBlitMode::OPAQUE);
-	if(!GAME->interface())
-		image->setPlayerColor(PlayerColor(1)); // in main menu we use blue
-	else if(playerColored)
-		image->setPlayerColor(GAME->interface()->playerID);
+	PlayerColor playerColor = GAME->interface() ? GAME->interface()->playerID : PlayerColor(1);
+
+	if(windowOptions & PLAYER_COLORED)
+	{
+		image->setPlayerColor(playerColor);
+	}
+	else if(windowOptions & PLAYER_COLORED_STATUSBAR)
+	{
+		auto composited = ENGINE->renderHandler().createImage(image->getSurface()->dimensions(), CanvasScalingPolicy::AUTO);
+		Canvas canvas = composited->getCanvas();
+		canvas.draw(image->getSurface(), Point(0, 0));
+
+		auto dialogBox = ENGINE->renderHandler().loadAnimation(AnimationPath::builtin("DIALGBOX"), EImageBlitMode::COLORKEY);
+		if(playerColor.isValidPlayer() && playerColor != PlayerColor(1))
+			dialogBox->playerColored(playerColor);
+
+		const int width = composited->width();
+		const int height = composited->height();
+		const int statusBarOverlayHeight = 30;
+		canvas.drawColorBlended(Rect(0, height - statusBarOverlayHeight, width, statusBarOverlayHeight), ColorRGBA(0, 0, 0, 88));
+
+		auto drawHorizontal = [&canvas](const std::shared_ptr<IImage> & source, int y, int xBegin, int xEnd)
+		{
+			for(int x = xBegin; x < xEnd; x += source->width())
+			{
+				int blitWidth = std::min(source->width(), xEnd - x);
+				canvas.draw(source, Point(x, y), Rect(0, 0, blitWidth, source->height()));
+			}
+		};
+		auto drawVertical = [&canvas](const std::shared_ptr<IImage> & source, int x, int yBegin, int yEnd)
+		{
+			for(int y = yBegin; y < yEnd; y += source->height())
+			{
+				int blitHeight = std::min(source->height(), yEnd - y);
+				canvas.draw(source, Point(x, y), Rect(0, 0, source->width(), blitHeight));
+			}
+		};
+
+		auto topLeft = dialogBox->getImage(0, 0);
+		auto topRight = dialogBox->getImage(1, 0);
+		auto leftEdge = dialogBox->getImage(4, 0);
+		auto rightEdge = dialogBox->getImage(5, 0);
+		auto topEdge = dialogBox->getImage(6, 0);
+		auto bottomLeft = dialogBox->getImage(8, 0);
+		auto bottomRight = dialogBox->getImage(9, 0);
+		auto bottomEdge = dialogBox->getImage(10, 0);
+
+		drawHorizontal(topEdge, 0, topLeft->width(), width - topRight->width());
+		drawHorizontal(bottomEdge, height - bottomEdge->height(), bottomLeft->width(), width - bottomRight->width());
+		drawVertical(leftEdge, 0, topLeft->height(), height - bottomLeft->height());
+		drawVertical(rightEdge, width - rightEdge->width(), topRight->height(), height - bottomRight->height());
+
+		canvas.draw(topLeft, Point(0, 0));
+		canvas.draw(topRight, Point(width - topRight->width(), 0));
+		canvas.draw(bottomLeft, Point(0, height - bottomLeft->height()));
+		canvas.draw(bottomRight, Point(width - bottomRight->width(), height - bottomRight->height()));
+
+		return std::make_shared<CPicture>(composited, Point(0,0));
+	}
+
 	return image;
 }
 
@@ -97,7 +154,7 @@ void CWindowObject::setBackground(const ImagePath & filename)
 {
 	OBJECT_CONSTRUCTION;
 
-	background = createBg(filename, options & PLAYER_COLORED);
+	background = createBg(filename, options);
 
 	if(background)
 		pos = background->center(Point(pos.w/2 + pos.x, pos.h/2 + pos.y));

--- a/client/windows/CWindowObject.cpp
+++ b/client/windows/CWindowObject.cpp
@@ -36,7 +36,7 @@
 CWindowObject::CWindowObject(int options_, const ImagePath & imageName, Point centerAt):
 	WindowBase(0, Point()),
 	options(options_),
-	background(createBg(imageName, options_))
+	background(createBg(imageName, options_ & PLAYER_COLORED))
 {
 	if(!(options & NEEDS_ANIMATED_BACKGROUND)) //currently workaround for highscores (currently uses window as normal control, because otherwise videos are not played in background yet)
 		assert(parent == nullptr); //Safe to remove, but windows should not have parent
@@ -56,7 +56,7 @@ CWindowObject::CWindowObject(int options_, const ImagePath & imageName, Point ce
 CWindowObject::CWindowObject(int options_, const ImagePath & imageName):
 	WindowBase(0, Point()),
 	options(options_),
-	background(createBg(imageName, options_))
+	background(createBg(imageName, options_ & PLAYER_COLORED))
 {
 	if(!(options & NEEDS_ANIMATED_BACKGROUND)) //currently workaround for highscores (currently uses window as normal control, because otherwise videos are not played in background yet)
 		assert(parent == nullptr); //Safe to remove, but windows should not have parent
@@ -79,7 +79,7 @@ CWindowObject::~CWindowObject()
 		ENGINE->cursor().show();
 }
 
-std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, int windowOptions)
+std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, bool playerColored)
 {
 	OBJECT_CONSTRUCTION;
 
@@ -89,12 +89,12 @@ std::shared_ptr<CPicture> CWindowObject::createBg(const ImagePath & imageName, i
 	auto image = std::make_shared<CPicture>(imageName, Point(0,0), EImageBlitMode::OPAQUE);
 	PlayerColor playerColor = GAME->interface() ? GAME->interface()->playerID : PlayerColor(1);
 
-	if(windowOptions & BORDERED_STATUSBAR)
+	if(options & BORDERED_STATUSBAR)
 	{
-		const PlayerColor frameColor = (windowOptions & PLAYER_COLORED) ? playerColor : PlayerColor(1);
+		const PlayerColor frameColor = playerColored ? playerColor : PlayerColor(1);
 		return createBorderedStatusbar(image, frameColor);
 	}
-	if(windowOptions & PLAYER_COLORED)
+	if(playerColored)
 		image->setPlayerColor(playerColor);
 
 	return image;
@@ -156,7 +156,7 @@ void CWindowObject::setBackground(const ImagePath & filename)
 {
 	OBJECT_CONSTRUCTION;
 
-	background = createBg(filename, options);
+	background = createBg(filename, options & PLAYER_COLORED);
 
 	if(background)
 		pos = background->center(Point(pos.w/2 + pos.x, pos.h/2 + pos.y));

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -30,7 +30,7 @@ protected:
 	//To display border
 	void updateShadow();
 	void setBackground(const ImagePath & filename);
-	std::shared_ptr<CPicture> createBg(const ImagePath & imageName, int windowOptions);
+	std::shared_ptr<CPicture> createBg(const ImagePath & imageName, bool playerColored);
 	std::shared_ptr<CPicture> createBorderedStatusbar(const std::shared_ptr<CPicture> & image, PlayerColor playerColor);
 public:
 	enum EOptions

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -31,7 +31,7 @@ protected:
 	void updateShadow();
 	void setBackground(const ImagePath & filename);
 	std::shared_ptr<CPicture> createBg(const ImagePath & imageName, int windowOptions);
-	std::shared_ptr<CPicture> createPlayerColoredBorderedStatusbar(const std::shared_ptr<CPicture> & image, PlayerColor playerColor);
+	std::shared_ptr<CPicture> createBorderedStatusbar(const std::shared_ptr<CPicture> & image, PlayerColor playerColor);
 public:
 	enum EOptions
 	{
@@ -40,7 +40,7 @@ public:
 		BORDERED=4, // window will have border if current resolution is bigger than size of window
 		SHADOW_DISABLED=8, //this window won't display any shadow
 		NEEDS_ANIMATED_BACKGROUND=16, //there are videos in the background that have to be played
-		PLAYER_COLORED_BORDERED_STATUSBAR=32 //composite player-colored bordered frame for statusbar dialogs
+		BORDERED_STATUSBAR=32 //composite bordered frame for statusbar dialogs (player-colored when combined with PLAYER_COLORED)
 	};
 
 	/*

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -40,8 +40,7 @@ public:
 		BORDERED=4, // window will have border if current resolution is bigger than size of window
 		SHADOW_DISABLED=8, //this window won't display any shadow
 		NEEDS_ANIMATED_BACKGROUND=16, //there are videos in the background that have to be played
-		PLAYER_COLORED_BORDERED_STATUSBAR=32, //composite player-colored bordered frame for statusbar dialogs
-		PLAYER_COLORED_STATUSBAR=PLAYER_COLORED_BORDERED_STATUSBAR // backwards-compatible alias
+		PLAYER_COLORED_BORDERED_STATUSBAR=32 //composite player-colored bordered frame for statusbar dialogs
 	};
 
 	/*

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -31,7 +31,7 @@ protected:
 	void updateShadow();
 	void setBackground(const ImagePath & filename);
 	std::shared_ptr<CPicture> createBg(const ImagePath & imageName, int windowOptions);
-	std::shared_ptr<CPicture> createPlayerColoredBorderedStatusbarBg(const std::shared_ptr<CPicture> & image, PlayerColor playerColor);
+	std::shared_ptr<CPicture> createPlayerColoredBorderedStatusbar(const std::shared_ptr<CPicture> & image, PlayerColor playerColor);
 public:
 	enum EOptions
 	{

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -30,7 +30,7 @@ protected:
 	//To display border
 	void updateShadow();
 	void setBackground(const ImagePath & filename);
-	std::shared_ptr<CPicture> createBg(const ImagePath & imageName, bool playerColored);
+	std::shared_ptr<CPicture> createBg(const ImagePath & imageName, int windowOptions);
 public:
 	enum EOptions
 	{
@@ -38,7 +38,8 @@ public:
 		RCLICK_POPUP=2, // window will behave as right-click popup
 		BORDERED=4, // window will have border if current resolution is bigger than size of window
 		SHADOW_DISABLED=8, //this window won't display any shadow
-		NEEDS_ANIMATED_BACKGROUND=16 //there are videos in the background that have to be played
+		NEEDS_ANIMATED_BACKGROUND=16, //there are videos in the background that have to be played
+		PLAYER_COLORED_STATUSBAR=32 //overlay player-colored frame with status bar styling
 	};
 
 	/*

--- a/client/windows/CWindowObject.h
+++ b/client/windows/CWindowObject.h
@@ -31,6 +31,7 @@ protected:
 	void updateShadow();
 	void setBackground(const ImagePath & filename);
 	std::shared_ptr<CPicture> createBg(const ImagePath & imageName, int windowOptions);
+	std::shared_ptr<CPicture> createPlayerColoredBorderedStatusbarBg(const std::shared_ptr<CPicture> & image, PlayerColor playerColor);
 public:
 	enum EOptions
 	{
@@ -39,7 +40,8 @@ public:
 		BORDERED=4, // window will have border if current resolution is bigger than size of window
 		SHADOW_DISABLED=8, //this window won't display any shadow
 		NEEDS_ANIMATED_BACKGROUND=16, //there are videos in the background that have to be played
-		PLAYER_COLORED_STATUSBAR=32 //overlay player-colored frame with status bar styling
+		PLAYER_COLORED_BORDERED_STATUSBAR=32, //composite player-colored bordered frame for statusbar dialogs
+		PLAYER_COLORED_STATUSBAR=PLAYER_COLORED_BORDERED_STATUSBAR // backwards-compatible alias
 	};
 
 	/*

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -262,7 +262,7 @@ void CRecruitmentWindow::showAll(Canvas & to)
 }
 
 CRecruitmentWindow::CRecruitmentWindow(const CGDwelling * Dwelling, int Level, const CArmedInstance * Dst, const std::function<void(CreatureID,int)> & Recruit, const std::function<void()> & onClose, int y_offset):
-	CWindowObject(PLAYER_COLORED_STATUSBAR, getRecruitmentBackground(Dwelling, Level)),
+	CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, getRecruitmentBackground(Dwelling, Level)),
 	onRecruit(Recruit),
 	onClose(onClose),
 	level(Level),
@@ -1072,7 +1072,7 @@ void CUniversityWindow::CItem::update()
 }
 
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed)
-	: CWindowObject(PLAYER_COLORED_STATUSBAR, getUniversityBackground(_market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
+	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, getUniversityBackground(_market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
 	hero(_hero),
 	onWindowClosed(onWindowClosed),
 	market(_market)
@@ -1149,7 +1149,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(PLAYER_COLORED_STATUSBAR, getUniversityConfirmBackground(1)),
+	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, getUniversityConfirmBackground(1)),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -126,6 +126,8 @@ static int getUniversityItemPosX(size_t itemIndex, size_t skillCount, int window
 	return stripX + (smallBlockWidth / 2) - iconHalfSize;
 }
 
+static constexpr int MAP_TILE_SIZE_PX = 32;
+
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | SHOW_POPUP),
 	parent(window),
@@ -1094,6 +1096,7 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 
 	std::string titleStr = LIBRARY->generaltexth->allTexts[602];
 	std::string speechStr = LIBRARY->generaltexth->allTexts[603];
+	int mapObjectTitleOffsetX = 0;
 
 	if(auto town = dynamic_cast<const CGTownInstance *>(_market))
 	{
@@ -1103,6 +1106,9 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 	else if(auto uni = dynamic_cast<const CGUniversity *>(_market); uni->appearance)
 	{
 		titlePic = std::make_shared<CAnimImage>(uni->appearance->animationFile, 0, 0, 0, 0, CShowableAnim::MAP_OBJECT_MODE);
+		const int mapObjectWidthPx = static_cast<int>(uni->appearance->getWidth()) * MAP_TILE_SIZE_PX;
+		const int renderedWidthPx = titlePic->getPosition().w;
+		mapObjectTitleOffsetX = std::max(0, (renderedWidthPx - mapObjectWidthPx) / 2);
 		titleStr = uni->getObjectName();
 		speechStr = uni->getSpeechTranslated();
 	}
@@ -1112,7 +1118,7 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 	}
 
 	const int centerX = pos.w / 2;
-	titlePic->center(Point(centerX + pos.x, 76 + pos.y));
+	titlePic->center(Point(centerX + pos.x + mapObjectTitleOffsetX, 76 + pos.y));
 
 	const int speechFrameWidth = 414;
 	const int speechFrameHeight = 74;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -72,7 +72,7 @@
 
 #include <boost/lexical_cast.hpp>
 
-static ImagePath getRecruitmentBackground(const CGDwelling * dwelling, int level)
+ImagePath CRecruitmentWindow::getRecruitmentBackground(const CGDwelling * dwelling, int level)
 {
 	int cardsCount = 0;
 	for(int i = 0; i < dwelling->creatures.size(); i++)
@@ -87,19 +87,19 @@ static ImagePath getRecruitmentBackground(const CGDwelling * dwelling, int level
 	return ImagePath::builtin(fileName);
 }
 
-static ImagePath getUniversityBackground(size_t skillCount)
+ImagePath CUniversityWindow::getUniversityBackground(size_t skillCount)
 {
 	const int backgroundSkills = std::clamp(static_cast<int>(skillCount), 1, 7);
 	return ImagePath::builtin("UNIVRS" + std::to_string(backgroundSkills));
 }
 
-static ImagePath getUniversityConfirmBackground(int costElements)
+ImagePath CUniversityWindow::getUniversityConfirmBackground(int costElements)
 {
 	const int backgroundCostElements = std::clamp(costElements, 1, 2);
 	return ImagePath::builtin("UNIVRSC" + std::to_string(backgroundCostElements));
 }
 
-static int getUniversityItemPosX(size_t itemIndex, size_t skillCount, int windowWidth)
+int CUniversityWindow::getUniversityItemPosX(size_t itemIndex, size_t skillCount, int windowWidth)
 {
 	const int skillColumns = std::clamp(static_cast<int>(skillCount), 1, 7);
 	const int smallBlockWidth = 102;
@@ -1147,7 +1147,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, getUniversityConfirmBackground(1)),
+	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, CUniversityWindow::getUniversityConfirmBackground(1)),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -112,8 +112,6 @@ static int getUniversityItemPosX(size_t itemIndex, size_t skillCount, int window
 	return stripX + (smallBlockWidth / 2) - iconHalfSize;
 }
 
-static constexpr int MAP_TILE_SIZE_PX = 32;
-
 CRecruitmentWindow::CCreatureCard::CCreatureCard(CRecruitmentWindow * window, const CCreature * crea, int totalAmount)
 	: CIntObject(LCLICK | SHOW_POPUP),
 	parent(window),
@@ -1092,7 +1090,7 @@ CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID bu
 	else if(auto uni = dynamic_cast<const CGUniversity *>(_market); uni->appearance)
 	{
 		titlePic = std::make_shared<CAnimImage>(uni->appearance->animationFile, 0, 0, 0, 0, CShowableAnim::MAP_OBJECT_MODE);
-		const int mapObjectWidthPx = static_cast<int>(uni->appearance->getWidth()) * MAP_TILE_SIZE_PX;
+		const int mapObjectWidthPx = static_cast<int>(uni->appearance->getWidth()) * 32; // map object tile width in pixels
 		const int renderedWidthPx = titlePic->getPosition().w;
 		mapObjectTitleOffsetX = std::max(0, (renderedWidthPx - mapObjectWidthPx) / 2);
 		titleStr = uni->getObjectName();

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1076,7 +1076,7 @@ void CUniversityWindow::CItem::update()
 }
 
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed)
-	: CWindowObject(BORDERED, getUniversityBackground(_market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
+	: CWindowObject(PLAYER_COLORED_STATUSBAR, getUniversityBackground(_market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
 	hero(_hero),
 	onWindowClosed(onWindowClosed),
 	market(_market)
@@ -1153,7 +1153,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(BORDERED, getUniversityConfirmBackground(1)),
+	: CWindowObject(PLAYER_COLORED_STATUSBAR, getUniversityConfirmBackground(1)),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -260,7 +260,7 @@ void CRecruitmentWindow::showAll(Canvas & to)
 }
 
 CRecruitmentWindow::CRecruitmentWindow(const CGDwelling * Dwelling, int Level, const CArmedInstance * Dst, const std::function<void(CreatureID,int)> & Recruit, const std::function<void()> & onClose, int y_offset):
-	CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, getRecruitmentBackground(Dwelling, Level)),
+	CWindowObject(PLAYER_COLORED | BORDERED_STATUSBAR, getRecruitmentBackground(Dwelling, Level)),
 	onRecruit(Recruit),
 	onClose(onClose),
 	level(Level),
@@ -1070,7 +1070,7 @@ void CUniversityWindow::CItem::update()
 }
 
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed)
-	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, getUniversityBackground(_market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
+	: CWindowObject(PLAYER_COLORED | BORDERED_STATUSBAR, getUniversityBackground(_market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
 	hero(_hero),
 	onWindowClosed(onWindowClosed),
 	market(_market)
@@ -1147,7 +1147,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, CUniversityWindow::getUniversityConfirmBackground(1)),
+	: CWindowObject(PLAYER_COLORED | BORDERED_STATUSBAR, CUniversityWindow::getUniversityConfirmBackground(1)),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -91,26 +91,16 @@ static ImagePath getRecruitmentBackground(const CGDwelling * dwelling, int level
 	return ImagePath::builtin(fileName);
 }
 
-static ImagePath getUniversityBackground(const CGHeroInstance * hero, size_t skillCount)
+static ImagePath getUniversityBackground(size_t skillCount)
 {
 	const int backgroundSkills = std::clamp(static_cast<int>(skillCount), 1, 7);
-	std::string fileName = "UNIVRS" + std::to_string(backgroundSkills);
-
-	if(hero && hero->tempOwner.isValidPlayer())
-		fileName += "-" + hero->tempOwner.toString();
-
-	return ImagePath::builtin(fileName);
+	return ImagePath::builtin("UNIVRS" + std::to_string(backgroundSkills));
 }
 
-static ImagePath getUniversityConfirmBackground(const CGHeroInstance * hero, int costElements)
+static ImagePath getUniversityConfirmBackground(int costElements)
 {
 	const int backgroundCostElements = std::clamp(costElements, 1, 2);
-	std::string fileName = "UNIVRSC" + std::to_string(backgroundCostElements);
-
-	if(hero && hero->tempOwner.isValidPlayer())
-		fileName += "-" + hero->tempOwner.toString();
-
-	return ImagePath::builtin(fileName);
+	return ImagePath::builtin("UNIVRSC" + std::to_string(backgroundCostElements));
 }
 
 static int getUniversityItemPosX(size_t itemIndex, size_t skillCount, int windowWidth)
@@ -1086,7 +1076,7 @@ void CUniversityWindow::CItem::update()
 }
 
 CUniversityWindow::CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed)
-	: CWindowObject(PLAYER_COLORED, getUniversityBackground(_hero, _market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
+	: CWindowObject(BORDERED, getUniversityBackground(_market->availableItemsIds(EMarketMode::RESOURCE_SKILL).size())),
 	hero(_hero),
 	onWindowClosed(onWindowClosed),
 	market(_market)
@@ -1163,7 +1153,7 @@ void CUniversityWindow::makeDeal(SecondarySkill skill)
 }
 
 CUnivConfirmWindow::CUnivConfirmWindow(CUniversityWindow * owner_, SecondarySkill SKILL, bool available)
-	: CWindowObject(PLAYER_COLORED, getUniversityConfirmBackground(owner_->getHero(), 1)),
+	: CWindowObject(BORDERED, getUniversityConfirmBackground(1)),
 	owner(owner_)
 {
 	OBJECT_CONSTRUCTION;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -84,10 +84,6 @@ static ImagePath getRecruitmentBackground(const CGDwelling * dwelling, int level
 	}
 
 	std::string fileName = cardsCount >= 6 ? "TPRCRT6" : cardsCount == 5 ? "TPRCRT5" : "TPRCRT4";
-
-	if (dwelling->tempOwner.isValidPlayer())
-		fileName += "-" + dwelling->tempOwner.toString();
-
 	return ImagePath::builtin(fileName);
 }
 
@@ -266,7 +262,7 @@ void CRecruitmentWindow::showAll(Canvas & to)
 }
 
 CRecruitmentWindow::CRecruitmentWindow(const CGDwelling * Dwelling, int Level, const CArmedInstance * Dst, const std::function<void(CreatureID,int)> & Recruit, const std::function<void()> & onClose, int y_offset):
-	CWindowObject(PLAYER_COLORED, getRecruitmentBackground(Dwelling, Level)),
+	CWindowObject(PLAYER_COLORED_STATUSBAR, getRecruitmentBackground(Dwelling, Level)),
 	onRecruit(Recruit),
 	onClose(onClose),
 	level(Level),

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -98,6 +98,7 @@ class CRecruitmentWindow : public CStatusbarWindow
 	void select(std::shared_ptr<CCreatureCard> card);
 	void buy();
 	void sliderMoved(int to);
+	static ImagePath getRecruitmentBackground(const CGDwelling * dwelling, int level);
 
 	void showAll(Canvas & to) override;
 public:
@@ -389,6 +390,9 @@ class CUniversityWindow final : public CStatusbarWindow, public IMarketHolder
 	std::function<void()> onWindowClosed;
 
 public:
+	static ImagePath getUniversityBackground(size_t skillCount);
+	static ImagePath getUniversityConfirmBackground(int costElements);
+	static int getUniversityItemPosX(size_t itemIndex, size_t skillCount, int windowWidth);
 	CUniversityWindow(const CGHeroInstance * _hero, BuildingID building, const IMarket * _market, const std::function<void()> & onWindowClosed);
 	const CGHeroInstance * getHero() const;
 


### PR DESCRIPTION
### Motivation
- Fix horizontal misalignment of the university title graphic for market objects that use map-based appearances where appearance width is reported in tiles rather than pixels.
- Make the tile-to-pixel conversion explicit so the title can be centered correctly for animated map objects.

### Description
- Add `static constexpr int MAP_TILE_SIZE_PX = 32` to define the pixel size of a map tile.
- Compute `mapObjectWidthPx` as `appearance->getWidth() * MAP_TILE_SIZE_PX` and obtain the rendered width from `titlePic->getPosition().w`.
- Calculate `mapObjectTitleOffsetX = std::max(0, (renderedWidthPx - mapObjectWidthPx) / 2)` to determine a horizontal offset.
- Apply `mapObjectTitleOffsetX` when centering `titlePic` so map-object appearances are aligned correctly.

### Testing
- Built the project using `cmake --build` and the build completed successfully.
- Executed the automated test suite with `ctest` and all tests passed.
- No test suite changes were required for this layout fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edaaf8068c832d9433febac622ff05)