### PR TITLE
Add CommanderSkillInfoWindow and use it for commander skill clicks

### DIFF
--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -116,7 +116,7 @@ public:
 		: CWindowObject(PLAYER_COLORED | BORDERED)
 	{
 		OBJECT_CONSTRUCTION;
-		pos = Rect(0, 0, 360, 420);
+		pos = Rect(0, 0, 504, 420);
 		center();
 		backgroundTexture = std::make_shared<CFilledTexture>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, pos.w, pos.h));
 
@@ -141,6 +141,7 @@ public:
 			CButton::tooltip(),
 			[this]() { close(); },
 			EShortcut::GLOBAL_RETURN);
+		closeButton->setBorderColor(Colors::METALLIC_GOLD);
 	}
 
 private:

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -116,6 +116,8 @@ public:
 		: CWindowObject(PLAYER_COLORED | BORDERED)
 	{
 		OBJECT_CONSTRUCTION;
+		pos = Rect(0, 0, 360, 420);
+		center();
 		backgroundTexture = std::make_shared<CFilledTexture>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, pos.w, pos.h));
 
 		constexpr int iconSize = 82;
@@ -503,11 +505,13 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 	{
 		Point skillPos = getSkillPos(index);
 
-		auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(getSkillImage(index), skillPos.x, skillPos.y), false, [=]()
-		{
-			auto skillInfoWindow = std::make_shared<CommanderSkillInfoWindow>(skillToFile(index, parent->info->commander->secondarySkills[index], false), getSkillDescription(index));
-			ENGINE->windows().pushWindow(std::static_pointer_cast<IShowActivatable>(skillInfoWindow));
-		});
+			auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(getSkillImage(index), skillPos.x, skillPos.y), false, [this, index]()
+			{
+				auto skillInfoWindow = std::make_shared<CommanderSkillInfoWindow>(
+					skillToFile(index, parent->info->commander->secondarySkills[index], false),
+					parent->getCommanderSkillDescription(index, parent->info->commander->secondarySkills[index]));
+				ENGINE->windows().pushWindow(std::static_pointer_cast<IShowActivatable>(skillInfoWindow));
+			});
 
 		icon->text = getSkillDescription(index); //used to handle right click description via LRClickableAreaWText::ClickRight()
 

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -109,6 +109,45 @@ private:
 
 };
 
+class CommanderSkillInfoWindow : public CWindowObject
+{
+public:
+	CommanderSkillInfoWindow(const ImagePath & skillIcon, const std::string & text)
+		: CWindowObject(PLAYER_COLORED | BORDERED)
+	{
+		OBJECT_CONSTRUCTION;
+		backgroundTexture = std::make_shared<CFilledTexture>(ImagePath::builtin("DiBoxBck"), Rect(0, 0, pos.w, pos.h));
+
+		constexpr int iconSize = 82;
+		const int iconX = (pos.w - iconSize) / 2;
+		constexpr int iconTop = 26;
+		constexpr int textTop = 126;
+		constexpr int horizontalMargin = 28;
+
+		background = std::make_shared<CPicture>(skillIcon, iconX, iconTop);
+		description = std::make_shared<CTextBox>(
+			text,
+			Rect(horizontalMargin, textTop, pos.w - horizontalMargin * 2, pos.h - textTop - 56),
+			0,
+			FONT_MEDIUM,
+			ETextAlignment::CENTER,
+			Colors::WHITE);
+
+		closeButton = std::make_shared<CButton>(
+			Point((pos.w - 64) / 2, pos.h - 44),
+			AnimationPath::builtin("IOK6432.DEF"),
+			CButton::tooltip(),
+			[this]() { close(); },
+			EShortcut::GLOBAL_RETURN);
+	}
+
+private:
+	std::shared_ptr<CFilledTexture> backgroundTexture;
+	std::shared_ptr<CPicture> background;
+	std::shared_ptr<CTextBox> description;
+	std::shared_ptr<CButton> closeButton;
+};
+
 CCommanderSkillIcon::CCommanderSkillIcon(std::shared_ptr<CIntObject> object_, bool isMasterAbility_, std::function<void()> callback)
 	: object(),
 	  isMasterAbility(isMasterAbility_),
@@ -466,7 +505,8 @@ CStackWindow::CommanderMainSection::CommanderMainSection(CStackWindow * owner, i
 
 		auto icon = std::make_shared<CCommanderSkillIcon>(std::make_shared<CPicture>(getSkillImage(index), skillPos.x, skillPos.y), false, [=]()
 		{
-			GAME->interface()->showInfoDialog(getSkillDescription(index));
+			auto skillInfoWindow = std::make_shared<CommanderSkillInfoWindow>(skillToFile(index, parent->info->commander->secondarySkills[index], false), getSkillDescription(index));
+			ENGINE->windows().pushWindow(std::static_pointer_cast<IShowActivatable>(skillInfoWindow));
 		});
 
 		icon->text = getSkillDescription(index); //used to handle right click description via LRClickableAreaWText::ClickRight()


### PR DESCRIPTION
### Motivation
- Replace the generic info dialog with a dedicated popup that shows a commander skill icon and centered description in a styled window.

### Description
- Add a new `CommanderSkillInfoWindow` class derived from `CWindowObject` that composes a `CFilledTexture` background, a centered `CPicture` for the skill icon, a centered `CTextBox` for the description, and a centered close `CButton`.
- Replace the previous click handler that called `GAME->interface()->showInfoDialog(...)` in `CommanderMainSection` with code that constructs a `CommanderSkillInfoWindow` and pushes it via `ENGINE->windows().pushWindow(...)`.
- Define layout constants for icon and text placement and construct the window with the `PLAYER_COLORED | BORDERED` style.

### Testing
- Built the client with the changes and confirmed the project compiles with no errors.
- Ran the existing automated unit test suite and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9afdf05c832da719eaf94f9afaeb)