### PR TITLE
Fix auto-resolved hero level-up dialog closing

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -540,7 +540,9 @@ void CPlayerInterface::heroGotLevel(const CGHeroInstance *hero, PrimarySkill psk
 
 		pendingLevelUpRequestID = cb->selectionMade(selection, queryID);
 	});
-	levelWindow->setCloseOnSelection(false);
+	// Auto-resolved level-ups do not receive a QueryReply acknowledgement,
+	// so allow the dialog to close itself when the player acknowledges it.
+	levelWindow->setCloseOnSelection(queryID < 0);
 	pendingLevelUpDialog = levelWindow;
 	ENGINE->windows().pushWindow(levelWindow);
 }


### PR DESCRIPTION
### Motivation
- Auto-resolved hero level-ups (those without a server `QueryReply`) left the UI blocked on the level-up dialog in some cases, notably when there was no commander, because the dialog was forced to stay open even though no reply would ever arrive.

### Description
- Update `CPlayerInterface::heroGotLevel` in `client/CPlayerInterface.cpp` to call `levelWindow->setCloseOnSelection(queryID < 0)` so auto-resolved level-up dialogs (negative `queryID`) can close themselves when the player clicks OK while query-backed dialogs still wait for a `QueryReply` as before.

### Testing
- Ran `git diff --check` to validate the change and there were no issues reported (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186caad8f0832d8ba703918a860695)