### PR TITLE
Support multiple native terrains and replace getNativeTerrain() with isNativeTerrain(TerrainId)

### DIFF
--- a/AI/Nullkiller2/Analyzers/ArmyManager.cpp
+++ b/AI/Nullkiller2/Analyzers/ArmyManager.cpp
@@ -139,15 +139,17 @@ std::vector<SlotInfo>::iterator ArmyManager::getBestUnitForScout(std::vector<Slo
 
 		if (terrainHasPenalty)
 		{
-			auto leftNativeTerrain = left.creature->getFactionID().toFaction()->nativeTerrain;
-			auto rightNativeTerrain = right.creature->getFactionID().toFaction()->nativeTerrain;
+			const auto leftFaction = left.creature->getFactionID().toFaction();
+			const auto rightFaction = right.creature->getFactionID().toFaction();
+			const bool leftIsNative = leftFaction->isNativeTerrain(armyTerrain);
+			const bool rightIsNative = rightFaction->isNativeTerrain(armyTerrain);
 
-			if (leftNativeTerrain != rightNativeTerrain)
+			if (leftIsNative != rightIsNative)
 			{
-				if (leftNativeTerrain == armyTerrain)
+				if (leftIsNative)
 					return true;
 
-				if (rightNativeTerrain == armyTerrain)
+				if (rightIsNative)
 					return false;
 			}
 		}

--- a/config/schemas/faction.json
+++ b/config/schemas/faction.json
@@ -57,7 +57,16 @@
 			"description" : "Faction alignment, good, neutral or evil"
 		},
 		"nativeTerrain" : {
-			"type" : "string",
+			"oneOf" : [
+				{
+					"type" : "string"
+				},
+				{
+					"type" : "array",
+					"items" : { "type" : "string" },
+					"minItems" : 1
+				}
+			],
 			"description" : "Native terrain for creatures. Creatures fighting on native terrain receive several bonuses"
 		},
 		"boat" : {

--- a/docs/modders/Entities_Format/Faction_Format.md
+++ b/docs/modders/Entities_Format/Faction_Format.md
@@ -55,8 +55,9 @@ Each town requires a set of buildings (Around 30-45 buildings)
 	// Optional but it should be present for playable faction
 	"town" : { ... },
 
-	// Native terrain for creatures. Creatures fighting on native terrain receive several bonuses
-	"nativeTerrain" : "grass",
+	// Native terrain for creatures. Can be single value or array.
+	// Creatures fighting on native terrain receive several bonuses
+	"nativeTerrain" : ["grass", "plateau"],
 
 	// Localizable faction name, e.g. "Rampart"
 	"name" : "", 

--- a/include/vcmi/Entity.h
+++ b/include/vcmi/Entity.h
@@ -25,9 +25,8 @@ public:
 class DLL_LINKAGE INativeTerrainProvider
 {
 public:
-	virtual TerrainId getNativeTerrain() const = 0;
 	virtual FactionID getFactionID() const = 0;
-	virtual bool isNativeTerrain(TerrainId terrain) const;
+	virtual bool isNativeTerrain(TerrainId terrain) const = 0;
 };
 
 class DLL_LINKAGE Entity : boost::noncopyable

--- a/include/vcmi/FactionMember.h
+++ b/include/vcmi/FactionMember.h
@@ -20,10 +20,7 @@ class PrimarySkill;
 class DLL_LINKAGE AFactionMember: public IConstBonusProvider, public INativeTerrainProvider
 {
 public:
-	/**
-	 Returns native terrain considering some terrain bonuses.
-	*/
-	virtual TerrainId getNativeTerrain() const;
+	bool isNativeTerrain(TerrainId terrain) const override;
 	/**
 	 Returns magic resistance considering some bonuses.
 	*/

--- a/lib/BasicTypes.cpp
+++ b/lib/BasicTypes.cpp
@@ -24,18 +24,9 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-bool INativeTerrainProvider::isNativeTerrain(TerrainId terrain) const
+bool AFactionMember::isNativeTerrain(TerrainId terrain) const
 {
-	auto native = getNativeTerrain();
-	return native == terrain || native == ETerrainId::ANY_TERRAIN;
-}
-
-TerrainId AFactionMember::getNativeTerrain() const
-{
-	//this code is used in the TerrainLimiter::limit to setup battle bonuses
-	//and in the CGHeroInstance::getNativeTerrain() to setup movement bonuses or/and penalties.
-	return getBonusBearer()->hasBonusOfType(BonusType::TERRAIN_NATIVE)
-			 ? TerrainId::ANY_TERRAIN : getFactionID().toEntity(LIBRARY)->getNativeTerrain();
+	return getBonusBearer()->hasBonusOfType(BonusType::TERRAIN_NATIVE) || getFactionID().toEntity(LIBRARY)->isNativeTerrain(terrain);
 }
 
 int32_t AFactionMember::magicResistance() const

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -281,8 +281,7 @@ bool CStack::canBeHealed() const
 
 bool CStack::isOnNativeTerrain() const
 {
-	auto nativeTerrain = getNativeTerrain();
-	return nativeTerrain == ETerrainId::ANY_TERRAIN || getCurrentTerrain() == nativeTerrain;
+	return isNativeTerrain(getCurrentTerrain());
 }
 
 TerrainId CStack::getCurrentTerrain() const

--- a/lib/bonuses/Limiters.cpp
+++ b/lib/bonuses/Limiters.cpp
@@ -327,8 +327,7 @@ ILimiter::EDecision TerrainLimiter::limit(const BonusLimitationContext &context)
 			return ILimiter::EDecision::NOT_SURE;
 
 		const auto * node = dynamic_cast<const INativeTerrainProvider *>(&context.node);
-		auto nativeTerrain = node->getFactionID().toEntity(LIBRARY)->getNativeTerrain();
-		return currentTerrain == nativeTerrain ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;
+		return node->getFactionID().toEntity(LIBRARY)->isNativeTerrain(currentTerrain) ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;
 	}
 
 	return currentTerrain == terrainType ? ILimiter::EDecision::ACCEPT : ILimiter::EDecision::DISCARD;

--- a/lib/entities/faction/CFaction.cpp
+++ b/lib/entities/faction/CFaction.cpp
@@ -106,9 +106,9 @@ BoatId CFaction::getBoatType() const
 	return boatType;
 }
 
