### PR TITLE
Add pre-battle enemy-spell learning (Eagle Eye) and related bonuses

### DIFF
--- a/AI/Nullkiller/AIUtility.cpp
+++ b/AI/Nullkiller/AIUtility.cpp
@@ -411,14 +411,16 @@ double getArtifactBonusRelevance(const CGHeroInstance * hero, const std::shared_
 			if (bonus->subtype == BonusCustomSubtype::damageTypeMelee)
 				return veryRelevant * (1 - getArmyPercentageWithBonus(BonusType::SHOOTER));
 			return 0;
-		case BonusType::MANA_PERCENTAGE_REGENERATION:
-		case BonusType::MANA_REGENERATION:
-			return hero->hasSpellbook() ? relevant : notRelevant;
-		case BonusType::LEARN_BATTLE_SPELL_CHANCE:
-			return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT) ? relevant : notRelevant;
-		case BonusType::NO_DISTANCE_PENALTY:
-		case BonusType::NO_WALL_PENALTY:
-			return getArmyPercentageWithBonus(BonusType::SHOOTER) * veryRelevant;
+			case BonusType::MANA_PERCENTAGE_REGENERATION:
+			case BonusType::MANA_REGENERATION:
+				return hero->hasSpellbook() ? relevant : notRelevant;
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE:
+				return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT) ? relevant : notRelevant;
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE:
+				return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) ? relevant : notRelevant;
+			case BonusType::NO_DISTANCE_PENALTY:
+			case BonusType::NO_WALL_PENALTY:
+				return getArmyPercentageWithBonus(BonusType::SHOOTER) * veryRelevant;
 		case BonusType::SPELLS_OF_SCHOOL:
 			if (!hero->hasSpellbook())
 				return notRelevant;
@@ -494,10 +496,11 @@ int32_t getArtifactBonusScoreImpl(const std::shared_ptr<Bonus> & bonus)
 			return bonus->subtype.getNum() * 6000;
 		case BonusType::SPELL_DAMAGE:
 			return bonus->val * 120;
-		case BonusType::SIGHT_RADIUS:
-			return bonus->val * 1000;
-		case BonusType::LEARN_BATTLE_SPELL_CHANCE:
-			return 0; // irrelevant in gameplay
+			case BonusType::SIGHT_RADIUS:
+				return bonus->val * 1000;
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE:
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE:
+				return 0; // irrelevant in gameplay
 		case BonusType::STACK_HEALTH:
 			return bonus->val * 5000;
 		case BonusType::NO_DISTANCE_PENALTY:

--- a/AI/Nullkiller2/AIUtility.cpp
+++ b/AI/Nullkiller2/AIUtility.cpp
@@ -361,14 +361,16 @@ double getArtifactBonusRelevance(const CGHeroInstance * hero, const std::shared_
 			if (bonus->subtype == BonusCustomSubtype::damageTypeMelee)
 				return veryRelevant * (1 - getArmyPercentageWithBonus(BonusType::SHOOTER));
 			return 0;
-		case BonusType::MANA_PERCENTAGE_REGENERATION:
-		case BonusType::MANA_REGENERATION:
-			return hero->hasSpellbook() ? relevant : notRelevant;
-		case BonusType::LEARN_BATTLE_SPELL_CHANCE:
-			return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT) ? relevant : notRelevant;
-		case BonusType::NO_DISTANCE_PENALTY:
-		case BonusType::NO_WALL_PENALTY:
-			return getArmyPercentageWithBonus(BonusType::SHOOTER) * veryRelevant;
+			case BonusType::MANA_PERCENTAGE_REGENERATION:
+			case BonusType::MANA_REGENERATION:
+				return hero->hasSpellbook() ? relevant : notRelevant;
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE:
+				return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT) ? relevant : notRelevant;
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE:
+				return hero->hasBonusOfType(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) ? relevant : notRelevant;
+			case BonusType::NO_DISTANCE_PENALTY:
+			case BonusType::NO_WALL_PENALTY:
+				return getArmyPercentageWithBonus(BonusType::SHOOTER) * veryRelevant;
 		case BonusType::SPELLS_OF_SCHOOL:
 			if (!hero->hasSpellbook())
 				return notRelevant;
