### PR TITLE
Make scenario tab background configurable and refactor options background generator

### DIFF
--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -1159,8 +1159,6 @@ SelectionTab::ListItem::ListItem(Point position)
 {
 	OBJECT_CONSTRUCTION;
 	pictureEmptyLine = std::make_shared<CPicture>(ImagePath::builtin("camcust"), Rect(25, 121, 349, 26), -8, -14);
-	pictureTextBackground = std::make_shared<CPicture>(ImagePath::builtin("SCSelTxtBck.png"), 13, -14);
-	pictureTextBackground->disable();
 	labelName = std::make_shared<CLabel>(LABEL_POS_X, 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, "", 185);
 	labelName->setAutoRedraw(false);
 	labelAmountOfPlayers = std::make_shared<CLabel>(8, 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
@@ -1189,7 +1187,6 @@ void SelectionTab::ListItem::updateItem(std::shared_ptr<ElementInfo> info, bool 
 		iconLossCondition->disable();
 		labelNumberOfCampaignMaps->disable();
 		labelName->disable();
-		pictureTextBackground->disable();
 		return;
 	}
 
@@ -1218,7 +1215,6 @@ void SelectionTab::ListItem::updateItem(std::shared_ptr<ElementInfo> info, bool 
 		}
 		labelName->setText(info->folderName);
 		labelName->setColor(color);
-		pictureTextBackground->disable();
 		return;
 	}
 
@@ -1267,8 +1263,4 @@ void SelectionTab::ListItem::updateItem(std::shared_ptr<ElementInfo> info, bool 
 	labelName->setText(info->name);
 	labelName->setColor(color);
 
-	if(info->name.empty())
-		pictureTextBackground->disable();
-	else
-		pictureTextBackground->enable();
 }

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -218,8 +218,6 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 	if(tabType != ESelectionScreen::campaignList)
 	{
 		scenarioTabConfigurable = std::make_shared<ScenarioTabConfigurable>(*this);
-		if(auto configurableBackground = scenarioTabConfigurable->backgroundWidget())
-			pos = configurableBackground->pos;
 		addChild(scenarioTabConfigurable.get(), false);
 		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
 

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -53,28 +53,6 @@
 #include "../../lib/json/JsonUtils.h"
 #include "../../lib/json/JsonNode.h"
 
-namespace
-{
-Rect getScenarioTabPositionFromConfig()
-{
-	const Rect fallback(0, 6, 800, 554);
-	const JsonNode config(JsonPath::builtin("config/widgets/scenarioTab.json"));
-
-	for(const auto & item : config["items"].Vector())
-	{
-		if(item["name"].String() != "background")
-			continue;
-
-		const auto image = ENGINE->renderHandler().loadImage(ImagePath::fromJson(item["image"]), EImageBlitMode::OPAQUE);
-		const auto x = item["position"]["x"].Integer();
-		const auto y = item["position"]["y"].Integer();
-		return Rect(x, y, image->width(), image->height());
-	}
-
-	return fallback;
-}
-}
-
 class ScenarioTabConfigurable : public InterfaceObjectConfigurable
 {
 public:
@@ -92,6 +70,11 @@ public:
 	std::shared_ptr<CLabel> mapSizeFilterLabel() const
 	{
 		return widget<CLabel>("labelMapSizes");
+	}
+
+	std::shared_ptr<CIntObject> backgroundWidget() const
+	{
+		return widget<CIntObject>("background");
 	}
 
 	void setMapSizeLabelVisible(bool visible) const
@@ -234,11 +217,11 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 
 	if(tabType != ESelectionScreen::campaignList)
 	{
-		pos = getScenarioTabPositionFromConfig();
-
 		scenarioTabConfigurable = std::make_shared<ScenarioTabConfigurable>(*this);
-		addChild(scenarioTabConfigurable.get(), false);
-		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
+		if(auto configurableBackground = scenarioTabConfigurable->backgroundWidget())
+			pos = configurableBackground->pos;
+		else
+			pos = Rect(0, 6, 800, 554); // fallback for broken json config
 
 		inputName = std::make_shared<CTextInput>(inputNameRect, Point(-32, -25), ImagePath::builtin("GSSTRIP.bmp"));
 		inputName->setFilterFilename();
@@ -254,6 +237,9 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 
 			buttonsSortBy.push_back(std::make_shared<CButton>(Point(xpos[i], 86), AnimationPath::builtin(sortIconNames[i]), LIBRARY->generaltexth->zelp[107 + i], std::bind(&SelectionTab::sortBy, this, criteria), sortShortcuts[i]));
 		}
+
+		addChild(scenarioTabConfigurable.get(), false);
+		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
 	}
 
 	int positionsToShow = 18;

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -53,6 +53,28 @@
 #include "../../lib/json/JsonUtils.h"
 #include "../../lib/json/JsonNode.h"
 
+namespace
+{
+Rect getScenarioTabPositionFromConfig()
+{
+	const Rect fallback(0, 6, 800, 554);
+	const JsonNode config(JsonPath::builtin("config/widgets/scenarioTab.json"));
+
+	for(const auto & item : config["items"].Vector())
+	{
+		if(item["name"].String() != "background")
+			continue;
+
+		const auto image = ENGINE->renderHandler().loadImage(ImagePath::fromJson(item["image"]), EImageBlitMode::OPAQUE);
+		const auto x = item["position"]["x"].Integer();
+		const auto y = item["position"]["y"].Integer();
+		return Rect(x, y, image->width(), image->height());
+	}
+
+	return fallback;
+}
+}
+
 class ScenarioTabConfigurable : public InterfaceObjectConfigurable
 {
 public:
@@ -70,11 +92,6 @@ public:
 	std::shared_ptr<CLabel> mapSizeFilterLabel() const
 	{
 		return widget<CLabel>("labelMapSizes");
-	}
-
-	std::shared_ptr<CIntObject> backgroundWidget() const
-	{
-		return widget<CIntObject>("background");
 	}
 
 	void setMapSizeLabelVisible(bool visible) const
@@ -217,13 +234,11 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 
 	if(tabType != ESelectionScreen::campaignList)
 	{
+		pos = getScenarioTabPositionFromConfig();
+
 		scenarioTabConfigurable = std::make_shared<ScenarioTabConfigurable>(*this);
 		addChild(scenarioTabConfigurable.get(), false);
 		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
-		if(auto configurableBackground = scenarioTabConfigurable->backgroundWidget())
-			pos = configurableBackground->pos;
-		else
-			pos = Rect(0, 6, 800, 554); // fallback for broken json config
 
 		inputName = std::make_shared<CTextInput>(inputNameRect, Point(-32, -25), ImagePath::builtin("GSSTRIP.bmp"));
 		inputName->setFilterFilename();

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -220,8 +220,6 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 		scenarioTabConfigurable = std::make_shared<ScenarioTabConfigurable>(*this);
 		if(auto configurableBackground = scenarioTabConfigurable->backgroundWidget())
 			pos = configurableBackground->pos;
-		else
-			pos = Rect(0, 6, 800, 554); // fallback for broken json config
 		addChild(scenarioTabConfigurable.get(), false);
 		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
 
@@ -1161,6 +1159,8 @@ SelectionTab::ListItem::ListItem(Point position)
 {
 	OBJECT_CONSTRUCTION;
 	pictureEmptyLine = std::make_shared<CPicture>(ImagePath::builtin("camcust"), Rect(25, 121, 349, 26), -8, -14);
+	pictureTextBackground = std::make_shared<CPicture>(ImagePath::builtin("SCSelTxtBck.png"), 13, -14);
+	pictureTextBackground->disable();
 	labelName = std::make_shared<CLabel>(LABEL_POS_X, 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE, "", 185);
 	labelName->setAutoRedraw(false);
 	labelAmountOfPlayers = std::make_shared<CLabel>(8, 0, FONT_SMALL, ETextAlignment::CENTER, Colors::WHITE);
@@ -1189,6 +1189,7 @@ void SelectionTab::ListItem::updateItem(std::shared_ptr<ElementInfo> info, bool 
 		iconLossCondition->disable();
 		labelNumberOfCampaignMaps->disable();
 		labelName->disable();
+		pictureTextBackground->disable();
 		return;
 	}
 
@@ -1217,6 +1218,7 @@ void SelectionTab::ListItem::updateItem(std::shared_ptr<ElementInfo> info, bool 
 		}
 		labelName->setText(info->folderName);
 		labelName->setColor(color);
+		pictureTextBackground->disable();
 		return;
 	}
 
@@ -1264,4 +1266,9 @@ void SelectionTab::ListItem::updateItem(std::shared_ptr<ElementInfo> info, bool 
 	}
 	labelName->setText(info->name);
 	labelName->setColor(color);
+
+	if(info->name.empty())
+		pictureTextBackground->disable();
+	else
+		pictureTextBackground->enable();
 }

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -72,6 +72,11 @@ public:
 		return widget<CLabel>("labelMapSizes");
 	}
 
+	std::shared_ptr<CIntObject> backgroundWidget() const
+	{
+		return widget<CIntObject>("background");
+	}
+
 	void setMapSizeLabelVisible(bool visible) const
 	{
 		if(auto label = mapSizeFilterLabel())
@@ -212,14 +217,16 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 
 	if(tabType != ESelectionScreen::campaignList)
 	{
-		background = std::make_shared<CPicture>(ImagePath::builtin("SCSELBCK.bmp"), 0, 6);
-		pos = background->pos;
-		inputName = std::make_shared<CTextInput>(inputNameRect, Point(-32, -25), ImagePath::builtin("GSSTRIP.bmp"));
-		inputName->setFilterFilename();
-
 		scenarioTabConfigurable = std::make_shared<ScenarioTabConfigurable>(*this);
 		addChild(scenarioTabConfigurable.get(), false);
 		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
+		if(auto configurableBackground = scenarioTabConfigurable->backgroundWidget())
+			pos = configurableBackground->pos;
+		else
+			pos = Rect(0, 6, 800, 554); // fallback for broken json config
+
+		inputName = std::make_shared<CTextInput>(inputNameRect, Point(-32, -25), ImagePath::builtin("GSSTRIP.bmp"));
+		inputName->setFilterFilename();
 
 		constexpr std::array xpos = {23, 55, 88, 121, 306, 339};
 		constexpr std::array sortIconNames = {"SCBUTT1.DEF", "SCBUTT2.DEF", "SCBUTCP.DEF", "SCBUTT3.DEF", "SCBUTT4.DEF", "SCBUTT5.DEF"};

--- a/client/lobby/SelectionTab.cpp
+++ b/client/lobby/SelectionTab.cpp
@@ -222,6 +222,8 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 			pos = configurableBackground->pos;
 		else
 			pos = Rect(0, 6, 800, 554); // fallback for broken json config
+		addChild(scenarioTabConfigurable.get(), false);
+		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
 
 		inputName = std::make_shared<CTextInput>(inputNameRect, Point(-32, -25), ImagePath::builtin("GSSTRIP.bmp"));
 		inputName->setFilterFilename();
@@ -238,8 +240,6 @@ SelectionTab::SelectionTab(ESelectionScreen Type)
 			buttonsSortBy.push_back(std::make_shared<CButton>(Point(xpos[i], 86), AnimationPath::builtin(sortIconNames[i]), LIBRARY->generaltexth->zelp[107 + i], std::bind(&SelectionTab::sortBy, this, criteria), sortShortcuts[i]));
 		}
 
-		addChild(scenarioTabConfigurable.get(), false);
-		scenarioTabConfigurable->setMapSizeLabelVisible(!CResourceHandler::get()->existsResource(AnimationPath::builtin("SCGTBUT.DEF")));
 	}
 
 	int positionsToShow = 18;

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -61,6 +61,7 @@ class SelectionTab : public CIntObject
 		std::shared_ptr<CAnimImage> iconVictoryCondition;
 		std::shared_ptr<CAnimImage> iconLossCondition;
 		std::shared_ptr<CPicture> pictureEmptyLine;
+		std::shared_ptr<CPicture> pictureTextBackground;
 		std::shared_ptr<CLabel> labelName;
 
 		const int LABEL_POS_X = 184;

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -123,7 +123,6 @@ public:
 	void restoreLastSelection();
 
 private:
-	std::shared_ptr<CPicture> background;
 	std::shared_ptr<CSlider> slider;
 	std::vector<std::shared_ptr<CButton>> buttonsSortBy;
 	std::shared_ptr<CLabel> labelTabTitle;

--- a/client/lobby/SelectionTab.h
+++ b/client/lobby/SelectionTab.h
@@ -61,7 +61,6 @@ class SelectionTab : public CIntObject
 		std::shared_ptr<CAnimImage> iconVictoryCondition;
 		std::shared_ptr<CAnimImage> iconLossCondition;
 		std::shared_ptr<CPicture> pictureEmptyLine;
-		std::shared_ptr<CPicture> pictureTextBackground;
 		std::shared_ptr<CLabel> labelName;
 
 		const int LABEL_POS_X = 184;

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -38,6 +38,7 @@ void AssetGenerator::initialize()
 
 	imageFiles[ImagePath::builtin("AdventureOptionsBackgroundClear.png")] = [this](){ return createAdventureOptionsCleanBackground();};
 	imageFiles[ImagePath::builtin("PlayerOptionsBackgroundClear.png")] = [this](){ return createPlayerOptionsCleanBackground();};
+	imageFiles[ImagePath::builtin("SCSelBckC.png")] = [this](){ return createScenarioSelectionBackgroundCampaign();};
 	imageFiles[ImagePath::builtin("SpellBookLarge.png")] = [this](){ return createBigSpellBook();};
 	imageFiles[ImagePath::builtin("MuPopUpCustom.png")] = [this](){ return createMuPopUpCustom();};
 
@@ -269,6 +270,20 @@ AssetGenerator::CanvasPtr AssetGenerator::createOptionsCleanBackground(bool with
 
 	return image;
 }
+
+AssetGenerator::CanvasPtr AssetGenerator::createScenarioSelectionBackgroundCampaign() const
+{
+	auto base = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("SCSelBck.bmp"), EImageBlitMode::OPAQUE));
+	auto camcust = ENGINE->renderHandler().loadImage(ImageLocator(ImagePath::builtin("CamCust.bmp"), EImageBlitMode::OPAQUE));
+
+	auto image = ENGINE->renderHandler().createImage(base->dimensions(), CanvasScalingPolicy::IGNORE);
+	auto canvas = image->getCanvas();
+	canvas.draw(base, Point(0, 0));
+	canvas.draw(camcust, Point(0, 0), Rect(3, 6, 402, 85));
+
+	return image;
+}
+
 AssetGenerator::CanvasPtr AssetGenerator::createBigSpellBook() const
 {
 	auto locator = ImageLocator(ImagePath::builtin("SpelBack"), EImageBlitMode::OPAQUE);

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -39,6 +39,7 @@ void AssetGenerator::initialize()
 	imageFiles[ImagePath::builtin("AdventureOptionsBackgroundClear.png")] = [this](){ return createAdventureOptionsCleanBackground();};
 	imageFiles[ImagePath::builtin("PlayerOptionsBackgroundClear.png")] = [this](){ return createPlayerOptionsCleanBackground();};
 	imageFiles[ImagePath::builtin("SCSelBckC.png")] = [this](){ return createScenarioSelectionBackgroundCampaign();};
+	imageFiles[ImagePath::builtin("SCSelTxtBck.png")] = [this](){ return createScenarioSelectionTextBackground();};
 	imageFiles[ImagePath::builtin("SpellBookLarge.png")] = [this](){ return createBigSpellBook();};
 	imageFiles[ImagePath::builtin("MuPopUpCustom.png")] = [this](){ return createMuPopUpCustom();};
 
@@ -332,6 +333,18 @@ AssetGenerator::CanvasPtr AssetGenerator::createBigSpellBook() const
 	canvas.draw(img, Point(481, 465), Rect(354, 406, 37, 41));
 	canvas.draw(img, Point(575, 465), Rect(417, 406, 37, 45));
 	canvas.draw(img, Point(667, 465), Rect(478, 406, 37, 47));
+
+	return image;
+}
+
+AssetGenerator::CanvasPtr AssetGenerator::createScenarioSelectionTextBackground() const
+{
+	auto locator = ImageLocator(ImagePath::builtin("SCSelBck"), EImageBlitMode::OPAQUE);
+	std::shared_ptr<IImage> base = ENGINE->renderHandler().loadImage(locator);
+
+	auto image = ENGINE->renderHandler().createImage(Point(135, 35), CanvasScalingPolicy::IGNORE);
+	Canvas canvas = image->getCanvas();
+	canvas.draw(base, Point(0, 0), Rect(21, 45, 135, 35));
 
 	return image;
 }

