### PR TITLE
Fix stack experience rank mapping for JSON values

### DIFF
--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -977,7 +977,9 @@ void CCreatureHandler::loadStackExperience(CCreature * creature, const JsonNode 
 	for (const JsonNode &exp : input.Vector())
 	{
 		const JsonVector &values = exp["values"].Vector();
-		int lowerLimit = 1;//, upperLimit = 255;
+		// RankRangeLimiter uses strict bounds (rank > minRank), so level 1 bonus
+		// must start from 0 to map values[0] -> rank 1 and values[9] -> rank 10.
+		int lowerLimit = 0;//, upperLimit = 255;
 		if (values[0].getType() == JsonNode::JsonType::DATA_BOOL)
 		{
 			for (const JsonNode &val : values)


### PR DESCRIPTION
### Motivation
- Fix an off-by-one bug when loading JSON `stackExperience.values` so level/rank 10 bonuses are applied (previous code required rank 11 due to `RankRangeLimiter` strict bound).

### Description
- Set `lowerLimit = 0` in `CCreatureHandler::loadStackExperience` and add a comment explaining the mapping so `values[0]` -> rank 1 and `values[9]` -> rank 10; this change applies to both the boolean and numeric parsing branches.

### Testing
- No automated tests were run for this small change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90e363894832db2333d1987bc357d)