@@ -444,10 +446,11 @@ int32_t getArtifactBonusScoreImpl(const std::shared_ptr<Bonus> & bonus)
 			return bonus->subtype.getNum() * 6000;
 		case BonusType::SPELL_DAMAGE:
 			return bonus->val * 120;
-		case BonusType::SIGHT_RADIUS:
-			return bonus->val * 1000;
-		case BonusType::LEARN_BATTLE_SPELL_CHANCE:
-			return 0; // irrelevant in gameplay
+			case BonusType::SIGHT_RADIUS:
+				return bonus->val * 1000;
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE:
+			case BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE:
+				return 0; // irrelevant in gameplay
 		case BonusType::STACK_HEALTH:
 			return bonus->val * 5000;
 		case BonusType::NO_DISTANCE_PENALTY:

--- a/client/ClientNetPackVisitors.h
+++ b/client/ClientNetPackVisitors.h
@@ -64,6 +64,7 @@ public:
 	void visitNewStructures(NewStructures & pack) override;
 	void visitRazeStructures(RazeStructures & pack) override;
 	void visitSetAvailableCreatures(SetAvailableCreatures & pack) override;
+	void visitChangeSpells(ChangeSpells & pack) override;
 	void visitSetHeroesInTown(SetHeroesInTown & pack) override;
 	void visitHeroRecruited(HeroRecruited & pack) override;
 	void visitGiveHero(GiveHero & pack) override;

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -586,6 +586,19 @@ void ApplyClientNetPackVisitor::visitSetAvailableCreatures(SetAvailableCreatures
 	callInterfaceIfPresent(cl, p, &IGameEventsReceiver::availableCreaturesChanged, dw);
 }
 
+void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
+{
+	if(!pack.learn || pack.spells.empty())
+		return;
+
+	const auto * hero = cl.gameInfo().getHero(pack.hid);
+	if(!hero)
+		return;
+
+	callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
+		UIHelper::getEagleEyeInfoWindowText(*hero, pack.spells), UIHelper::getSpellsComponents(pack.spells), soundBase::soundID(0));
+}
+
 void ApplyClientNetPackVisitor::visitSetHeroesInTown(SetHeroesInTown & pack)
 {
 	const CGTownInstance * t = gs.getTown(pack.tid);

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -49,10 +49,7 @@
 #include "../lib/GameConstants.h"
 #include "../lib/CPlayerState.h"
 
-namespace
-{
-std::map<ObjectInstanceID, std::set<SpellID>> pendingBattleStartSpellLearnDialogs;
-}
+static std::map<ObjectInstanceID, std::set<SpellID>> pendingBattleStartSpellLearnDialogs;
 
 // TODO: as Tow suggested these template should all be part of CClient
 // This will require rework spectator interface properly though

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -595,6 +595,24 @@ void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
 	if(!hero)
 		return;
 
+	bool heroInBattle = false;
+	for(const auto & battlePtr : gs.currentBattles)
+	{
+		if(!battlePtr)
+			continue;
+
+		const auto * attackerHero = battlePtr->battleGetFightingHero(BattleSide::ATTACKER);
+		const auto * defenderHero = battlePtr->battleGetFightingHero(BattleSide::DEFENDER);
+		if((attackerHero && attackerHero->id == pack.hid) || (defenderHero && defenderHero->id == pack.hid))
+		{
+			heroInBattle = true;
+			break;
+		}
+	}
+
+	if(!heroInBattle)
+		return;
+
 	callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
 		UIHelper::getEagleEyeInfoWindowText(*hero, pack.spells), UIHelper::getSpellsComponents(pack.spells), soundBase::soundID(0));
 }

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -49,6 +49,11 @@
 #include "../lib/GameConstants.h"
 #include "../lib/CPlayerState.h"
 
+namespace
+{
+std::map<ObjectInstanceID, std::set<SpellID>> pendingBattleStartSpellLearnDialogs;
+}
+
 // TODO: as Tow suggested these template should all be part of CClient
 // This will require rework spectator interface properly though
 
@@ -611,7 +616,11 @@ void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
 	}
 
 	if(!heroInBattle)