-TerrainId CFaction::getNativeTerrain() const
+bool CFaction::isNativeTerrain(TerrainId terrain) const
 {
-	return nativeTerrain;
+	return vstd::contains(nativeTerrains, terrain);
 }
 
 void CFaction::updateFrom(const JsonNode & data)

--- a/lib/entities/faction/CFaction.h
+++ b/lib/entities/faction/CFaction.h
@@ -42,7 +42,7 @@ class DLL_LINKAGE CFaction : public Faction
 	FactionID getFactionID() const override; //This function should not be used
 
 public:
-	TerrainId nativeTerrain;
+	std::vector<TerrainId> nativeTerrains;
 	EAlignment alignment = EAlignment::NEUTRAL;
 	bool preferUndergroundPlacement = false;
 	bool special = false;
@@ -74,7 +74,7 @@ public:
 	std::string getDescriptionTextID() const;
 
 	bool hasTown() const override;
-	TerrainId getNativeTerrain() const override;
+	bool isNativeTerrain(TerrainId terrain) const override;
 	EAlignment getAlignment() const override;
 	BoatId getBoatType() const override;
 

--- a/lib/entities/faction/CTownHandler.cpp
+++ b/lib/entities/faction/CTownHandler.cpp
@@ -753,7 +753,36 @@ void CTownHandler::loadPuzzle(CFaction &faction, const JsonNode &source) const
 
 		faction.puzzleMap.push_back(spi);
 	}
