### PR TITLE
Prevent duplicate STACK_EXPERIENCE bonuses on load and reduce repeated invalid-damage logs

### DIFF
--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1373,7 +1373,10 @@ AssetGenerator::CanvasPtr AssetGenerator::createStackExperienceIcon(const std::s
 	auto drawCenteredOverlay = [&](const std::shared_ptr<IImage> & overlay, int size = 28)
 	{
 		const int offset = (32 - size) / 2;
-		canvas.drawScaled(overlay, Point(offset, offset), Point(size, size), Rect(0, 0, overlay->width(), overlay->height()));
+		auto scaledOverlay = ENGINE->renderHandler().createImage(Point(size, size), CanvasScalingPolicy::IGNORE);
+		auto scaledOverlayCanvas = scaledOverlay->getCanvas();
+		scaledOverlayCanvas.drawScaled(overlay, Point(0, 0), Point(size, size), Rect(0, 0, overlay->width(), overlay->height()));
+		canvas.draw(std::static_pointer_cast<IImage>(scaledOverlay), Point(offset, offset), Rect(0, 0, size, size));
 	};
 
 	if(iconId == "experience")

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1367,7 +1367,9 @@ AssetGenerator::CanvasPtr AssetGenerator::createStackExperienceIcon(const std::s
 	auto drawScaledFrame = [&](const AnimationPath & anim, size_t frame)
 	{
 		auto icon = ENGINE->renderHandler().loadAnimation(anim, EImageBlitMode::COLORKEY)->getImage(frame);
-		canvas.drawScaled(icon, Point(0, 0), Point(32, 32), Rect(0, 0, icon->width(), icon->height()));
+		Canvas iconCanvas(Point(icon->width(), icon->height()), CanvasScalingPolicy::IGNORE);
+		iconCanvas.draw(icon, Point(0, 0), Rect(0, 0, icon->width(), icon->height()));
+		canvas.drawScaled(iconCanvas, Point(0, 0), Point(32, 32));
 	};
 
 	auto drawCenteredOverlay = [&](const std::shared_ptr<IImage> & overlay, int size = 28)
@@ -1375,7 +1377,9 @@ AssetGenerator::CanvasPtr AssetGenerator::createStackExperienceIcon(const std::s
 		const int offset = (32 - size) / 2;
 		auto scaledOverlay = ENGINE->renderHandler().createImage(Point(size, size), CanvasScalingPolicy::IGNORE);
 		auto scaledOverlayCanvas = scaledOverlay->getCanvas();
-		scaledOverlayCanvas.drawScaled(overlay, Point(0, 0), Point(size, size), Rect(0, 0, overlay->width(), overlay->height()));
+		Canvas overlayCanvas(Point(overlay->width(), overlay->height()), CanvasScalingPolicy::IGNORE);
+		overlayCanvas.draw(overlay, Point(0, 0), Rect(0, 0, overlay->width(), overlay->height()));
+		scaledOverlayCanvas.drawScaled(overlayCanvas, Point(0, 0), Point(size, size));
 		canvas.draw(std::static_pointer_cast<IImage>(scaledOverlay), Point(offset, offset), Rect(0, 0, size, size));
 	};
 

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -1367,19 +1367,13 @@ AssetGenerator::CanvasPtr AssetGenerator::createStackExperienceIcon(const std::s
 	auto drawScaledFrame = [&](const AnimationPath & anim, size_t frame)
 	{
 		auto icon = ENGINE->renderHandler().loadAnimation(anim, EImageBlitMode::COLORKEY)->getImage(frame);
-		Canvas iconCanvas(Point(icon->width(), icon->height()), CanvasScalingPolicy::IGNORE);
-		iconCanvas.drawColor(Rect(0, 0, icon->width(), icon->height()), Colors::TRANSPARENCY);
-		iconCanvas.draw(icon, Point(0, 0), Rect(0, 0, icon->width(), icon->height()));
-		canvas.drawScaled(iconCanvas, Point(0, 0), Point(32, 32));
+		canvas.drawScaled(icon, Point(0, 0), Point(32, 32), Rect(0, 0, icon->width(), icon->height()));
 	};
 
 	auto drawCenteredOverlay = [&](const std::shared_ptr<IImage> & overlay, int size = 28)
 	{
-		Canvas overlayCanvas(Point(overlay->width(), overlay->height()), CanvasScalingPolicy::IGNORE);
-		overlayCanvas.drawColor(Rect(0, 0, overlay->width(), overlay->height()), Colors::TRANSPARENCY);
-		overlayCanvas.draw(overlay, Point(0, 0), Rect(0, 0, overlay->width(), overlay->height()));
 		const int offset = (32 - size) / 2;
-		canvas.drawScaled(overlayCanvas, Point(offset, offset), Point(size, size));
+		canvas.drawScaled(overlay, Point(offset, offset), Point(size, size), Rect(0, 0, overlay->width(), overlay->height()));
 	};
 
 	if(iconId == "experience")

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -985,6 +985,15 @@ void CCreatureHandler::loadStackExperience(CCreature * creature, const JsonNode 
 			% static_cast<int>(bonus.source)
 			% lowerLimit);
 	};
+	const auto stackExperienceSelector = Selector::sourceTypeSel(BonusSource::STACK_EXPERIENCE);
+	for(const auto & existingBonus : *creature->getBonuses(stackExperienceSelector))
+	{
+		int lowerLimit = 0;
+		if (const auto * rankLimiter = dynamic_cast<const RankRangeLimiter *>(existingBonus->limiter.get()))
+			lowerLimit = rankLimiter->minRank;
+
+		loadedStackExperienceBonuses.insert(makeStackExpBonusSignature(*existingBonus, lowerLimit));
+	}
 
 	for (const JsonNode &exp : input.Vector())
 	{

--- a/lib/CCreatureHandler.cpp
+++ b/lib/CCreatureHandler.cpp
@@ -974,30 +974,8 @@ void CCreatureHandler::loadCreatureJson(CCreature * creature, const JsonNode & c
 
 void CCreatureHandler::loadStackExperience(CCreature * creature, const JsonNode & input) const
 {
-	std::set<std::string> loadedStackExperienceBonuses;
-	auto makeStackExpBonusSignature = [](const Bonus & bonus, int lowerLimit)
-	{
-		return boost::str(boost::format("%d|%d|%d|%d|%d|%d")
-			% static_cast<int>(bonus.type)
-			% bonus.subtype.getNum()
-			% bonus.val
-			% static_cast<int>(bonus.valType)
-			% static_cast<int>(bonus.source)
-			% lowerLimit);
-	};
-	const auto stackExperienceSelector = Selector::sourceTypeSel(BonusSource::STACK_EXPERIENCE);
-	for(const auto & existingBonus : *creature->getBonuses(stackExperienceSelector))
-	{
-		int lowerLimit = 0;
-		if (const auto * rankLimiter = dynamic_cast<const RankRangeLimiter *>(existingBonus->limiter.get()))
-			lowerLimit = rankLimiter->minRank;
-
-		loadedStackExperienceBonuses.insert(makeStackExpBonusSignature(*existingBonus, lowerLimit));
-	}
-
 	for (const JsonNode &exp : input.Vector())
 	{
-		const bool hasExplicitSubtype = !exp["bonus"]["subtype"].isNull();
 		const JsonVector &values = exp["values"].Vector();
 		// RankRangeLimiter uses strict bounds (rank > minRank), so level 1 bonus
 		// must start from 0 to map values[0] -> rank 1 and values[9] -> rank 10.
@@ -1011,17 +989,12 @@ void CCreatureHandler::loadStackExperience(CCreature * creature, const JsonNode 
 					// parse each bonus separately
 					// we can not create copies since identifiers resolution does not tracks copies
 					// leading to unset identifier values in copies
-					auto bonus = JsonUtils::parseBonus (exp["bonus"]);
-						bonus->source = BonusSource::STACK_EXPERIENCE;
-						bonus->duration = BonusDuration::PERMANENT;
-						if(!hasExplicitSubtype)
-							bonus->subtype = BonusSubtypeID();
-						const std::string signature = makeStackExpBonusSignature(*bonus, lowerLimit);
-						if(!loadedStackExperienceBonuses.insert(signature).second)
-							continue;
-						bonus->addLimiter(std::make_shared<RankRangeLimiter>(lowerLimit));
-						creature->addNewBonus (bonus);
-						break; //TODO: allow bonuses to turn off?
+						auto bonus = JsonUtils::parseBonus (exp["bonus"]);
+					bonus->source = BonusSource::STACK_EXPERIENCE;
+					bonus->duration = BonusDuration::PERMANENT;
+					bonus->addLimiter(std::make_shared<RankRangeLimiter>(lowerLimit));
+					creature->addNewBonus (bonus);
+					break; //TODO: allow bonuses to turn off?
 				}
 				++lowerLimit;
 			}
@@ -1037,15 +1010,10 @@ void CCreatureHandler::loadStackExperience(CCreature * creature, const JsonNode 
 					bonusInput["val"].Float() = val.Integer() - lastVal;
 
 					auto bonus = JsonUtils::parseBonus (bonusInput);
-						bonus->source = BonusSource::STACK_EXPERIENCE;
-						bonus->duration = BonusDuration::PERMANENT;
-						if(!hasExplicitSubtype)
-							bonus->subtype = BonusSubtypeID();
-						const std::string signature = makeStackExpBonusSignature(*bonus, lowerLimit);
-						if(!loadedStackExperienceBonuses.insert(signature).second)
-							continue;
-						bonus->addLimiter(std::make_shared<RankRangeLimiter>(lowerLimit));
-						creature->addNewBonus (bonus);
+					bonus->source = BonusSource::STACK_EXPERIENCE;
+					bonus->duration = BonusDuration::PERMANENT;
+					bonus->addLimiter(std::make_shared<RankRangeLimiter>(lowerLimit));
+					creature->addNewBonus (bonus);
 					}
 				lastVal = static_cast<int>(val.Float());
 				++lowerLimit;

--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -21,6 +21,8 @@
 #include "../IGameSettings.h"
 #include "../GameLibrary.h"
 
+#include <set>
+
 
 VCMI_LIB_NAMESPACE_BEGIN
 
@@ -34,9 +36,14 @@ DamageRange DamageCalculator::getBaseDamageSingle() const
 
 	if(minDmg > maxDmg)
 	{
-	const auto & creatureName = info.attacker->creatureId().toEntity(LIBRARY)->getNamePluralTranslated();
-	logGlobal->error("Creature %s: min damage %lld exceeds max damage %lld.", creatureName, minDmg, maxDmg);
-		logGlobal->error("This may lead to unexpected results, please report it to the mod's creator.");
+		const CreatureID creatureId = info.attacker->creatureId();
+		static std::set<CreatureID> reportedInvalidDamageCreatures;
+		if (reportedInvalidDamageCreatures.insert(creatureId).second)
+		{
+			const auto & creatureName = creatureId.toEntity(LIBRARY)->getNamePluralTranslated();
+			logGlobal->error("Creature %s: min damage %lld exceeds max damage %lld.", creatureName, minDmg, maxDmg);
+			logGlobal->error("This may lead to unexpected results, please report it to the mod's creator.");
+		}
 		// to avoid an RNG crash and make bless and curse spells work as expected
 		std::swap(minDmg, maxDmg);
 	}

--- a/lib/battle/DamageCalculator.cpp
+++ b/lib/battle/DamageCalculator.cpp
@@ -21,9 +21,6 @@
 #include "../IGameSettings.h"
 #include "../GameLibrary.h"
 
-#include <set>
-
-
 VCMI_LIB_NAMESPACE_BEGIN
 
 DamageRange DamageCalculator::getBaseDamageSingle() const
@@ -36,14 +33,9 @@ DamageRange DamageCalculator::getBaseDamageSingle() const
 
 	if(minDmg > maxDmg)
 	{
-		const CreatureID creatureId = info.attacker->creatureId();
-		static std::set<CreatureID> reportedInvalidDamageCreatures;
-		if (reportedInvalidDamageCreatures.insert(creatureId).second)
-		{
-			const auto & creatureName = creatureId.toEntity(LIBRARY)->getNamePluralTranslated();
-			logGlobal->error("Creature %s: min damage %lld exceeds max damage %lld.", creatureName, minDmg, maxDmg);
-			logGlobal->error("This may lead to unexpected results, please report it to the mod's creator.");
-		}
+	const auto & creatureName = info.attacker->creatureId().toEntity(LIBRARY)->getNamePluralTranslated();
+	logGlobal->error("Creature %s: min damage %lld exceeds max damage %lld.", creatureName, minDmg, maxDmg);
+		logGlobal->error("This may lead to unexpected results, please report it to the mod's creator.");
 		// to avoid an RNG crash and make bless and curse spells work as expected
 		std::swap(minDmg, maxDmg);
 	}


### PR DESCRIPTION
### Motivation

- Loading creature JSON must not re-add already-present `STACK_EXPERIENCE` bonuses and should avoid duplicate entries when bonuses use `RankRangeLimiter`.
- Log spam when a creature's min damage exceeds max damage should be reduced by reporting the issue only once per creature.

### Description

- In `CCreatureHandler::loadStackExperience` iterate existing bonuses selected with `Selector::sourceTypeSel(BonusSource::STACK_EXPERIENCE)` and populate `loadedStackExperienceBonuses` using the existing `RankRangeLimiter` `minRank` to avoid creating duplicate bonuses when parsing JSON.
- In `DamageCalculator::getBaseDamageSingle` add `#include <set>` and introduce a static `std::set<CreatureID> reportedInvalidDamageCreatures` to ensure the min>max damage warning is logged only once per `CreatureID`.
- Preserve the original swap of `minDmg`/`maxDmg` to avoid RNG crashes and keep existing special-case handling for towers.

### Testing

- Project was built successfully and the automated test suite was executed with no failing tests.
- Relevant battle damage and creature-loading tests ran and showed no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fba053f4832d98017cc585fa67f5)