+	{
+		auto & pendingSpells = pendingBattleStartSpellLearnDialogs[pack.hid];
+		pendingSpells.insert(pack.spells.begin(), pack.spells.end());
 		return;
+	}
 
 	callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
 		UIHelper::getEagleEyeInfoWindowText(*hero, pack.spells), UIHelper::getSpellsComponents(pack.spells), soundBase::soundID(0));
@@ -770,6 +779,27 @@ void ApplyFirstClientNetPackVisitor::visitBattleStart(BattleStart & pack)
 void ApplyClientNetPackVisitor::visitBattleStart(BattleStart & pack)
 {
 	cl.battleStarted(pack.battleID);
+
+	const auto tryShowPendingDialog = [this](const CGHeroInstance * hero)
+	{
+		if(!hero)
+			return;
+
+		auto pendingIt = pendingBattleStartSpellLearnDialogs.find(hero->id);
+		if(pendingIt == pendingBattleStartSpellLearnDialogs.end() || pendingIt->second.empty())
+			return;
+
+		callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
+			UIHelper::getEagleEyeInfoWindowText(*hero, pendingIt->second), UIHelper::getSpellsComponents(pendingIt->second), soundBase::soundID(0));
+		pendingBattleStartSpellLearnDialogs.erase(pendingIt);
+	};
+
+	const auto * battle = gs.getBattle(pack.battleID);
+	if(!battle)
+		return;
+
+	tryShowPendingDialog(battle->battleGetFightingHero(BattleSide::ATTACKER));
+	tryShowPendingDialog(battle->battleGetFightingHero(BattleSide::DEFENDER));
 }
 
 void ApplyFirstClientNetPackVisitor::visitBattleNextRound(BattleNextRound & pack)

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -49,8 +49,6 @@
 #include "../lib/GameConstants.h"
 #include "../lib/CPlayerState.h"
 
-static std::map<ObjectInstanceID, std::set<SpellID>> pendingBattleStartSpellLearnDialogs;
-
 // TODO: as Tow suggested these template should all be part of CClient
 // This will require rework spectator interface properly though
 
@@ -613,11 +611,10 @@ void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
 	}
 
 	if(!heroInBattle)
-	{
-		auto & pendingSpells = pendingBattleStartSpellLearnDialogs[pack.hid];
-		pendingSpells.insert(pack.spells.begin(), pack.spells.end());
 		return;
-	}
+
+	if(hero->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) <= 0)
+		return;
 
 	callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
 		UIHelper::getEagleEyeInfoWindowText(*hero, pack.spells), UIHelper::getSpellsComponents(pack.spells), soundBase::soundID(0));
@@ -776,27 +773,6 @@ void ApplyFirstClientNetPackVisitor::visitBattleStart(BattleStart & pack)
 void ApplyClientNetPackVisitor::visitBattleStart(BattleStart & pack)
 {
 	cl.battleStarted(pack.battleID);
-
-	const auto tryShowPendingDialog = [this](const CGHeroInstance * hero)
-	{
-		if(!hero)
-			return;
-
-		auto pendingIt = pendingBattleStartSpellLearnDialogs.find(hero->id);
-		if(pendingIt == pendingBattleStartSpellLearnDialogs.end() || pendingIt->second.empty())
-			return;
-
-		callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
-			UIHelper::getEagleEyeInfoWindowText(*hero, pendingIt->second), UIHelper::getSpellsComponents(pendingIt->second), soundBase::soundID(0));
-		pendingBattleStartSpellLearnDialogs.erase(pendingIt);
-	};
-
-	const auto * battle = gs.getBattle(pack.battleID);
-	if(!battle)
-		return;
-
-	tryShowPendingDialog(battle->battleGetFightingHero(BattleSide::ATTACKER));
-	tryShowPendingDialog(battle->battleGetFightingHero(BattleSide::DEFENDER));
 }
 
 void ApplyFirstClientNetPackVisitor::visitBattleNextRound(BattleNextRound & pack)

--- a/client/NetPacksClient.cpp
+++ b/client/NetPacksClient.cpp
@@ -117,6 +117,17 @@ void callBattleInterfaceIfPresentForBothSides(CClient & cl, const BattleID & bat
 	}
 }
 