--- a/client/render/AssetGenerator.cpp
+++ b/client/render/AssetGenerator.cpp
@@ -37,6 +37,7 @@ void AssetGenerator::initialize()
 		boost::filesystem::remove_all(VCMIDirs::get().userDataPath() / "Generated");
 
 	imageFiles[ImagePath::builtin("AdventureOptionsBackgroundClear.png")] = [this](){ return createAdventureOptionsCleanBackground();};
+	imageFiles[ImagePath::builtin("PlayerOptionsBackgroundClear.png")] = [this](){ return createPlayerOptionsCleanBackground();};
 	imageFiles[ImagePath::builtin("SpellBookLarge.png")] = [this](){ return createBigSpellBook();};
 	imageFiles[ImagePath::builtin("MuPopUpCustom.png")] = [this](){ return createMuPopUpCustom();};
 
@@ -235,6 +236,17 @@ auto getColorFilters()
 
 AssetGenerator::CanvasPtr AssetGenerator::createAdventureOptionsCleanBackground() const
 {
+	return createOptionsCleanBackground(true);
+}
+
+
+AssetGenerator::CanvasPtr AssetGenerator::createPlayerOptionsCleanBackground() const
+{
+	return createOptionsCleanBackground(false);
+}
+
+AssetGenerator::CanvasPtr AssetGenerator::createOptionsCleanBackground(bool withPlayerOptionsColumns) const
+{
 	auto locator = ImageLocator(ImagePath::builtin("ADVOPTBK"), EImageBlitMode::OPAQUE);
 
 	std::shared_ptr<IImage> img = ENGINE->renderHandler().loadImage(locator);
@@ -243,16 +255,20 @@ AssetGenerator::CanvasPtr AssetGenerator::createAdventureOptionsCleanBackground(
 	Canvas canvas = image->getCanvas();
 
 	canvas.draw(img, Point(0, 0), Rect(0, 0, 575, 585));
-	canvas.draw(img, Point(54, 121), Rect(54, 123, 335, 1));
-	canvas.draw(img, Point(158, 84), Rect(156, 84, 2, 37));
-	canvas.draw(img, Point(234, 84), Rect(232, 84, 2, 37));
-	canvas.draw(img, Point(310, 84), Rect(308, 84, 2, 37));
+
+	if(withPlayerOptionsColumns)
+	{
+		canvas.draw(img, Point(54, 121), Rect(54, 123, 335, 1));
+		canvas.draw(img, Point(158, 84), Rect(156, 84, 2, 37));
+		canvas.draw(img, Point(234, 84), Rect(232, 84, 2, 37));
+		canvas.draw(img, Point(310, 84), Rect(308, 84, 2, 37));
+	}
+
 	canvas.draw(img, Point(53, 567), Rect(53, 520, 339, 3));
 	canvas.draw(img, Point(53, 520), Rect(53, 264, 339, 47));
 
 	return image;
 }
-
 AssetGenerator::CanvasPtr AssetGenerator::createBigSpellBook() const
 {
 	auto locator = ImageLocator(ImagePath::builtin("SpelBack"), EImageBlitMode::OPAQUE);

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -60,6 +60,7 @@ private:
 	CanvasPtr createAdventureOptionsCleanBackground() const;
 	CanvasPtr createPlayerOptionsCleanBackground() const;
 	CanvasPtr createOptionsCleanBackground(bool withPlayerOptionsColumns) const;
+	CanvasPtr createScenarioSelectionBackgroundCampaign() const;
 	CanvasPtr createBigSpellBook() const;
 	CanvasPtr createPlayerColoredBackground(const PlayerColor & player) const;
 	CanvasPtr createCombatUnitNumberWindow(float multR, float multG, float multB) const;

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -61,6 +61,7 @@ private:
 	CanvasPtr createPlayerOptionsCleanBackground() const;
 	CanvasPtr createOptionsCleanBackground(bool withPlayerOptionsColumns) const;
 	CanvasPtr createScenarioSelectionBackgroundCampaign() const;
+	CanvasPtr createScenarioSelectionTextBackground() const;
 	CanvasPtr createBigSpellBook() const;
 	CanvasPtr createPlayerColoredBackground(const PlayerColor & player) const;
 	CanvasPtr createCombatUnitNumberWindow(float multR, float multG, float multB) const;

--- a/client/render/AssetGenerator.h
+++ b/client/render/AssetGenerator.h
@@ -58,6 +58,8 @@ private:
 	std::map<AnimationPath, AnimationLayoutMap> animationFiles;
 
 	CanvasPtr createAdventureOptionsCleanBackground() const;
+	CanvasPtr createPlayerOptionsCleanBackground() const;
+	CanvasPtr createOptionsCleanBackground(bool withPlayerOptionsColumns) const;
 	CanvasPtr createBigSpellBook() const;
 	CanvasPtr createPlayerColoredBackground(const PlayerColor & player) const;
 	CanvasPtr createCombatUnitNumberWindow(float multR, float multG, float multB) const;

--- a/config/widgets/extraOptionsTab.json
+++ b/config/widgets/extraOptionsTab.json
@@ -6,7 +6,7 @@
 		{
 			"name": "background",
 			"type": "picture",
-			"image": "AdventureOptionsBackgroundClear",
+			"image": "PlayerOptionsBackgroundClear",
 			"position": {"x": 0, "y": 6}
 		},
 		{

--- a/config/widgets/scenarioTab.json
+++ b/config/widgets/scenarioTab.json
@@ -4,7 +4,7 @@
 		{
 			"name": "background",
 			"type": "picture",
-			"image": "PlayerOptionsBackgroundClear",
+			"image": "SCSelBckC",
 			"position": {"x": 0, "y": 6}
 		},
 		{

--- a/config/widgets/scenarioTab.json
+++ b/config/widgets/scenarioTab.json
@@ -2,6 +2,12 @@
 	"items":
 	[
 		{
+			"name": "background",
+			"type": "picture",
+			"image": "SCSelBck",
+			"position": {"x": 0, "y": 6}
+		},
+		{
 			"name": "labelMapSizes",
 			"type": "label",
 			"font": "small",

--- a/config/widgets/scenarioTab.json
+++ b/config/widgets/scenarioTab.json
@@ -4,7 +4,7 @@
 		{
 			"name": "background",
 			"type": "picture",
-			"image": "SCSelBckC",
+			"image": "SCSelBckC.png",
 			"position": {"x": 0, "y": 6}
 		},
 		{

--- a/config/widgets/scenarioTab.json
+++ b/config/widgets/scenarioTab.json
@@ -8,6 +8,12 @@
 			"position": {"x": 0, "y": 6}
 		},
 		{
+			"name": "labelMapSizesBackground",
+			"type": "picture",
+			"image": "SCSelTxtBck.png",
+			"position": {"x": 21, "y": 45}
+		},
+		{
 			"name": "labelMapSizes",
 			"type": "label",
 			"font": "small",

--- a/config/widgets/scenarioTab.json
+++ b/config/widgets/scenarioTab.json
@@ -4,7 +4,7 @@
 		{
 			"name": "background",
 			"type": "picture",
-			"image": "SCSelBck",
+			"image": "PlayerOptionsBackgroundClear",
 			"position": {"x": 0, "y": 6}
 		},
 		{


### PR DESCRIPTION
### Motivation

- Allow the scenario selection UI background to be defined by the widget JSON instead of being hardcoded in C++ and reduce duplicated drawing code for options backgrounds.

### Description

- Add a `background` picture entry to `config/widgets/scenarioTab.json` and expose it via `ScenarioTabConfigurable::backgroundWidget()` so the tab can obtain its layout from JSON.
- Remove the hardcoded `background` member from `SelectionTab` and use the configurable widget position to initialize `pos`, with a `Rect(0, 6, 800, 554)` fallback if the JSON entry is missing. `inputName` creation remains and is adjusted accordingly. 
- Refactor `AssetGenerator` by introducing `createOptionsCleanBackground(bool withPlayerOptionsColumns)` and `createPlayerOptionsCleanBackground()`, change `createAdventureOptionsCleanBackground()` to delegate to the shared implementation, and conditionally draw the player-options columns; register the generated image under `PlayerOptionsBackgroundClear.png`.
- Update `AssetGenerator.h` to declare the new functions and add the new image mapping in `AssetGenerator::initialize()`.

### Testing

- Project was built successfully after the changes with no compile errors. 
- The project's automated test suite and client UI smoke tests were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0397fba920832dabfc87d398e65e91)