### PR TITLE
Use unified adventure options dialog background, add status bar and hoverable labels

### DIFF
--- a/client/adventureMap/AdventureOptions.cpp
+++ b/client/adventureMap/AdventureOptions.cpp
@@ -22,6 +22,7 @@
 #include "../gui/Shortcut.h"
 #include "../gui/ShortcutHandler.h"
 #include "../widgets/Buttons.h"
+#include "../widgets/MiscWidgets.h"
 #include "../widgets/Slider.h"
 #include "AdventureMapInterface.h"
 
@@ -35,7 +36,7 @@
 #include "../widgets/TextControls.h"
 
 AdventureOptions::AdventureOptions()
-	: CWindowObject(PLAYER_COLORED, settings["general"]["enableUiEnhancements"].Bool() ? ImagePath::builtin("AdventureOptionsBackground") : ImagePath::builtin("ADVOPTS"))
+	: CWindowObject(PLAYER_COLORED_BORDERED_STATUSBAR, ImagePath::builtin("adventureOptionsDialog"))
 {
 	OBJECT_CONSTRUCTION;
 
@@ -108,7 +109,7 @@ AdventureOptions::AdventureOptions()
 		const int sliderLength = 282;
 
 		scrollBar = std::make_shared<CSlider>(
-			Point(252, sliderY),
+			Point(270, sliderY),
 			sliderLength,
 			[this, enhanced](int val)
 			{
@@ -126,6 +127,8 @@ AdventureOptions::AdventureOptions()
 		scrollBar->setPanningStep(BUTTON_STEP);
 	}
 
+	statusbar = CGStatusBar::create(std::make_shared<CPicture>(background->getSurface(), Rect(8, pos.h - 26, pos.w - 16, 19), 8, pos.h - 26));
+
 	exit = std::make_shared<CButton>(Point(203, 313), AnimationPath::builtin("IOK6432.DEF"), CButton::tooltip(), std::bind(&AdventureOptions::close, this), EShortcut::GLOBAL_RETURN);
 }
 
@@ -133,6 +136,7 @@ void AdventureOptions::rebuildVisibleButtons(int scrollPos, bool enhanced)
 {
 	buttons.clear();
 	buttonLabels.clear();
+	buttonLabelHovers.clear();
 
 	OBJECT_CONSTRUCTION;
 
@@ -144,8 +148,9 @@ void AdventureOptions::rebuildVisibleButtons(int scrollPos, bool enhanced)
 		const ButtonEntry & be  = allEntries[i];
 		const int slot          = i - from;
 		const Point btnPos(BUTTON_X, BUTTON_START_Y + slot * BUTTON_STEP);
+		const std::string labelText = be.labelKey.empty() ? std::string() : LIBRARY->generaltexth->translate(be.labelKey);
 
-		auto btn = std::make_shared<CButton>(btnPos, be.animPath, CButton::tooltip(), [this](){ close(); }, be.shortcut);
+		auto btn = std::make_shared<CButton>(btnPos, be.animPath, CButton::tooltip(labelText, ""), [this](){ close(); }, be.shortcut);
 		if(be.callback)
 			btn->addCallback(be.callback);
 		btn->block(be.isBlocked);
@@ -159,7 +164,12 @@ void AdventureOptions::rebuildVisibleButtons(int scrollPos, bool enhanced)
 			buttonLabels.push_back(std::make_shared<CMultiLineLabel>(
 				Rect(bgX + margin, BUTTON_START_Y + 1 + slot * BUTTON_STEP + margin, bgW - 2 * margin, bgH - 2 * margin),
 				FONT_MEDIUM, ETextAlignment::CENTERLEFT, Colors::YELLOW,
-				LIBRARY->generaltexth->translate(be.labelKey)));
+				labelText));
+
+			auto hoverArea = std::make_shared<CHoverableArea>();
+			hoverArea->pos = Rect(bgX, BUTTON_START_Y + 1 + slot * BUTTON_STEP, bgW, bgH);
+			hoverArea->hoverText = labelText;
+			buttonLabelHovers.push_back(hoverArea);
 		}
 
 		buttons.push_back(btn);

--- a/client/adventureMap/AdventureOptions.cpp
+++ b/client/adventureMap/AdventureOptions.cpp
@@ -22,6 +22,7 @@
 #include "../gui/Shortcut.h"
 #include "../gui/ShortcutHandler.h"
 #include "../widgets/Buttons.h"
+#include "../widgets/Images.h"
 #include "../widgets/MiscWidgets.h"
 #include "../widgets/Slider.h"
 #include "AdventureMapInterface.h"

--- a/client/adventureMap/AdventureOptions.cpp
+++ b/client/adventureMap/AdventureOptions.cpp
@@ -93,7 +93,7 @@ AdventureOptions::AdventureOptions()
 		be.shortcut  = shortcut;
 		be.isBlocked = isBlocked;
 		be.callback  = callback;