+static void showEagleEyeLearnedSpellsDialog(CClient & cl, ObjectInstanceID heroId, const std::set<SpellID> & spells, PlayerColor player)
+{
+	if(spells.empty())
+		return;
+
+	const auto * hero = cl.gameInfo().getHero(heroId);
+	assert(hero);
+	callInterfaceIfPresent(cl, player, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
+		UIHelper::getEagleEyeInfoWindowText(*hero, spells), UIHelper::getSpellsComponents(spells), soundBase::soundID(0));
+}
+
 void ApplyClientNetPackVisitor::visitSetResources(SetResources & pack)
 {
 	//todo: inform on actual resource set transferred
@@ -595,29 +606,10 @@ void ApplyClientNetPackVisitor::visitChangeSpells(ChangeSpells & pack)
 	if(!hero)
 		return;
 
-	bool heroInBattle = false;
-	for(const auto & battlePtr : gs.currentBattles)
-	{
-		if(!battlePtr)
-			continue;
-
-		const auto * attackerHero = battlePtr->battleGetFightingHero(BattleSide::ATTACKER);
-		const auto * defenderHero = battlePtr->battleGetFightingHero(BattleSide::DEFENDER);
-		if((attackerHero && attackerHero->id == pack.hid) || (defenderHero && defenderHero->id == pack.hid))
-		{
-			heroInBattle = true;
-			break;
-		}
-	}
-
-	if(!heroInBattle)
-		return;
-
 	if(hero->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) <= 0)
 		return;
 
-	callInterfaceIfPresent(cl, hero->tempOwner, &CGameInterface::showInfoDialog, EInfoWindowMode::AUTO,
-		UIHelper::getEagleEyeInfoWindowText(*hero, pack.spells), UIHelper::getSpellsComponents(pack.spells), soundBase::soundID(0));
+	showEagleEyeLearnedSpellsDialog(cl, pack.hid, pack.spells, hero->tempOwner);
 }
 
 void ApplyClientNetPackVisitor::visitSetHeroesInTown(SetHeroesInTown & pack)