-	assert(faction.puzzleMap.size() == GameConstants::PUZZLE_MAP_PIECES);
+assert(faction.puzzleMap.size() == GameConstants::PUZZLE_MAP_PIECES);
+}
+
+static std::vector<JsonNode> getNativeTerrainEntries(const JsonNode & nativeTerrainConfig)
+{
+	if (nativeTerrainConfig.getType() == JsonNode::JsonType::DATA_VECTOR)
+		return nativeTerrainConfig.Vector();
+
+	return {nativeTerrainConfig};
+}
+
+static void loadNativeTerrains(const JsonNode & nativeTerrainConfig, const std::shared_ptr<CFaction> & faction)
+{
+	faction->nativeTerrains.clear();
+
+	if (nativeTerrainConfig.isNull())
+		return;
+
+	for (const auto & terrainIdentifier : getNativeTerrainEntries(nativeTerrainConfig))
+	{
+		// Explicit "none" means "no native terrain".
+		if (terrainIdentifier.String() == "none")
+			continue;
+
+		LIBRARY->identifiers()->requestIdentifier("terrain", terrainIdentifier, [=](int32_t index)
+		{
+			auto terrainId = TerrainId(index);
+			faction->nativeTerrains.push_back(terrainId);
+		});
+	}
 }
 
 std::shared_ptr<CFaction> CTownHandler::loadFromJson(const std::string & scope, const JsonNode & source, const std::string & identifier, size_t index)
@@ -791,17 +820,9 @@ std::shared_ptr<CFaction> CTownHandler::loadFromJson(const std::string & scope, 
 	faction->preferUndergroundPlacement = preferUndergound.isNull() ? false : preferUndergound.Bool();
 	faction->special = source["special"].Bool();
 
-	// NOTE: semi-workaround - normally, towns are supposed to have native terrains.
-	// Towns without one are exceptions. So, vcmi requires nativeTerrain to be defined
-	// But allows it to be defined with explicit value of "none" if town should not have native terrain
-	// This is better than allowing such terrain-less towns silently, leading to issues with RMG
-	faction->nativeTerrain = ETerrainId::NONE;
-	if (!source["nativeTerrain"].isNull() && source["nativeTerrain"].String() != "none")
-	{
-		LIBRARY->identifiers()->requestIdentifier("terrain", source["nativeTerrain"], [=](int32_t index){
-			faction->nativeTerrain = TerrainId(index);
-		});
-	}
+	// NOTE: normally, towns are expected to have native terrains.
+	// "none" results in an empty nativeTerrains vector.
+	loadNativeTerrains(source["nativeTerrain"], faction);
 
 	if (!source["town"].isNull())
 	{

--- a/lib/mapObjects/CGHeroInstance.cpp
+++ b/lib/mapObjects/CGHeroInstance.cpp
@@ -90,20 +90,12 @@ const IBonusBearer* CGHeroInstance::getBonusBearer() const
 	return this;
 }
 
-TerrainId CGHeroInstance::getNativeTerrain() const
+bool CGHeroInstance::isNativeTerrain(TerrainId terrain) const
 {
-	TerrainId nativeTerrain = ETerrainId::ANY_TERRAIN;
-
 	for(const auto & stack : stacks)
-	{
-		TerrainId stackNativeTerrain = stack.second->getNativeTerrain(); //consider terrain bonuses e.g. Lodestar.
-
-		if(nativeTerrain == ETerrainId::ANY_TERRAIN)
-			nativeTerrain = stackNativeTerrain;
-		else if(nativeTerrain != stackNativeTerrain)
-			return ETerrainId::NONE;
-	}
-	return nativeTerrain;
+		if(!stack.second->isNativeTerrain(terrain))
+			return false;
+	return true;
 }
 
 bool CGHeroInstance::isCoastVisitable() const

--- a/lib/mapObjects/CGHeroInstance.h
+++ b/lib/mapObjects/CGHeroInstance.h
@@ -172,7 +172,7 @@ public:
 
 	//INativeTerrainProvider
 	FactionID getFactionID() const override;
-	TerrainId getNativeTerrain() const override;
+	bool isNativeTerrain(TerrainId terrain) const override;
 	int getLowestCreatureSpeed() const;
 	si32 manaRegain() const; //how many points of mana can hero regain "naturally" in one day
 	si32 getManaNewTurn() const; //calculate how much mana this hero is going to have the next day

--- a/lib/mapObjects/CGTownInstance.cpp
+++ b/lib/mapObjects/CGTownInstance.cpp
@@ -1169,14 +1169,9 @@ FactionID CGTownInstance::getFactionID() const
 	return FactionID(subID.getNum());
 }
 