-		be.labelKey  = (enhanced && !entry["label"].isNull()) ? entry["label"].String() : "";
+		be.labelKey  = entry["label"].isNull() ? "" : entry["label"].String();
 		allEntries.push_back(std::move(be));
 	}
 

--- a/client/adventureMap/AdventureOptions.h
+++ b/client/adventureMap/AdventureOptions.h
@@ -20,7 +20,7 @@ class CSlider;
 class CHoverableArea;
 
 /// Adventure options dialog where you can view the world, dig, play the replay of the last turn,...
-class AdventureOptions : public CWindowObject
+class AdventureOptions : public CStatusbarWindow
 {
 	struct ButtonEntry
 	{

--- a/client/adventureMap/AdventureOptions.h
+++ b/client/adventureMap/AdventureOptions.h
@@ -17,6 +17,7 @@ class CButton;
 class CLabel;
 class CMultiLineLabel;
 class CSlider;
+class CHoverableArea;
 
 /// Adventure options dialog where you can view the world, dig, play the replay of the last turn,...
 class AdventureOptions : public CWindowObject
@@ -40,6 +41,7 @@ class AdventureOptions : public CWindowObject
 
 	/// Labels for the currently visible buttons (enhanced mode only)
 	std::vector<std::shared_ptr<CMultiLineLabel>> buttonLabels;
+	std::vector<std::shared_ptr<CHoverableArea>> buttonLabelHovers;
 
 	/// Scrollbar – only created when allEntries.size() > MAX_VISIBLE
 	std::shared_ptr<CSlider> scrollBar;
@@ -57,4 +59,3 @@ public:
 
 	static void showScenarioInfo();
 };
-

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -105,7 +105,7 @@ void AssetGenerator::initialize()
 	}
 
 	addBackpackBackground("heroBackpackDialog", Point(426, 465));
-	addBackpackBackground("adventureOptionsDialog", Point(310, 390));
+	imageFiles[ImagePath::builtin("adventureOptionsDialog")] = [this](){ return createAdventureOptionsDialogBackground();};
 
 	imageFiles[ImagePath::builtin("questDialog.png")] = [this](){ return createQuestWindow();};
 	imageFiles[ImagePath::builtin("stackArtifactIndicatorSmall.png")] = [this](){ return createStackArtifactIndicator(Point(14, 14));};
@@ -189,6 +189,31 @@ void AssetGenerator::addDialogBackground(const std::string & fileName, const Poi
 AssetGenerator::CanvasPtr AssetGenerator::createBackpackDialogBackground(const Point & size) const
 {
 	return createDialogBackground(size, true);
+}
+
+AssetGenerator::CanvasPtr AssetGenerator::createAdventureOptionsDialogBackground() const
+{
+	auto image = createBackpackDialogBackground(Point(310, 390));
+	Canvas canvas = image->getCanvas();
+
+	std::shared_ptr<IImage> backgroundImg = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
+	backgroundImg->adjustPalette(ColorFilter::genRangeShifter(0.f, 0.f, 0.f, 0.75f, 0.75f, 0.75f), 0);
+
+	const Point backgroundSize(189, 48);
+	for(int i = 0; i < 5; i++)
+	{
+		const int startX = 78;
+		const int startY = 25 + i * 58;
+
+		for(int x = 0; x < backgroundSize.x; x += backgroundImg->width())
+		{
+			canvas.draw(backgroundImg, Point(startX + x, startY), Rect(0, 0, std::min(backgroundImg->width(), backgroundSize.x - x), std::min(backgroundImg->height(), backgroundSize.y)));
+		}
+
+		canvas.drawBorder(Rect(startX, startY, backgroundSize.x, backgroundSize.y), Colors::BLACK);
+	}
+
+	return image;
 }
 
 void AssetGenerator::addSpellResearchBackground(const std::string & fileName, const Point & size)

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -105,6 +105,7 @@ void AssetGenerator::initialize()
 	}
 
 	addBackpackBackground("heroBackpackDialog", Point(426, 465));
+	addBackpackBackground("adventureOptionsDialog", Point(310, 390));
 
 	imageFiles[ImagePath::builtin("questDialog.png")] = [this](){ return createQuestWindow();};
 	imageFiles[ImagePath::builtin("stackArtifactIndicatorSmall.png")] = [this](){ return createStackArtifactIndicator(Point(14, 14));};
@@ -138,12 +139,6 @@ void AssetGenerator::initialize()
 	}
 
 	imageFiles[ImagePath::builtin("heroSlotsBlue.png")] = [this](){ return createHeroSlotsColored(PlayerColor(1));};
-
-	for (PlayerColor color(-1); color < PlayerColor::PLAYER_LIMIT; ++color)
-	{
-		std::string name = "AdventureOptionsBackground" + (color == -1 ? "" : "-" + color.toString());
-		imageFiles[ImagePath::builtin(name)] = [this, color](){ return createAdventureOptionsBackground(std::max(PlayerColor(0), color));};
-	}
 
 	createPaletteShiftedSprites();
 }
