### PR TITLE
Fix RMG size matching and underground toggle availability in lobby

### DIFF
--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -452,14 +452,23 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 	}
 	if(auto w = widget<CToggleButton>("buttonTwoLevels"))
 	{
-		int possibleLevelCount = 2;
+		bool canUseOneLevel = true;
+		bool canUseTwoLevels = true;
 		if(mapGenOptions->getMapTemplate())
 		{
-			auto sizes = mapGenOptions->getMapTemplate()->getMapSizes();
-			possibleLevelCount = sizes.second.z - sizes.first.z + 1;
+			const int currentWidth = opts->getWidth();
+			const int currentHeight = opts->getHeight();
+			canUseOneLevel = mapGenOptions->getMapTemplate()->matchesSize(int3{currentWidth, currentHeight, 1});
+			canUseTwoLevels = mapGenOptions->getMapTemplate()->matchesSize(int3{currentWidth, currentHeight, 2});
 		}
+
+		if(!canUseOneLevel && canUseTwoLevels)
+			opts->setLevels(2);
+		else if(canUseOneLevel && !canUseTwoLevels)
+			opts->setLevels(1);
+
 		w->setSelectedSilent(opts->getLevels() == 2);
-		w->block(possibleLevelCount < 2);
+		w->block(!canUseOneLevel || !canUseTwoLevels);
 	}
 	if(auto w = widget<CToggleGroup>("groupMaxPlayers"))
 	{

--- a/client/lobby/RandomMapTab.cpp
+++ b/client/lobby/RandomMapTab.cpp
@@ -425,9 +425,14 @@ void RandomMapTab::setMapGenOptions(std::shared_ptr<CMapGenOptions> opts)
 					continue;
 				}
 
-				int3 size(*mapSize, *mapSize, mapGenOptions->getLevels());
-
-				bool sizeAllowed = !mapGenOptions->getMapTemplate() || mapGenOptions->getMapTemplate()->matchesSize(size);
+				bool sizeAllowed = true;
+				if(mapGenOptions->getMapTemplate())
+				{
+					const int currentSize = *mapSize;
+					const bool sizeWithOneLevelAllowed = mapGenOptions->getMapTemplate()->matchesSize(int3{currentSize, currentSize, 1});
+					const bool sizeWithTwoLevelsAllowed = mapGenOptions->getMapTemplate()->matchesSize(int3{currentSize, currentSize, 2});
+					sizeAllowed = sizeWithOneLevelAllowed || sizeWithTwoLevelsAllowed;
+				}
 				button->block(!sizeAllowed);
 			}
 		}

--- a/lib/rmg/CRmgTemplate.cpp
+++ b/lib/rmg/CRmgTemplate.cpp
@@ -703,11 +703,9 @@ CRmgTemplate::CRmgTemplate()
 
 bool CRmgTemplate::matchesSize(const int3 & value) const
 {
-	const int64_t square = value.x * value.y * value.z;
-	const int64_t minSquare = minSize.x * minSize.y * minSize.z;
-	const int64_t maxSquare = maxSize.x * maxSize.y * maxSize.z;
-
-	return minSquare <= square && square <= maxSquare;
+	return minSize.x <= value.x && value.x <= maxSize.x
+		&& minSize.y <= value.y && value.y <= maxSize.y
+		&& minSize.z <= value.z && value.z <= maxSize.z;
 }
 
 bool CRmgTemplate::isWaterContentAllowed(EWaterContent::EWaterContent waterContent) const


### PR DESCRIPTION
### Motivation
- The `CRmgTemplate::matchesSize` implementation used total area (`x*y*z`) which allowed invalid combinations (e.g. a template intended to enforce underground could pass due to area alone). 
- The random-map lobby UI inferred underground availability from `minSize`/`maxSize` z-range in a way that produced incorrect or confusing toggle state for certain templates and sizes. 

### Description
- Replace `CRmgTemplate::matchesSize` area check with per-dimension bounds checking so each of `x`, `y`, and `z` must be within `minSize`/`maxSize` (`minSize.x <= x <= maxSize.x && ...`).
- Update lobby code in `RandomMapTab` to compute `canUseOneLevel` and `canUseTwoLevels` by calling `matchesSize(int3{width,height,1})` and `matchesSize(int3{width,height,2})` respectively. 
- When a template/size supports only one of the layer counts, force `opts->setLevels(1)` or `opts->setLevels(2)` accordingly and block the underground toggle when switching is not possible.

### Testing
- Verified the source changes by generating and inspecting the diff for `lib/rmg/CRmgTemplate.cpp` and `client/lobby/RandomMapTab.cpp`, confirming the intended replacements were applied (inspection succeeded).
- Printed the modified file sections with line numbers using `nl` to confirm the new `matchesSize` logic and updated toggle handling are present at the expected locations (verification succeeded).
- No unit test suite for RMG changes was executed in this run and no runtime UI integration tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01964f3924832d9720af626f9a0c9f)