-TerrainId CGTownInstance::getNativeTerrain() const
+bool CGTownInstance::isNativeTerrain(TerrainId terrain) const
 {
-	auto const & terrain = getTown()->faction->getNativeTerrain();
-
-	if (!terrain.toEntity(LIBRARY)->isSurface() && !terrain.toEntity(LIBRARY)->isUnderground())
-		logMod->warn("Faction %s has terrain %s as native, but terrain is not suitable for either surface or subterranean layers!", getTown()->faction->getJsonKey(), terrain.toEntity(LIBRARY)->getJsonKey());
-
-	return terrain;
+	return getTown()->faction->isNativeTerrain(terrain);
 }
 
 ArtifactID CGTownInstance::getWarMachineInBuilding(BuildingID building) const

--- a/lib/mapObjects/CGTownInstance.h
+++ b/lib/mapObjects/CGTownInstance.h
@@ -202,7 +202,7 @@ public:
 
 	/// INativeTerrainProvider
 	FactionID getFactionID() const override;
-	TerrainId getNativeTerrain() const override;
+	bool isNativeTerrain(TerrainId terrain) const override;
 
 	/// Returns ID of war machine that is produced by specified building or NONE if this is not built or if building does not produce war machines
 	ArtifactID getWarMachineInBuilding(BuildingID) const;

--- a/lib/mapObjects/army/CStackInstance.cpp
+++ b/lib/mapObjects/army/CStackInstance.cpp
@@ -249,12 +249,12 @@ int32_t CStackInstance::getInitiative(int turn) const
 	return ACreature::getInitiative(turn);
 }
 
-TerrainId CStackInstance::getNativeTerrain() const
+bool CStackInstance::isNativeTerrain(TerrainId terrain) const
 {
 	if(nativeTerrain.hasBonus())
-		return TerrainId::ANY_TERRAIN;
+		return true;
 
-	return getFactionID().toEntity(LIBRARY)->getNativeTerrain();
+	return getFactionID().toEntity(LIBRARY)->isNativeTerrain(terrain);
 }
 
 TerrainId CStackInstance::getCurrentTerrain() const

--- a/lib/mapObjects/army/CStackInstance.h
+++ b/lib/mapObjects/army/CStackInstance.h
@@ -129,7 +129,7 @@ public:
 	PlayerColor getOwner() const override;
 
 	int32_t getInitiative(int turn = 0) const final;
-	TerrainId getNativeTerrain() const final;
+	bool isNativeTerrain(TerrainId terrain) const override;
 	TerrainId getCurrentTerrain() const;
 };
 

--- a/lib/pathfinder/TurnInfo.cpp
+++ b/lib/pathfinder/TurnInfo.cpp
@@ -180,12 +180,22 @@ TurnInfo::TurnInfo(TurnInfoCache * sharedCache, const CGHeroInstance * target, i
 			noterrainPenalty.at(affectedTerrain.num) = true;
 		}
 