@@ -870,13 +862,7 @@ void ApplyClientNetPackVisitor::visitStacksInjured(StacksInjured & pack)
 
 void ApplyClientNetPackVisitor::visitBattleResultsApplied(BattleResultsApplied & pack)
 {
-	if(!pack.learnedSpells.spells.empty())
-	{
-		const auto * hero = cl.gameInfo().getHero(pack.learnedSpells.hid);
-		assert(hero);
-		callInterfaceIfPresent(cl, pack.victor, &CGameInterface::showInfoDialog, EInfoWindowMode::MODAL,
-			UIHelper::getEagleEyeInfoWindowText(*hero, pack.learnedSpells.spells), UIHelper::getSpellsComponents(pack.learnedSpells.spells), soundBase::soundID(0));
-	}
+	showEagleEyeLearnedSpellsDialog(cl, pack.learnedSpells.hid, pack.learnedSpells.spells, pack.victor);
 
 	if(!pack.movingArtifacts.empty())
 	{

--- a/config/bonuses.json
+++ b/config/bonuses.json
@@ -269,7 +269,19 @@
 		"blockDescriptionPropagation": true
 	},
 
+	"LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE":
+	{
+		"hidden": true,
+		"blockDescriptionPropagation": true
+	},
+
 	"LEARN_BATTLE_SPELL_LEVEL_LIMIT":
+	{
+		"hidden": true,
+		"blockDescriptionPropagation": true
+	},
+
+	"LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE":
 	{
 		"hidden": true,
 		"blockDescriptionPropagation": true

--- a/config/skills.json
+++ b/config/skills.json
@@ -331,12 +331,21 @@
 	"eagleEye" : {
 		"index" : 11,
 		"specialty" : [
-			"main"
+			"main",
+			"preBattle"
 		],
 		"base" : {
 			"effects" : {
 				"main" : {
 					"type" : "LEARN_BATTLE_SPELL_CHANCE",
+					"valueType" : "BASE_NUMBER"
+				},
+				"preBattle" : {
+					"type" : "LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE",
+					"valueType" : "BASE_NUMBER"
+				},
+				"preBattleLevel" : {
+					"type" : "LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE",
 					"valueType" : "BASE_NUMBER"
 				},
 				"val2" : {
@@ -348,18 +357,24 @@
 		"basic" : {
 			"effects" : {
 				"main" : { "val" : 40 },
+				"preBattle" : { "val" : 30 },
+				"preBattleLevel" : { "val" : 3 },
 				"val2" : { "val" : 2 }
 			}
 		},
 		"advanced" : {
 			"effects" : {
 				"main" : { "val" : 50 },
+				"preBattle" : { "val" : 40 },
+				"preBattleLevel" : { "val" : 4 },
 				"val2" : { "val" : 3 }
 			}
 		},
 		"expert" : {
 			"effects" : {
 				"main" : { "val" : 60 },
+				"preBattle" : { "val" : 50 },
+				"preBattleLevel" : { "val" : 5 },
 				"val2" : { "val" : 4 }
 			}
 		}

--- a/docs/modders/Bonus/Bonus_Types.md
+++ b/docs/modders/Bonus/Bonus_Types.md
@@ -233,6 +233,18 @@ Allows affected heroes to learn spell cast by enemy hero after battle
 
 - val: maximal level of spell that can be learned
 
+### LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE
+
+Determines chance for affected heroes to learn spells from enemy hero spellbook at battle start (before first turn)
+
+- val: chance to learn each spell, percentage
+
+### LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE
+
+Allows affected heroes to learn spells from enemy hero spellbook at battle start (before first turn)
+
+- val: maximal level of spell that can be learned
+
 ### LEARN_MEETING_SPELL_LIMIT
 
 Allows affected heroes to learn spells from each other during hero exchange

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -154,9 +154,7 @@ class JsonNode;
 	BONUS_NAME(THIEVES_GUILD_ACCESS) \
 	BONUS_NAME(LIMITED_SHOOTING_RANGE) /*limits range of shooting creatures, doesn't adjust any other mechanics (half vs full damage etc). val - range in hexes, additional info - optional new range for broken arrow mechanic */\
 	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE) /*skill-agnostic eagle eye chance. subtype = 0 - from enemy, 1 - TODO: from entire battlefield*/\
-	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) /*skill-agnostic eagle eye chance to learn enemy hero spells at battle start*/\
 	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT) /*skill-agnostic eagle eye limit, subtype - school (-1 for all), others TODO*/\
-	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) /*skill-agnostic eagle eye spell level limit to learn enemy hero spells at battle start*/\
 	BONUS_NAME(PERCENTAGE_DAMAGE_BOOST) /*skill-agnostic archery and offence, subtype is 0 for offence and 1 for archery*/\
 	BONUS_NAME(LEARN_MEETING_SPELL_LIMIT) /*skill-agnostic scholar, subtype is -1 for all, TODO for others (> 0)*/\
 	BONUS_NAME(ROUGH_TERRAIN_DISCOUNT) /*skill-agnostic pathfinding*/\
@@ -206,6 +204,8 @@ class JsonNode;
 	BONUS_NAME(DEITYOFFIRE) /* Controls special week */ \
 	BONUS_NAME(ON_COMBAT_EVENT) /* Allows triggering various effects on combat events */ \
 	BONUS_NAME(LONG_WEAPON) /* melee attack from one hex away (attacker-empty-victim), without retaliation */ \
+	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) /*skill-agnostic eagle eye chance to learn enemy hero spells at battle start*/\
+	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) /*skill-agnostic eagle eye spell level limit to learn enemy hero spells at battle start*/\
 
 	/* end of list */
 

--- a/lib/bonuses/BonusEnum.h
+++ b/lib/bonuses/BonusEnum.h
@@ -154,7 +154,9 @@ class JsonNode;
 	BONUS_NAME(THIEVES_GUILD_ACCESS) \
 	BONUS_NAME(LIMITED_SHOOTING_RANGE) /*limits range of shooting creatures, doesn't adjust any other mechanics (half vs full damage etc). val - range in hexes, additional info - optional new range for broken arrow mechanic */\
 	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE) /*skill-agnostic eagle eye chance. subtype = 0 - from enemy, 1 - TODO: from entire battlefield*/\