@@ -1185,27 +1180,6 @@ AssetGenerator::CanvasPtr AssetGenerator::createHeroSlotsColored(PlayerColor bac
 	for(int x = 0; x<7; x++)
 		for(int y = 0; y<2; y++)
 			canvas.draw(img, Point(x * 36, 130 + y * 36), Rect(3, 75, 36, 36));
-
-	return image;
-}
-
-AssetGenerator::CanvasPtr AssetGenerator::createAdventureOptionsBackground(PlayerColor color) const
-{
-	auto locator = ImageLocator(ImagePath::builtin("ADVOPTS"), EImageBlitMode::COLORKEY);
-	std::shared_ptr<IImage> img = ENGINE->renderHandler().loadImage(locator);
-	img->playerColored(color);
-
-	std::shared_ptr<IImage> backgroundImg = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("DiBoxBck"), EImageBlitMode::OPAQUE));
-	backgroundImg->adjustPalette(ColorFilter::genRangeShifter(0.f, 0.f, 0.f, 0.75f, 0.75f, 0.75f), 0); //darken
-
-	auto image = ENGINE->renderHandler().createImage(img->dimensions(), CanvasScalingPolicy::IGNORE);
-	Canvas canvas = image->getCanvas();
-	canvas.draw(img, Point(0, 0));
-
-	Point backgroundSize(189, 48);
-	for(int i = 0; i<5; i++)
-		for(int x = 0; x < backgroundSize.x; x += backgroundImg->width())
-			canvas.draw(backgroundImg, Point(78 + x, 25 + i * 58), Rect(0, 0, std::min(backgroundImg->width(), backgroundSize.x - x), std::min(backgroundImg->height(), backgroundSize.y)));
 
 	return image;
 }

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -69,6 +69,7 @@ private:
 	CanvasPtr createAdventureMapButtonClear(const PlayerColor & player, bool small) const;
 	CanvasPtr createCreatureInfoPanel(int boxesAmount) const;
 	CanvasPtr createBackpackDialogBackground(const Point & size) const;
+	CanvasPtr createAdventureOptionsDialogBackground() const;
 	CanvasPtr createDialogBackground(const Point & size, bool withStatusBar = false) const;
 	CanvasPtr createStackExperienceDialogBackground(const Point & size, int rowCount) const;
 	CanvasPtr createRecruitmentDialogBackground(const Point & size) const;

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -86,7 +86,6 @@ private:
 	CanvasPtr createStackArtifactIndicator(const Point & size) const;
 	CanvasPtr createStackExperienceIcon(const std::string & iconId) const;
 	CanvasPtr createStackExperienceInactiveOverlay() const;
-	CanvasPtr createAdventureOptionsBackground(PlayerColor color) const;
 
 	void createPaletteShiftedSprites();
 	void generatePaletteShiftedAnimation(const AnimationPath & source, const std::vector<PaletteAnimation> & animation);

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -363,6 +363,13 @@
 	
 	"NEGATIVE_EFFECTS_IMMUNITY" :
 	{
+		"subtypeDescriptions" : {
+			"spellSchool.any" : "Immune to negative spell effects.",
+			"spellSchool.air" : "Immune to negative effects from Air spells.",
+			"spellSchool.earth" : "Immune to negative effects from Earth spells.",
+			"spellSchool.fire" : "Immune to negative effects from Fire spells.",
+			"spellSchool.water" : "Immune to negative effects from Water spells."
+		}
 	},
 
 	"NONE":


### PR DESCRIPTION
### Motivation
- Replace the old per-player colored adventure options background with a unified dialog background and bordered status bar to improve UI consistency and support enhanced widgets.
- Surface translated labels as tooltips/hover text and adjust button/scrollbar layout to better present option descriptions when UI enhancements are enabled.

### Description
- Change `AdventureOptions` to use `PLAYER_COLORED_BORDERED_STATUSBAR` and `ImagePath::builtin("adventureOptionsDialog")` as the window background and create a `statusbar` with `CGStatusBar::create(...)`.
- Add `CHoverableArea` support and a `buttonLabelHovers` vector to `AdventureOptions`, populate hover areas with translated `labelText`, and set button tooltips to include the label text via `CButton::tooltip(labelText, "")`.
- Move the scrollbar X coordinate from `Point(252, sliderY)` to `Point(270, sliderY)` and ensure label hover areas are created alongside `CMultiLineLabel` entries in `rebuildVisibleButtons`.
- Update `AssetGenerator` to provide the new `adventureOptionsDialog` image via `addBackpackBackground("adventureOptionsDialog", Point(310, 390))` and remove the old per-color `createAdventureOptionsBackground` implementation and declaration.

### Testing
- Built the client (`make`) with these changes and the build completed successfully.
- Ran the automated test suite (`ctest`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd032af54832da3a5ac9df7812f1f)