### PR TITLE
Support configurable mine guards and populate mine stacks from config

### DIFF
--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -153,7 +153,7 @@ AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const
 
 std::vector<CStackBasicDescriptor> MineInstanceConstructor::getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const
 {
-	if (guards.getType() != JsonNode::JsonType::DATA_VECTOR)
+	if (!guards.isVector())
 		return {};
 
 	JsonRandom randomizer(const_cast<IGameInfoCallback *>(cb), gameRandomizer);

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -95,7 +95,6 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 {
 	config = input;
 	guards.clear();
-	hasGuardsConfig = false;
 	hasGuardedMessageConfig = false;
 
 	resourceType = GameResID::NONE; //set up fallback
@@ -120,7 +119,6 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 
 	if (config["guards"].getType() == JsonNode::JsonType::DATA_VECTOR)
 	{
-		hasGuardsConfig = true;
 		guards = config["guards"];
 	}
 }
@@ -162,12 +160,12 @@ AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const
 
 bool MineInstanceConstructor::hasGuards() const
 {
-	return hasGuardsConfig;
+	return guards.getType() == JsonNode::JsonType::DATA_VECTOR;
 }
 
 std::vector<CStackBasicDescriptor> MineInstanceConstructor::getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const
 {
-	if (!hasGuardsConfig)
+	if (!hasGuards())
 		return {};
 
 	JsonRandom randomizer(const_cast<IGameInfoCallback *>(cb), gameRandomizer);

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -95,6 +95,7 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 {
 	config = input;
 	guards.clear();
+	hasGuardsConfig = false;
 
 	resourceType = GameResID::NONE; //set up fallback
 	LIBRARY->identifiers()->requestIdentifierIfNotNull("resource", input["resource"], [&](si32 index)
@@ -113,9 +114,8 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 
 	if (config["guards"].getType() == JsonNode::JsonType::DATA_VECTOR)
 	{
-		JsonRandom randomizer(nullptr, CRandomGenerator::getDefault());
-		JsonRandom::Variables emptyVariables;
-		guards = randomizer.loadCreatures(config["guards"], emptyVariables);
+		hasGuardsConfig = true;
+		guards = config["guards"];
 	}
 }
 
@@ -144,9 +144,19 @@ AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const
 	return kingdomOverviewImage;
 }
 
-const std::vector<CStackBasicDescriptor> & MineInstanceConstructor::getGuards() const
+bool MineInstanceConstructor::hasGuards() const
 {
-	return guards;
+	return hasGuardsConfig;
+}
+
+std::vector<CStackBasicDescriptor> MineInstanceConstructor::getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const
+{
+	if (!hasGuardsConfig)
+		return {};
+
+	JsonRandom randomizer(cb, gameRandomizer);
+	JsonRandom::Variables emptyVariables;
+	return randomizer.loadCreatures(guards, emptyVariables);
 }
 
 void CTownInstanceConstructor::initTypeData(const JsonNode & input)

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -154,7 +154,7 @@ std::vector<CStackBasicDescriptor> MineInstanceConstructor::getGuards(const IGam
 	if (!hasGuardsConfig)
 		return {};
 
-	JsonRandom randomizer(cb, gameRandomizer);
+	JsonRandom randomizer(const_cast<IGameInfoCallback *>(cb), gameRandomizer);
 	JsonRandom::Variables emptyVariables;
 	return randomizer.loadCreatures(guards, emptyVariables);
 }

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -95,7 +95,6 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 {
 	config = input;
 	guards.clear();
-	hasGuardedMessageConfig = false;
 
 	resourceType = GameResID::NONE; //set up fallback
 	LIBRARY->identifiers()->requestIdentifierIfNotNull("resource", input["resource"], [&](si32 index)
@@ -110,10 +109,7 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 	if (!config["description"].isNull())
 		LIBRARY->generaltexth->registerString(config.getModScope(), getDescriptionTextID(), config["description"]);
 	if (!config["guardedMessage"].isNull())
-	{
-		hasGuardedMessageConfig = true;
 		LIBRARY->generaltexth->registerString(config.getModScope(), getGuardedMessageTextID(), config["guardedMessage"]);
-	}
 
 	kingdomOverviewImage = AnimationPath::fromJson(config["kingdomOverviewImage"]);
 
@@ -140,12 +136,9 @@ std::string MineInstanceConstructor::getDescriptionTextID() const
 
 std::string MineInstanceConstructor::getGuardedMessageTextID() const
 {
+	if (config["guardedMessage"].isNull())
+		return {};
 	return TextIdentifier(getBaseTextID(), "guardedMessage").get();
-}
-
-bool MineInstanceConstructor::hasGuardedMessage() const
-{
-	return hasGuardedMessageConfig;
 }
 
 std::string MineInstanceConstructor::getDescriptionTranslated() const
@@ -158,14 +151,9 @@ AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const
 	return kingdomOverviewImage;
 }
 
-bool MineInstanceConstructor::hasGuards() const
-{
-	return guards.getType() == JsonNode::JsonType::DATA_VECTOR;
-}
-
 std::vector<CStackBasicDescriptor> MineInstanceConstructor::getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const
 {
-	if (!hasGuards())
+	if (guards.getType() != JsonNode::JsonType::DATA_VECTOR)
 		return {};
 
 	JsonRandom randomizer(const_cast<IGameInfoCallback *>(cb), gameRandomizer);

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -94,6 +94,7 @@ void ResourceInstanceConstructor::randomizeObject(CGResource * object, IGameRand
 void MineInstanceConstructor::initTypeData(const JsonNode & input)
 {
 	config = input;
+	guards.clear();
 
 	resourceType = GameResID::NONE; //set up fallback
 	LIBRARY->identifiers()->requestIdentifierIfNotNull("resource", input["resource"], [&](si32 index)
@@ -109,6 +110,13 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 		LIBRARY->generaltexth->registerString(config.getModScope(), getDescriptionTextID(), config["description"]);
 
 	kingdomOverviewImage = AnimationPath::fromJson(config["kingdomOverviewImage"]);
+
+	if (config["guards"].getType() == JsonNode::JsonType::DATA_VECTOR)
+	{
+		JsonRandom randomizer(nullptr, CRandomGenerator::getDefault());
+		JsonRandom::Variables emptyVariables;
+		guards = randomizer.loadCreatures(config["guards"], emptyVariables);
+	}
 }
 
 GameResID MineInstanceConstructor::getResourceType() const
@@ -134,6 +142,11 @@ std::string MineInstanceConstructor::getDescriptionTranslated() const
 AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const
 {
 	return kingdomOverviewImage;
+}
+
+const std::vector<CStackBasicDescriptor> & MineInstanceConstructor::getGuards() const
+{
+	return guards;
 }
 
 void CTownInstanceConstructor::initTypeData(const JsonNode & input)

--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -96,6 +96,7 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 	config = input;
 	guards.clear();
 	hasGuardsConfig = false;
+	hasGuardedMessageConfig = false;
 
 	resourceType = GameResID::NONE; //set up fallback
 	LIBRARY->identifiers()->requestIdentifierIfNotNull("resource", input["resource"], [&](si32 index)
@@ -109,6 +110,11 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 
 	if (!config["description"].isNull())
 		LIBRARY->generaltexth->registerString(config.getModScope(), getDescriptionTextID(), config["description"]);
+	if (!config["guardedMessage"].isNull())
+	{
+		hasGuardedMessageConfig = true;
+		LIBRARY->generaltexth->registerString(config.getModScope(), getGuardedMessageTextID(), config["guardedMessage"]);
+	}
 
 	kingdomOverviewImage = AnimationPath::fromJson(config["kingdomOverviewImage"]);
 
@@ -132,6 +138,16 @@ ui32 MineInstanceConstructor::getDefaultQuantity() const
 std::string MineInstanceConstructor::getDescriptionTextID() const
 {
 	return TextIdentifier(getBaseTextID(), "description").get();
+}
+
+std::string MineInstanceConstructor::getGuardedMessageTextID() const
+{
+	return TextIdentifier(getBaseTextID(), "guardedMessage").get();
+}
+
+bool MineInstanceConstructor::hasGuardedMessage() const
+{
+	return hasGuardedMessageConfig;
 }
 
 std::string MineInstanceConstructor::getDescriptionTranslated() const

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -30,6 +30,8 @@ class CGCreature;
 class CGBoat;
 class CFaction;
 class CStackBasicDescriptor;
+class IGameInfoCallback;
+class IGameRandomizer;
 
 class CObstacleConstructor : public CDefaultObjectTypeHandler<CGObjectInstance>
 {
@@ -68,7 +70,8 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	GameResID resourceType;
 	ui32 defaultQuantity;
 	AnimationPath kingdomOverviewImage;
-	std::vector<CStackBasicDescriptor> guards;
+	JsonNode guards;
+	bool hasGuardsConfig = false;
 public:
 	void initTypeData(const JsonNode & input) override;
 
@@ -77,7 +80,8 @@ public:
 	std::string getDescriptionTextID() const;
 	std::string getDescriptionTranslated() const;
 	AnimationPath getKingdomOverviewImage() const;
-	const std::vector<CStackBasicDescriptor> & getGuards() const;
+	bool hasGuards() const;
+	std::vector<CStackBasicDescriptor> getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const;
 };
 
 class CTownInstanceConstructor : public CDefaultObjectTypeHandler<CGTownInstance>

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -72,12 +72,15 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	AnimationPath kingdomOverviewImage;
 	JsonNode guards;
 	bool hasGuardsConfig = false;
+	bool hasGuardedMessageConfig = false;
 public:
 	void initTypeData(const JsonNode & input) override;
 
 	GameResID getResourceType() const;
 	ui32 getDefaultQuantity() const;
 	std::string getDescriptionTextID() const;
+	std::string getGuardedMessageTextID() const;
+	bool hasGuardedMessage() const;
 	std::string getDescriptionTranslated() const;
 	AnimationPath getKingdomOverviewImage() const;
 	bool hasGuards() const;

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -71,7 +71,6 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	ui32 defaultQuantity;
 	AnimationPath kingdomOverviewImage;
 	JsonNode guards;
-	bool hasGuardedMessageConfig = false;
 public:
 	void initTypeData(const JsonNode & input) override;
 
@@ -79,10 +78,8 @@ public:
 	ui32 getDefaultQuantity() const;
 	std::string getDescriptionTextID() const;
 	std::string getGuardedMessageTextID() const;
-	bool hasGuardedMessage() const;
 	std::string getDescriptionTranslated() const;
 	AnimationPath getKingdomOverviewImage() const;
-	bool hasGuards() const;
 	std::vector<CStackBasicDescriptor> getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const;
 };
 

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -71,7 +71,6 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	ui32 defaultQuantity;
 	AnimationPath kingdomOverviewImage;
 	JsonNode guards;
-	bool hasGuardsConfig = false;
 	bool hasGuardedMessageConfig = false;
 public:
 	void initTypeData(const JsonNode & input) override;

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -68,6 +68,7 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	GameResID resourceType;
 	ui32 defaultQuantity;
 	AnimationPath kingdomOverviewImage;
+	std::vector<CStackBasicDescriptor> guards;
 public:
 	void initTypeData(const JsonNode & input) override;
 
@@ -76,6 +77,7 @@ public:
 	std::string getDescriptionTextID() const;
 	std::string getDescriptionTranslated() const;
 	AnimationPath getKingdomOverviewImage() const;
+	const std::vector<CStackBasicDescriptor> & getGuards() const;
 };
 
 class CTownInstanceConstructor : public CDefaultObjectTypeHandler<CGTownInstance>

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -98,8 +98,9 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 	{
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
-		if(!isAbandoned() && getResourceHandler()->hasGuards() && getResourceHandler()->hasGuardedMessage())
-			ynd.text.appendTextID(getResourceHandler()->getGuardedMessageTextID());
+		const auto guardedMessageTextID = getResourceHandler()->getGuardedMessageTextID();
+		if(!isAbandoned() && !guardedMessageTextID.empty())
+			ynd.text.appendTextID(guardedMessageTextID);
 		else
 			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187);
 		gameEvents.showBlockingDialog(this, &ynd);
@@ -111,13 +112,12 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 
 void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
-	const bool hasGuardsConfig = getResourceHandler()->hasGuards();
 	const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
-	const bool isGuardedFromConfig = hasGuardsConfig && !configuredGuards.empty();
+	const bool isGuardedFromConfig = !configuredGuards.empty();
 
 	if(isAbandoned())
 	{
-		if(hasGuardsConfig)
+		if(isGuardedFromConfig)
 		{
 			for(const auto & stack : configuredGuards)
 			{

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -108,12 +108,26 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 
 void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
+	const auto & configuredGuards = getResourceHandler()->getGuards();
+	const bool isGuardedFromConfig = !configuredGuards.empty();
+
 	if(isAbandoned())
 	{
-		//set guardians
-		int howManyGuards = gameRandomizer.getDefault().nextInt(abandonedMineGuards.minAmount, abandonedMineGuards.maxAmount);
-		auto guards = std::make_unique<CStackInstance>(cb, abandonedMineGuards.creature, howManyGuards);
-		putStack(SlotID(0), std::move(guards));
+		if(isGuardedFromConfig)
+		{
+			for(const auto & stack : configuredGuards)
+			{
+				auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
+				putStack(SlotID(stacksCount()), std::move(guards));
+			}
+		}
+		else
+		{
+			//set default abandoned mine guardians
+			int howManyGuards = gameRandomizer.getDefault().nextInt(abandonedMineGuards.minAmount, abandonedMineGuards.maxAmount);
+			auto guards = std::make_unique<CStackInstance>(cb, abandonedMineGuards.creature, howManyGuards);
+			putStack(SlotID(0), std::move(guards));
+		}
 
 		assert(!abandonedMineResources.empty());
 		if (!abandonedMineResources.empty())
@@ -128,6 +142,15 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 	}
 	else
 	{
+		if(isGuardedFromConfig)
+		{
+			for(const auto & stack : configuredGuards)
+			{
+				auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
+				putStack(SlotID(stacksCount()), std::move(guards));
+			}
+		}
+
 		if(getResourceHandler()->getResourceType() == GameResID::NONE) // fallback
 			producedResource = GameResID(getObjTypeIndex().getNum());
 		else

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -98,7 +98,10 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 	{
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
-		ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187); //TODO: alternative text for custom guards
+		if(!isAbandoned() && getResourceHandler()->hasGuards() && getResourceHandler()->hasGuardedMessage())
+			ynd.text.appendTextID(getResourceHandler()->getGuardedMessageTextID());
+		else
+			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187);
 		gameEvents.showBlockingDialog(this, &ynd);
 		return;
 	}

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -108,12 +108,13 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 
 void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
-	const auto & configuredGuards = getResourceHandler()->getGuards();
-	const bool isGuardedFromConfig = !configuredGuards.empty();
+	const bool hasGuardsConfig = getResourceHandler()->hasGuards();
+	const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
+	const bool isGuardedFromConfig = hasGuardsConfig && !configuredGuards.empty();
 
 	if(isAbandoned())
 	{
-		if(isGuardedFromConfig)
+		if(hasGuardsConfig)
 		{
 			for(const auto & stack : configuredGuards)
 			{

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -113,11 +113,10 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
 	const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
-	const bool isGuardedFromConfig = !configuredGuards.empty();
 
 	if(isAbandoned())
 	{
-		if(isGuardedFromConfig)
+		if(!configuredGuards.empty())
 		{
 			for(const auto & stack : configuredGuards)
 			{
@@ -146,7 +145,7 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 	}
 	else
 	{
-		if(isGuardedFromConfig)
+		if(!configuredGuards.empty())
 		{
 			for(const auto & stack : configuredGuards)
 			{


### PR DESCRIPTION
### Motivation

- Allow mines to specify guard stacks in JSON configuration so custom mods can define specific creatures and counts for guarded mines. 
- Preserve existing fallback behavior for abandoned and non-configured mines while enabling explicit guard configuration.

### Description

- Added a `guards` vector to `MineInstanceConstructor` and clear it on `initTypeData` to hold configured guard stacks. 
- Load `guards` from the JSON `guards` entry using `JsonRandom::loadCreatures` when the node is a data vector during `initTypeData`. 
- Exposed `getGuards()` accessor on `MineInstanceConstructor`. 
- Updated `CGMine::initObj` to populate mine stack instances from configured guards when present for both abandoned and normal mines, and retain the original random/fallback guard logic when not configured.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021c633e50832d922f5ba8827ed240)