### PR TITLE
Fix map centering before multiplayer turn-start prompt

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -326,6 +326,24 @@ void CPlayerInterface::yourTurn(QueryID queryID)
 
 		if (hotseatWait) //hot seat or MP message
 		{
+			const CGHeroInstance * heroToSelect = nullptr;
+			for (auto hero : localState->getWanderingHeroes())
+			{
+				if (!localState->isHeroSleeping(hero))
+				{
+					heroToSelect = hero;
+					break;
+				}
+			}
+
+			if (heroToSelect != nullptr)
+				localState->setSelection(heroToSelect);
+			else if (!localState->getOwnedTowns().empty())
+				localState->setSelection(localState->getOwnedTown(0));
+			else
+				localState->setSelection(localState->getWanderingHero(0));
+
+			adventureInt->onSelectionChanged(localState->getCurrentArmy());
 			adventureInt->onHotseatWaitStarted(playerID);
 
 			makingTurn = true;


### PR DESCRIPTION
### Motivation
- Players joining a multiplayer/LAN game could see the camera focused at the top-left until the "your turn" dialog was dismissed; the UI should center the map on the player's starting hero/town immediately after load so the view is correct before the turn-start prompt.

### Description
- In `client/CPlayerInterface.cpp` inside `CPlayerInterface::yourTurn`, preselect the first non-sleeping hero (or fall back to the first owned town / first hero) and call `adventureInt->onSelectionChanged(localState->getCurrentArmy())` before invoking `adventureInt->onHotseatWaitStarted(playerID)`, ensuring the map centers on the player's location on load.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7ca0eff4832d9176f02ca2c72b5a)