+	BONUS_NAME(LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE) /*skill-agnostic eagle eye chance to learn enemy hero spells at battle start*/\
 	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT) /*skill-agnostic eagle eye limit, subtype - school (-1 for all), others TODO*/\
+	BONUS_NAME(LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE) /*skill-agnostic eagle eye spell level limit to learn enemy hero spells at battle start*/\
 	BONUS_NAME(PERCENTAGE_DAMAGE_BOOST) /*skill-agnostic archery and offence, subtype is 0 for offence and 1 for archery*/\
 	BONUS_NAME(LEARN_MEETING_SPELL_LIMIT) /*skill-agnostic scholar, subtype is -1 for all, TODO for others (> 0)*/\
 	BONUS_NAME(ROUGH_TERRAIN_DISCOUNT) /*skill-agnostic pathfinding*/\

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -150,7 +150,7 @@ void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 		learnedSpells.learn = 1;
 		learnedSpells.hid = learner->id;
 
-		for(const auto & spellID : enemy->spells)
+		for(const auto & spellID : enemy->getSpellsInSpellbook())
 		{
 			const auto * spell = spellID.toSpell();
 			if (!spell)

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -134,6 +134,47 @@ void BattleFlowProcessor::tryPlaceMoats(const CBattleInfoCallback & battle)
 
 void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 {
+	const auto learnEnemySpellsAtBattleStart = [this](const CGHeroInstance * learner, const CGHeroInstance * enemy)
+	{
+		if (!learner || !enemy || !learner->hasSpellbook())
+			return;
+
+		const auto spellLevelLimit = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE)
+			? learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE)
+			: learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT);
+		const auto learnChance = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE);
+		if (spellLevelLimit <= 0 || learnChance <= 0)
+			return;
+
+		ChangeSpells learnedSpells;
+		learnedSpells.learn = 1;
+		learnedSpells.hid = learner->id;
+
+		for(const auto & spellID : enemy->spells)
+		{
+			const auto * spell = spellID.toSpell();
+			if (!spell)
+				continue;
+
+			if (spell->getLevel() > spellLevelLimit)
+				continue;
+
+			if (learner->spellbookContainsSpell(spellID))
+				continue;
+
+			if (gameHandler->getRandomGenerator().nextInt(99) >= learnChance)
+				continue;
+
+			learnedSpells.spells.insert(spellID);
+		}
+
+		if (!learnedSpells.spells.empty())
+			gameHandler->sendAndApply(learnedSpells);
+	};
+
+	learnEnemySpellsAtBattleStart(battle.battleGetFightingHero(BattleSide::ATTACKER), battle.battleGetFightingHero(BattleSide::DEFENDER));
+	learnEnemySpellsAtBattleStart(battle.battleGetFightingHero(BattleSide::DEFENDER), battle.battleGetFightingHero(BattleSide::ATTACKER));
+
 	tryPlaceMoats(battle);
 
 	gameHandler->turnTimerHandler->onBattleStart(battle.getBattle()->getBattleID());

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -137,7 +137,7 @@ void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 	const auto getLearnableEnemySpellsAtBattleStart = [this](const CGHeroInstance * learner, const CGHeroInstance * enemy)
 	{
 		std::set<SpellID> learnedSpells;
-		if (!learner || !enemy || !learner->hasSpellbook())
+		if (!learner || !enemy)
 			return learnedSpells;
 
 		const auto spellLevelLimit = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE)

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -134,21 +134,18 @@ void BattleFlowProcessor::tryPlaceMoats(const CBattleInfoCallback & battle)
 
 void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 {
-	const auto learnEnemySpellsAtBattleStart = [this](const CGHeroInstance * learner, const CGHeroInstance * enemy)
+	const auto getLearnableEnemySpellsAtBattleStart = [this](const CGHeroInstance * learner, const CGHeroInstance * enemy)
 	{
+		std::set<SpellID> learnedSpells;
 		if (!learner || !enemy || !learner->hasSpellbook())
-			return;
+			return learnedSpells;
 
 		const auto spellLevelLimit = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE)
 			? learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE)
 			: learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT);
 		const auto learnChance = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE);
 		if (spellLevelLimit <= 0 || learnChance <= 0)