-		const auto nativeTerrain = target->getNativeTerrain();
-		if (nativeTerrain.hasValue())
-			noterrainPenalty.at(nativeTerrain.num) = true;
+		const auto allStacksNativeForTerrain = [this](TerrainId terrainId)
+		{
+			for (const auto & slot : this->target->Slots())
+			{
+				if (!slot.second->isNativeTerrain(terrainId))
+					return false;
+			}
+			return true;
+		};
 
-		if (nativeTerrain == ETerrainId::ANY_TERRAIN)
-			boost::range::fill(noterrainPenalty, true);
+		for (const auto & terrain : LIBRARY->terrainTypeHandler->objects)
+		{
+			auto terrainId = terrain->getId();
+			if (allStacksNativeForTerrain(terrainId))
+				noterrainPenalty.at(terrainId.num) = true;
+		}
 	}
 }
 

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -331,25 +331,44 @@ void CZonePlacer::prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const 
 				zonesToPlace.push_back(zone);
 			else
 			{
-				auto & tt = (*LIBRARY->townh)[faction]->nativeTerrain;
-				if(tt == ETerrainId::NONE)
+				const auto & factionObject = (*LIBRARY->townh)[faction];
+				const auto & nativeTerrains = factionObject->nativeTerrains;
+				if(nativeTerrains.empty())
 				{
 					//any / random
 					zonesToPlace.push_back(zone);
 				}
 				else
 				{
-					const auto & terrainType = LIBRARY->terrainTypeHandler->getById(tt);
-					if(terrainType->isUnderground() && !terrainType->isSurface())
+					bool hasUndergroundTerrain = false;
+					bool hasSurfaceTerrain = false;
+					for (const auto & terrainId : nativeTerrains)
 					{
-						//underground only
-						zonesOnLevel[1]++;
-						levels[zone.first] = 1;
+						const auto & terrainType = LIBRARY->terrainTypeHandler->getById(terrainId);
+						if (terrainType->isUnderground())
+							hasUndergroundTerrain = true;
+						if (terrainType->isSurface())
+							hasSurfaceTerrain = true;
+					}
+
+					if(hasUndergroundTerrain && !hasSurfaceTerrain)
+					{
+						// underground only
+						if (mapLevels > 1)
+						{
+							zonesOnLevel[1]++;
+							levels[zone.first] = 1;
+						}
+						else
+						{
+							levels[zone.first] = 0;
+						}
 					}
 					else
 					{
-						//surface
-						addZoneEqually(zone, true);
+						// surface-only or mixed surface+underground
+						// mixed should not be forced to surface
+						addZoneEqually(zone, !hasUndergroundTerrain);
 					}
 				}
 			}

