### PR TITLE
Close lobby screen on game start to prevent UI hang

### DIFF
--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -183,6 +183,9 @@ void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pac
 
 void ApplyOnLobbyScreenNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pack)
 {
+	if(lobby)
+		lobby->close();
+
 	if(auto w = ENGINE->windows().topWindow<CLoadingScreen>())
 	{
 		w->finish();


### PR DESCRIPTION
### Motivation
- Joining players could remain stuck on the lobby UI instead of entering the map after `LobbyStartGame`, notably observed for Android↔Android multiplayer, so the lobby must be closed deterministically when the start pack arrives.

### Description
- Close the lobby window from the lobby-screen netpack visitor by calling `lobby->close()` in `client/NetPacksLobbyClient.cpp::ApplyOnLobbyScreenNetPackVisitor::visitLobbyStartGame`, preserving the existing loading-screen finish logic.

### Testing
- Applied the patch and verified via `git diff` and `nl -ba client/NetPacksLobbyClient.cpp | sed -n '176,205p'` that the change is present, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbdad2060832d9aedbe1c7512d8db)