### PR TITLE
Support configurable mine guards and custom guarded message for mines

### DIFF
--- a/lib/mapObjectConstructors/CommonConstructors.cpp
+++ b/lib/mapObjectConstructors/CommonConstructors.cpp
@@ -94,6 +94,7 @@ void ResourceInstanceConstructor::randomizeObject(CGResource * object, IGameRand
 void MineInstanceConstructor::initTypeData(const JsonNode & input)
 {
 	config = input;
+	guards.setType(JsonNode::JsonType::DATA_VECTOR);
 
 	resourceType = GameResID::NONE; //set up fallback
 	LIBRARY->identifiers()->requestIdentifierIfNotNull("resource", input["resource"], [&](si32 index)
@@ -107,8 +108,15 @@ void MineInstanceConstructor::initTypeData(const JsonNode & input)
 
 	if (!config["description"].isNull())
 		LIBRARY->generaltexth->registerString(config.getModScope(), getDescriptionTextID(), config["description"]);
+	if (!config["onGuardedMessage"].isNull())
+		LIBRARY->generaltexth->registerString(config.getModScope(), getOnGuardedMessageTextID(), config["onGuardedMessage"]);
 
 	kingdomOverviewImage = AnimationPath::fromJson(config["kingdomOverviewImage"]);
+
+	if (config["guards"].isVector())
+	{
+		guards = config["guards"];
+	}
 }
 
 GameResID MineInstanceConstructor::getResourceType() const
@@ -126,6 +134,18 @@ std::string MineInstanceConstructor::getDescriptionTextID() const
 	return TextIdentifier(getBaseTextID(), "description").get();
 }
 
+std::string MineInstanceConstructor::getOnGuardedMessageTextID() const
+{
+	return TextIdentifier(getBaseTextID(), "onGuardedMessage").get();
+}
+
+std::string MineInstanceConstructor::getOnGuardedMessageTranslated() const
+{
+	if (config["onGuardedMessage"].isNull())
+		return {};
+	return LIBRARY->generaltexth->translate(getOnGuardedMessageTextID());
+}
+
 std::string MineInstanceConstructor::getDescriptionTranslated() const
 {
 	return LIBRARY->generaltexth->translate(getDescriptionTextID());
@@ -134,6 +154,13 @@ std::string MineInstanceConstructor::getDescriptionTranslated() const
 AnimationPath MineInstanceConstructor::getKingdomOverviewImage() const
 {
 	return kingdomOverviewImage;
+}
+
+std::vector<CStackBasicDescriptor> MineInstanceConstructor::getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const
+{
+	JsonRandom randomizer(const_cast<IGameInfoCallback *>(cb), gameRandomizer);
+	JsonRandom::Variables emptyVariables;
+	return randomizer.loadCreatures(guards, emptyVariables);
 }
 
 void CTownInstanceConstructor::initTypeData(const JsonNode & input)

--- a/lib/mapObjectConstructors/CommonConstructors.h
+++ b/lib/mapObjectConstructors/CommonConstructors.h
@@ -30,6 +30,8 @@ class CGCreature;
 class CGBoat;
 class CFaction;
 class CStackBasicDescriptor;
+class IGameInfoCallback;
+class IGameRandomizer;
 
 class CObstacleConstructor : public CDefaultObjectTypeHandler<CGObjectInstance>
 {
@@ -68,14 +70,18 @@ class DLL_LINKAGE MineInstanceConstructor : public CDefaultObjectTypeHandler<CGM
 	GameResID resourceType;
 	ui32 defaultQuantity;
 	AnimationPath kingdomOverviewImage;
+	JsonNode guards;
 public:
 	void initTypeData(const JsonNode & input) override;
 
 	GameResID getResourceType() const;
 	ui32 getDefaultQuantity() const;
 	std::string getDescriptionTextID() const;
+	std::string getOnGuardedMessageTextID() const;
+	std::string getOnGuardedMessageTranslated() const;
 	std::string getDescriptionTranslated() const;
 	AnimationPath getKingdomOverviewImage() const;
+	std::vector<CStackBasicDescriptor> getGuards(const IGameInfoCallback * cb, IGameRandomizer & gameRandomizer) const;
 };
 
 class CTownInstanceConstructor : public CDefaultObjectTypeHandler<CGTownInstance>

--- a/lib/mapObjects/MiscObjects.cpp
+++ b/lib/mapObjects/MiscObjects.cpp
@@ -98,7 +98,11 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 	{
 		BlockingDialog ynd(true,false);
 		ynd.player = h->tempOwner;
-		ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187); //TODO: alternative text for custom guards
+		const auto guardedMessageTranslated = getResourceHandler()->getOnGuardedMessageTranslated();
+		if(!isAbandoned() && !guardedMessageTranslated.empty())
+			ynd.text.appendRawString(guardedMessageTranslated);
+		else
+			ynd.text.appendLocalString(EMetaText::ADVOB_TXT, isAbandoned() ? 84 : 187);
 		gameEvents.showBlockingDialog(this, &ynd);
 		return;
 	}
@@ -108,12 +112,25 @@ void CGMine::onHeroVisit(IGameEventCallback & gameEvents, const CGHeroInstance *
 
 void CGMine::initObj(IGameRandomizer & gameRandomizer)
 {
+	const auto configuredGuards = getResourceHandler()->getGuards(cb, gameRandomizer);
+
 	if(isAbandoned())
 	{
-		//set guardians
-		int howManyGuards = gameRandomizer.getDefault().nextInt(abandonedMineGuards.minAmount, abandonedMineGuards.maxAmount);
-		auto guards = std::make_unique<CStackInstance>(cb, abandonedMineGuards.creature, howManyGuards);
-		putStack(SlotID(0), std::move(guards));
+		if(!configuredGuards.empty())
+		{
+			for(const auto & stack : configuredGuards)
+			{
+				auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
+				putStack(SlotID(stacksCount()), std::move(guards));
+			}
+		}
+		else
+		{
+			//set default abandoned mine guardians
+			int howManyGuards = gameRandomizer.getDefault().nextInt(abandonedMineGuards.minAmount, abandonedMineGuards.maxAmount);
+			auto guards = std::make_unique<CStackInstance>(cb, abandonedMineGuards.creature, howManyGuards);
+			putStack(SlotID(0), std::move(guards));
+		}
 
 		assert(!abandonedMineResources.empty());
 		if (!abandonedMineResources.empty())
@@ -128,6 +145,15 @@ void CGMine::initObj(IGameRandomizer & gameRandomizer)
 	}
 	else
 	{
+		if(!configuredGuards.empty())
+		{
+			for(const auto & stack : configuredGuards)
+			{
+				auto guards = std::make_unique<CStackInstance>(cb, stack.getId(), stack.getCount());
+				putStack(SlotID(stacksCount()), std::move(guards));
+			}
+		}
+
 		if(getResourceHandler()->getResourceType() == GameResID::NONE) // fallback
 			producedResource = GameResID(getObjTypeIndex().getNum());
 		else


### PR DESCRIPTION
### Motivation
- Enable map/json-defined guard stacks for mines and a custom message shown when a hero encounters guarded mines so mods can override default guardian behavior and text.
- Preserve existing fallbacks so mines without custom configuration continue to use default guardians and legacy dialog text.

### Description
- Added a `guards` `JsonNode` to `MineInstanceConstructor`, set its type to `DATA_VECTOR`, and register an optional `onGuardedMessage` text id during `initTypeData` parsing.  
- Implemented `getOnGuardedMessageTextID`, `getOnGuardedMessageTranslated` and `getGuards(const IGameInfoCallback*, IGameRandomizer&)` in `MineInstanceConstructor`, where `getGuards` uses `JsonRandom` to produce a `std::vector<CStackBasicDescriptor>` from the JSON.  
- Updated `CGMine::initObj` to populate guard stacks from the configured `guards` when present for both abandoned and non-abandoned mines, falling back to the previous default guardian generation when `guards` is empty.  
- Updated `CGMine::onHeroVisit` to show the custom `onGuardedMessage` when available and not abandoned, otherwise falling back to the existing localized text flow.

### Testing
- Performed a full project build with `make` and the build completed successfully.  
- Ran the automated unit/integration test suite with `ctest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021c633e50832d922f5ba8827ed240)