--- a/lib/rmg/modificators/TerrainPainter.cpp
+++ b/lib/rmg/modificators/TerrainPainter.cpp
@@ -60,7 +60,30 @@ void TerrainPainter::initTerrainType()
 	{
 		if(zone.isMatchTerrainToTown() && zone.getTownType() != ETownType::NEUTRAL)
 		{
-			auto terrainType = (*LIBRARY->townh)[zone.getTownType()]->nativeTerrain;
+			const auto & faction = (*LIBRARY->townh)[zone.getTownType()];
+			const auto & nativeTerrains = faction->nativeTerrains;
+			TerrainId terrainType = ETerrainId::NONE;
+
+			// If preferred native terrain is incompatible with zone level,
+			// try subsequent native terrains in declared order.
+			const auto isCompatibleWithLevel = [this](TerrainId terrainId)
+			{
+				const auto & terrain = LIBRARY->terrainTypeHandler->getById(terrainId);
+				return zone.isUnderground() ? terrain->isUnderground() : terrain->isSurface();
+			};
+
+			std::vector<TerrainId> compatibleTerrains;
+			for (const auto & candidate : nativeTerrains)
+			{
+				if (isCompatibleWithLevel(candidate))
+					compatibleTerrains.push_back(candidate);
+			}
+
+			// Prefer random native terrain when multiple compatible terrains exist.
+			if (!compatibleTerrains.empty())
+				terrainType = *RandomGeneratorUtil::nextItem(compatibleTerrains, zone.getRand());
+			else if (!nativeTerrains.empty())
+				terrainType = nativeTerrains.front();
 
 			if (terrainType <= ETerrainId::NONE)
 			{

--- a/lib/rmg/modificators/TownPlacer.cpp
+++ b/lib/rmg/modificators/TownPlacer.cpp
@@ -243,7 +243,7 @@ FactionID TownPlacer::getTownTypeFromHint(size_t hintIndex)
 		auto townTypesAllowed = zone.getTownTypes();
 		vstd::erase_if(townTypesAllowed, [townTerrain](FactionID type)
 		{
-			return (*LIBRARY->townh)[type]->getNativeTerrain() != townTerrain;
+			return !(*LIBRARY->townh)[type]->isNativeTerrain(townTerrain);
 		});
 		zone.setTownTypes(townTypesAllowed);
 		

--- a/server/battles/BattleProcessor.cpp
+++ b/server/battles/BattleProcessor.cpp
@@ -154,7 +154,11 @@ BattleID BattleProcessor::setupBattle(int3 tile, BattleSideArray<const CArmedIns
 	const auto & t = *gameHandler->gameInfo().getTile(tile);
 	TerrainId terrain = t.getTerrainID();
 	if (town)
-		terrain = town->getNativeTerrain();
+	{
+		const auto & nativeTerrains = town->getTown()->faction->nativeTerrains;
+		if (!nativeTerrains.empty())
+			terrain = nativeTerrains.front();
+	}
 	else if (gameHandler->gameState().getMap().isCoastalTile(tile)) //coastal tile is always ground
 		terrain = ETerrainId::SAND;
 


### PR DESCRIPTION
### Motivation

- Allow factions to declare multiple native terrains instead of a single `TerrainId`, so creatures/factions can have several native terrain types and terrain-related logic can check membership rather than relying on a single value. 
- Simplify and unify native-terrain checks by replacing `getNativeTerrain()` with `isNativeTerrain(TerrainId)` throughout the codebase.

### Description

- Replaced the single `nativeTerrain` field with `nativeTerrains` (`std::vector<TerrainId>`) in `CFaction` and updated related API to `bool isNativeTerrain(TerrainId)` instead of `TerrainId getNativeTerrain()` across headers and implementations such as `Entity.h`, `FactionMember.h`, `CFaction.*`, `CStack*`, `CGHeroInstance*`, `CGTownInstance*`, and other consumers. 
- Updated logic that depended on native terrain: pathfinder (`TurnInfo`), battle setup (`BattleProcessor::setupBattle`), RMG (`CZonePlacer`, `TerrainPainter`, `TownPlacer`), bonus limiters (`TerrainLimiter`), army heuristics (`ArmyManager`), and other stack/hero/town checks to call `isNativeTerrain(terrain)` or iterate `nativeTerrains` where appropriate. 
- Added JSON parsing support for `nativeTerrain` to accept either a single string or an array of strings in `CTownHandler` using new helpers `getNativeTerrainEntries` and `loadNativeTerrains`, and adjusted `config/schemas/faction.json` and documentation (`Faction_Format.md`) to document and validate the new form (string or array). 
- Adjusted behavior details: explicit string value `"none"` means no native terrains; when multiple compatible native terrains exist during terrain painting the code prefers a random compatible terrain; some code paths (e.g. battle setup) use the first declared native terrain as a fallback for selecting battle terrain. 

### Testing

- Performed a full debug build of the project (`make`), which completed successfully. 
- Ran the engine unit test suite (`ctest`) and core automated tests, and they passed without regressions. 
- Exercised RMG-related code paths and terrain assignment heuristics in automated map generation tests, which completed successfully. 
- Ran pathfinding/movement-related unit tests covering `TurnInfo` and movement penalty logic, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae3a32b44832d8a871703bc5db299)