### PR TITLE
Make statistic windows optionally skip player colorization and switch background to indexed texture

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1924,5 +1924,5 @@ void CPlayerInterface::unregisterBattleInterface(std::shared_ptr<CBattleGameInte
 
 void CPlayerInterface::responseStatistic(StatisticDataSet & statistic)
 {
-	ENGINE->windows().createAndPushWindow<CStatisticScreen>(statistic);
+	ENGINE->windows().createAndPushWindow<CStatisticScreen>(statistic, false);
 }

--- a/client/mainmenu/CStatisticScreen.cpp
+++ b/client/mainmenu/CStatisticScreen.cpp
@@ -43,13 +43,14 @@ std::string CStatisticScreen::getDay(int d)
 	return std::to_string(CGameState::getDate(d, Date::MONTH)) + "/" + std::to_string(CGameState::getDate(d, Date::WEEK)) + "/" + std::to_string(CGameState::getDate(d, Date::DAY_OF_WEEK));
 }
 
-CStatisticScreen::CStatisticScreen(const StatisticDataSet & stat)
-	: CWindowObject(BORDERED), statistic(stat)
+CStatisticScreen::CStatisticScreen(const StatisticDataSet & stat, bool colorizeBackground)
+	: CWindowObject(BORDERED), statistic(stat), colorizeBackground(colorizeBackground)
 {
 	OBJECT_CONSTRUCTION;
 	pos = center(Rect(0, 0, 800, 600));
-	filledBackground = std::make_shared<FilledTexturePlayerColored>(Rect(0, 0, pos.w, pos.h));
-	filledBackground->setPlayerColor(PlayerColor(1));
+	filledBackground = std::make_shared<FilledTexturePlayerIndexed>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, pos.w, pos.h));
+	if(colorizeBackground)
+		filledBackground->setPlayerColor(PlayerColor(1));
 
 	contentArea = Rect(10, 40, 780, 510);
 	layout.emplace_back(std::make_shared<CLabel>(400, 20, FONT_BIG, ETextAlignment::CENTER, Colors::YELLOW, LIBRARY->generaltexth->translate("vcmi.statisticWindow.statistics")));
@@ -87,9 +88,9 @@ void CStatisticScreen::onSelectButton()
 			{
 				OBJECT_CONSTRUCTION;
 				mainContent = getContent(content, possibleRes[index]);
-			});
+			}, colorizeBackground);
 		}
-	});
+	}, colorizeBackground);
 }
 
 TData CStatisticScreen::extractData(const StatisticDataSet & stat, const ExtractFunctor & selector) const
@@ -221,13 +222,14 @@ std::shared_ptr<CIntObject> CStatisticScreen::getContent(Content c, EGameResID r
 	return nullptr;
 }
 
-StatisticSelector::StatisticSelector(const std::vector<std::string> & texts, const std::function<void(int selectedIndex)> & cb)
+StatisticSelector::StatisticSelector(const std::vector<std::string> & texts, const std::function<void(int selectedIndex)> & cb, bool colorizeBackground)
 	: CWindowObject(BORDERED | NEEDS_ANIMATED_BACKGROUND), texts(texts), cb(cb)
 {
 	OBJECT_CONSTRUCTION;
 	pos = center(Rect(0, 0, 128 + 16, std::min(static_cast<int>(texts.size()), LINES) * 40));
-	filledBackground = std::make_shared<FilledTexturePlayerColored>(Rect(0, 0, pos.w, pos.h));
-	filledBackground->setPlayerColor(PlayerColor(1));
+	filledBackground = std::make_shared<FilledTexturePlayerIndexed>(ImagePath::builtin("DIBOXBCK"), Rect(0, 0, pos.w, pos.h));
+	if(colorizeBackground)
+		filledBackground->setPlayerColor(PlayerColor(1));
 
 	slider = std::make_shared<CSlider>(Point(pos.w - 16, 0), pos.h, [this](int to){ update(to); redraw(); }, LINES, texts.size(), 0, Orientation::VERTICAL, CSlider::BLUE);
 	slider->setPanningStep(40);

--- a/client/mainmenu/CStatisticScreen.h
+++ b/client/mainmenu/CStatisticScreen.h
@@ -11,7 +11,7 @@
 #include "../windows/CWindowObject.h"
 #include "../../lib/gameState/GameStatistics.h"
 
-class FilledTexturePlayerColored;
+class FilledTexturePlayerIndexed;
 class CButton;
 class GraphicalPrimitiveCanvas;
 class LineChart;
@@ -58,7 +58,8 @@ class CStatisticScreen : public CWindowObject
 		{ CHART_MAP_EXPLORED,              { "vcmi.statisticWindow.title.mapExplored",             false } },
 	};
 
-	std::shared_ptr<FilledTexturePlayerColored> filledBackground;
+	std::shared_ptr<FilledTexturePlayerIndexed> filledBackground;
+	bool colorizeBackground;
 	std::vector<std::shared_ptr<CIntObject>> layout;
 	std::shared_ptr<CButton> buttonCsvSave;
 	std::shared_ptr<CButton> buttonSelect;
@@ -72,13 +73,13 @@ class CStatisticScreen : public CWindowObject
 	std::shared_ptr<CIntObject> getContent(Content c, EGameResID res);
 	void onSelectButton();
 public:
-	CStatisticScreen(const StatisticDataSet & stat);
+	CStatisticScreen(const StatisticDataSet & stat, bool colorizeBackground = true);
 	static std::string getDay(int day);
 };
 
 class StatisticSelector : public CWindowObject
 {
-	std::shared_ptr<FilledTexturePlayerColored> filledBackground;
+	std::shared_ptr<FilledTexturePlayerIndexed> filledBackground;
 	std::vector<std::shared_ptr<CButton>> buttons;
 	std::shared_ptr<CSlider> slider;
 
@@ -89,7 +90,7 @@ class StatisticSelector : public CWindowObject
 
 	void update(int to);
 public:
-	StatisticSelector(const std::vector<std::string> & texts, const std::function<void(int selectedIndex)> & cb);
+	StatisticSelector(const std::vector<std::string> & texts, const std::function<void(int selectedIndex)> & cb, bool colorizeBackground);
 };
 
 class OverviewPanel : public CIntObject


### PR DESCRIPTION
### Motivation
- Allow opening the statistics window without applying player color tint (useful when invoked from contexts like battle UI).
- Standardize background rendering by using an indexed background texture rather than the old player-colored filled texture.
- Propagate the optional colorization choice to nested selectors so all statistic-related windows behave consistently.

### Description
- Changed `CStatisticScreen` constructor to `CStatisticScreen(const StatisticDataSet & stat, bool colorizeBackground = true)` and added a `bool colorizeBackground` member.
- Replaced `FilledTexturePlayerColored` with `FilledTexturePlayerIndexed` for the window background and only call `setPlayerColor(PlayerColor(1))` when `colorizeBackground` is true.
- Updated `StatisticSelector` to accept the `colorizeBackground` flag and apply the same background behavior, and passed the flag when creating selectors from `CStatisticScreen`.
- Modified `CPlayerInterface::responseStatistic` to open the statistics window with `colorizeBackground` set to `false`.
- Updated relevant header declarations to reflect the new constructor signatures and member types.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16ae415df0832db1563a1ce17122a3)