-			return;
-
-		ChangeSpells learnedSpells;
-		learnedSpells.learn = 1;
-		learnedSpells.hid = learner->id;
+			return learnedSpells;
 
 		for(const auto & spellID : enemy->getSpellsInSpellbook())
 		{
@@ -165,15 +162,31 @@ void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 			if (gameHandler->getRandomGenerator().nextInt(99) >= learnChance)
 				continue;
 
-			learnedSpells.spells.insert(spellID);
+			learnedSpells.insert(spellID);
 		}
 
-		if (!learnedSpells.spells.empty())
-			gameHandler->sendAndApply(learnedSpells);
+		return learnedSpells;
 	};
 
-	learnEnemySpellsAtBattleStart(battle.battleGetFightingHero(BattleSide::ATTACKER), battle.battleGetFightingHero(BattleSide::DEFENDER));
-	learnEnemySpellsAtBattleStart(battle.battleGetFightingHero(BattleSide::DEFENDER), battle.battleGetFightingHero(BattleSide::ATTACKER));
+	const auto * attackerHero = battle.battleGetFightingHero(BattleSide::ATTACKER);
+	const auto * defenderHero = battle.battleGetFightingHero(BattleSide::DEFENDER);
+	const auto attackerLearnedSpells = getLearnableEnemySpellsAtBattleStart(attackerHero, defenderHero);
+	const auto defenderLearnedSpells = getLearnableEnemySpellsAtBattleStart(defenderHero, attackerHero);
+
+	const auto applyLearnedSpells = [this](const CGHeroInstance * learner, const std::set<SpellID> & learnedSpells)
+	{
+		if(!learner || learnedSpells.empty())
+			return;
+
+		ChangeSpells changedSpells;
+		changedSpells.learn = 1;
+		changedSpells.hid = learner->id;
+		changedSpells.spells = learnedSpells;
+		gameHandler->sendAndApply(changedSpells);
+	};
+
+	applyLearnedSpells(attackerHero, attackerLearnedSpells);
+	applyLearnedSpells(defenderHero, defenderLearnedSpells);
 
 	tryPlaceMoats(battle);
 

--- a/server/battles/BattleFlowProcessor.cpp
+++ b/server/battles/BattleFlowProcessor.cpp
@@ -137,7 +137,7 @@ void BattleFlowProcessor::onBattleStarted(const CBattleInfoCallback & battle)
 	const auto getLearnableEnemySpellsAtBattleStart = [this](const CGHeroInstance * learner, const CGHeroInstance * enemy)
 	{
 		std::set<SpellID> learnedSpells;
-		if (!learner || !enemy)
+		if (!learner || !enemy || !learner->hasSpellbook())
 			return learnedSpells;
 
 		const auto spellLevelLimit = learner->valOfBonuses(BonusType::LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE)


### PR DESCRIPTION
### Motivation
- Add support for heroes to learn enemy hero spells at the start of battle separately from in-battle learning. 
- Expose new pre-battle bonus types so skills and configuration can control pre-battle learning behavior and limits. 
- Wire the mechanic into the battle startup flow so learning happens before the fight begins.

### Description
- Added two new bonus enums: `LEARN_BATTLE_SPELL_CHANCE_PRE_BATTLE` and `LEARN_BATTLE_SPELL_LEVEL_LIMIT_PRE_BATTLE` in `BonusEnum.h` with explanatory comments. 
- Added hidden bonus definitions for the two new pre-battle bonuses in `config/bonuses.json` with `blockDescriptionPropagation` set. 
- Extended the `eagleEye` skill in `config/skills.json` to include `preBattle` chance and `preBattleLevel` effects and populated values for `basic`, `advanced`, and `expert` tiers. 
- Implemented pre-battle learning logic in `BattleFlowProcessor::onBattleStarted` to check hero bonuses, respect level limits and chance, avoid duplicates, and apply learned spells via `ChangeSpells` before battle begins.

### Testing
- Performed a project build to ensure compilation with the new enum and battle flow changes, which completed successfully. 
- Exercised the battle startup flow to validate the pre-battle learning path is executed and applies `ChangeSpells` when conditions are met. 
- Ran the existing automated test suite (unit/integration) against the build; no regressions were observed and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ca709c2c832da6ea73a20ddb37a7)