### PR TITLE
Close CLobbyScreen when `LobbyStartGame` is received

### DIFF
--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -183,6 +183,9 @@ void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pac
 
 void ApplyOnLobbyScreenNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pack)
 {
+	if(lobby)
+		ENGINE->windows().popWindow(lobby);
+
 	if(auto w = ENGINE->windows().topWindow<CLoadingScreen>())
 	{
 		w->finish();


### PR DESCRIPTION
### Motivation
- Prevent a client UI hang where a joining player (reported on Android↔Android over LAN) remains on the lobby screen instead of transitioning into the game when `LobbyStartGame` is processed.

### Description
- In `client/NetPacksLobbyClient.cpp` added an explicit check to pop the lobby window in `ApplyOnLobbyScreenNetPackVisitor::visitLobbyStartGame` by calling `ENGINE->windows().popWindow(lobby)` if `lobby` is set, while keeping the existing loading-screen completion (`finish/tick/redraw`) unchanged.

### Testing
- Ran `git diff --check` to validate whitespace and simple checks which passed. 
- Inspected `git diff` for `client/NetPacksLobbyClient.cpp` to verify the intended change; the diff matched the expected insertion and was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb773cf88832d97ce388908574143)