### PR TITLE
CI: set Conan VS version for MSVC jobs

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -60,7 +60,6 @@ jobs:
           - platform: msvc-x64
             arch: x64
             toolset: '14.29'
-            vs_version: '18'
             os: windows-2025
             pack: 1
             upload: 0
@@ -69,13 +68,12 @@ jobs:
             preset: windows-msvc-ninja-release
             conan_profile: msvc-x64
             conan_prebuilts: dependencies-windows-x64
-            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh -o "&:target_pre_windows10=True"
+            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh -c tools.microsoft.msbuild:vs_version=18 -o "&:target_pre_windows10=True"
             artifact_platform: x64
 
           - platform: msvc-x86
             arch: amd64_x86
             toolset: '14.29'
-            vs_version: '18'
             os: windows-2025
             pack: 1
             upload: 0
@@ -84,12 +82,11 @@ jobs:
             preset: windows-msvc-ninja-release-x86
             conan_profile: msvc-x86
             conan_prebuilts: dependencies-windows-x86
-            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh -o "&:target_pre_windows10=True"
+            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh -c tools.microsoft.msbuild:vs_version=18 -o "&:target_pre_windows10=True"
             artifact_platform: x86
 
           - platform: msvc-arm64
             arch: arm64
-            vs_version: '18'
             os: windows-11-arm
             pack: 1
             upload: 0
@@ -98,7 +95,7 @@ jobs:
             preset: windows-msvc-ninja-release-arm64
             conan_profile: msvc-arm64
             conan_prebuilts: dependencies-windows-arm64
-            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh -o "&:lua_lib=lua"
+            conan_options: -s "&:build_type=RelWithDebInfo" -c tools.env.virtualenv:powershell=pwsh -c tools.microsoft.msbuild:vs_version=18 -o "&:lua_lib=lua"
             artifact_platform: arm64
 
           - platform: android-32
@@ -284,7 +281,6 @@ jobs:
           --build=never \
           --profile=dependencies/conan_profiles/${{ matrix.conan_profile }} \
           --conf="tools.cmake.cmaketoolchain:generator=Ninja" \
-          ${{ startsWith(matrix.platform, 'msvc') && format('--conf=tools.microsoft.msbuild:vs_version={0}', matrix.vs_version) || '' }} \
           ${{ matrix.conan_options }}
         ${{ startsWith(matrix.platform, 'msvc') && 'echo CONANRUN_PWSH_SCRIPT="$outFolder/conanrun.ps1" >> $GITHUB_ENV' || '' }}
 
@@ -717,7 +713,6 @@ jobs:
 
           - platform: msvc-arm64
             arch: arm64
-            vs_version: '18'
             os: windows-11-arm
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -284,7 +284,7 @@ jobs:
           --build=never \
           --profile=dependencies/conan_profiles/${{ matrix.conan_profile }} \
           --conf="tools.cmake.cmaketoolchain:generator=Ninja" \
-          ${{ startsWith(matrix.platform, "msvc") && format('--conf=\"tools.microsoft.msbuild:vs_version={0}\"', matrix.vs_version) || "" }} \
+          ${{ startsWith(matrix.platform, 'msvc') && format('--conf=tools.microsoft.msbuild:vs_version={0}', matrix.vs_version) || '' }} \
           ${{ matrix.conan_options }}
         ${{ startsWith(matrix.platform, 'msvc') && 'echo CONANRUN_PWSH_SCRIPT="$outFolder/conanrun.ps1" >> $GITHUB_ENV' || '' }}
 

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -60,6 +60,7 @@ jobs:
           - platform: msvc-x64
             arch: x64
             toolset: '14.29'
+            vs_version: '18'
             os: windows-2025
             pack: 1
             upload: 0
@@ -74,6 +75,7 @@ jobs:
           - platform: msvc-x86
             arch: amd64_x86
             toolset: '14.29'
+            vs_version: '18'
             os: windows-2025
             pack: 1
             upload: 0
@@ -87,6 +89,7 @@ jobs:
 
           - platform: msvc-arm64
             arch: arm64
+            vs_version: '18'
             os: windows-11-arm
             pack: 1
             upload: 0
@@ -281,6 +284,7 @@ jobs:
           --build=never \
           --profile=dependencies/conan_profiles/${{ matrix.conan_profile }} \
           --conf="tools.cmake.cmaketoolchain:generator=Ninja" \
+          ${{ startsWith(matrix.platform, "msvc") && format('--conf=\"tools.microsoft.msbuild:vs_version={0}\"', matrix.vs_version) || "" }} \
           ${{ matrix.conan_options }}
         ${{ startsWith(matrix.platform, 'msvc') && 'echo CONANRUN_PWSH_SCRIPT="$outFolder/conanrun.ps1" >> $GITHUB_ENV' || '' }}
 
@@ -713,6 +717,7 @@ jobs:
 
           - platform: msvc-arm64
             arch: arm64
+            vs_version: '18'
             os: windows-11-arm
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Motivation
- Conan on newer Windows runners detected MSVC toolset 19.5 (VS 2026) but the CI previously did not pass an explicit VS version, causing `ConanException: VS non-existing installation: Visual Studio 17` during `conan install`.

### Description
- Add `vs_version: '18'` to all MSVC build matrix entries (`msvc-x64`, `msvc-x86`, `msvc-arm64`) in `.github/workflows/github.yml`.
- Pass a conditional Conan configuration `--conf="tools.microsoft.msbuild:vs_version={matrix.vs_version}"` to `conan install` for MSVC platforms so Conan generates a toolchain matching the runner's VS installation.
- Keep non-MSVC platforms and other CI behaviour unchanged.

### Testing
- No automated tests were executed for this change; this is a CI-only configuration tweak and requires a GitHub Actions run to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036e786478832d90afdc91cfc0f3ab)