### PR TITLE
Close CLobbyScreen on LobbyStartGame to fix clients stuck in lobby

### DIFF
--- a/client/NetPacksLobbyClient.cpp
+++ b/client/NetPacksLobbyClient.cpp
@@ -183,6 +183,9 @@ void ApplyOnLobbyHandlerNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pac
 
 void ApplyOnLobbyScreenNetPackVisitor::visitLobbyStartGame(LobbyStartGame & pack)
 {
+	if(lobby)
+		ENGINE->windows().popWindow(lobby);
+
 	if(auto w = ENGINE->windows().topWindow<CLoadingScreen>())
 	{
 		w->finish();


### PR DESCRIPTION
### Motivation
- Android-to-Android multiplayer clients could remain on the lobby UI after the host starts the game, so the UI must be deterministically removed when `LobbyStartGame` arrives.

### Description
- In `client/NetPacksLobbyClient.cpp` add an explicit `ENGINE->windows().popWindow(lobby)` call at the start of `ApplyOnLobbyScreenNetPackVisitor::visitLobbyStartGame` so the `CLobbyScreen` is removed before the existing loading-screen finalization (`finish/tick/redraw`).

### Testing
- No automated tests were run for this trivial UI transition change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc97b4244832d854bcfd46ec9f94b)