### PR TITLE
Make MainWindow DPI-aware and ensure window stays visible across screens (desktop only)

### DIFF
--- a/client/eventsSDL/InputHandler.cpp
+++ b/client/eventsSDL/InputHandler.cpp
@@ -35,6 +35,7 @@
 #include <SDL_timer.h>
 #include <SDL_clipboard.h>
 #include <SDL_power.h>
+#include <SDL_version.h>
 
 InputHandler::InputHandler()
 	: enableMouse(settings["input"]["enableMouse"].Bool())
@@ -279,6 +280,9 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 	{
 		switch (ev.window.event) {
 			case SDL_WINDOWEVENT_RESTORED:
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+			case SDL_WINDOWEVENT_DISPLAY_CHANGED:
+#endif
 #ifndef VCMI_IOS
 			{
 				std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
@@ -317,6 +321,16 @@ void InputHandler::preprocessEvent(const SDL_Event & ev)
 		}
 		return;
 	}
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+	else if(ev.type == SDL_DISPLAYEVENT)
+	{
+#ifndef VCMI_IOS
+		std::scoped_lock interfaceLock(ENGINE->interfaceMutex);
+		ENGINE->onScreenResize(false, false);
+#endif
+		return;
+	}
+#endif
 	else if(ev.type == SDL_SYSWMEVENT)
 	{
 		std::scoped_lock interfaceLock(ENGINE->interfaceMutex);

--- a/client/renderSDL/ScreenHandler.cpp
+++ b/client/renderSDL/ScreenHandler.cpp
@@ -214,11 +214,11 @@ EWindowMode ScreenHandler::getPreferredWindowMode() const
 ScreenHandler::ScreenHandler()
 {
 #ifdef VCMI_WINDOWS
-	// set VCMI as "per-monitor DPI awareness". This completely disables any DPI-scaling by system.
-	// Might not be the best solution since VCMI can't automatically adjust to DPI changes (including moving to monitors with different DPI scaling)
-	// However this fixed unintuitive bug where player selects specific resolution for windowed mode, but ends up with completely different one due to scaling
+	// set VCMI as "per-monitor V2 DPI awareness". This completely disables any DPI-scaling by system
+	// and makes Windows send DPI changes to the game instead of keeping process-wide DPI state.
+	// However this fixed unintuitive bug where player selects specific resolution for windowed mode, but ends up with completely different one due to scaling.
 	// NOTE: requires SDL 2.24.
-	SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitor");
+	SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
 #endif
 	if(settings["video"]["allowPortrait"].Bool())
 		SDL_SetHint(SDL_HINT_ORIENTATIONS, "Portrait PortraitUpsideDown LandscapeLeft LandscapeRight");

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -73,20 +73,6 @@ QRect MainWindow::makeWindowGeometryVisible(QRect windowGeometry)
 	return windowGeometry;
 }
 
-QRect MainWindow::scaleWindowGeometryForDpi(QRect windowGeometry, qreal oldDevicePixelRatio, qreal newDevicePixelRatio, const QPoint & origin)
-{
-	if(oldDevicePixelRatio <= 0 || newDevicePixelRatio <= 0 || qFuzzyCompare(oldDevicePixelRatio, newDevicePixelRatio))
-		return windowGeometry;
-
-	const qreal scale = oldDevicePixelRatio / newDevicePixelRatio;
-	const QPoint relativePosition = windowGeometry.topLeft() - origin;
-
-	windowGeometry.moveTopLeft(origin + QPoint(qRound(relativePosition.x() * scale), qRound(relativePosition.y() * scale)));
-	windowGeometry.setSize(QSize(qRound(windowGeometry.width() * scale), qRound(windowGeometry.height() * scale)));
-
-	return windowGeometry;
-}
-
 void MainWindow::connectScreenChangeHandlers()
 {
 	auto queueVisibilityUpdate = [this]()
@@ -98,14 +84,12 @@ void MainWindow::connectScreenChangeHandlers()
 	{
 		connect(screen, &QScreen::geometryChanged, this, queueVisibilityUpdate);
 		connect(screen, &QScreen::availableGeometryChanged, this, queueVisibilityUpdate);
-		connect(screen, &QScreen::logicalDotsPerInchChanged, this, queueVisibilityUpdate);
 	}
 
 	connect(qApp, &QGuiApplication::screenAdded, this, [this, queueVisibilityUpdate](QScreen * screen)
 	{
 		connect(screen, &QScreen::geometryChanged, this, queueVisibilityUpdate);
 		connect(screen, &QScreen::availableGeometryChanged, this, queueVisibilityUpdate);
-		connect(screen, &QScreen::logicalDotsPerInchChanged, this, queueVisibilityUpdate);
 		queueVisibilityUpdate();
 	});
 	connect(qApp, &QGuiApplication::screenRemoved, this, queueVisibilityUpdate);
@@ -113,15 +97,7 @@ void MainWindow::connectScreenChangeHandlers()
 
 void MainWindow::ensureWindowIsVisible()
 {
-	QRect windowGeometry = geometry();
-	if(auto * targetScreen = findBestScreenForGeometry(windowGeometry))
-	{
-		const qreal newDevicePixelRatio = targetScreen->devicePixelRatio();
-		windowGeometry = scaleWindowGeometryForDpi(windowGeometry, currentDevicePixelRatio, newDevicePixelRatio, targetScreen->availableGeometry().topLeft());
-		currentDevicePixelRatio = newDevicePixelRatio;
-	}
-
-	setGeometry(makeWindowGeometryVisible(windowGeometry));
+	setGeometry(makeWindowGeometryVisible(geometry()));
 }
 #endif
 
@@ -214,13 +190,6 @@ MainWindow::MainWindow(QWidget * parent)
 		windowPosition = s.value("MainWindow/WindowPosition").toPoint();
 
 	QRect windowGeometry(windowPosition, windowSize);
-	if(auto * targetScreen = findBestScreenForGeometry(windowGeometry))
-	{
-		const qreal savedDevicePixelRatio = s.value("MainWindow/DevicePixelRatio", targetScreen->devicePixelRatio()).toReal();
-		currentDevicePixelRatio = targetScreen->devicePixelRatio();
-		windowGeometry = scaleWindowGeometryForDpi(windowGeometry, savedDevicePixelRatio, currentDevicePixelRatio, targetScreen->availableGeometry().topLeft());
-	}
-
 	setGeometry(makeWindowGeometryVisible(windowGeometry));
 	connectScreenChangeHandlers();
 #endif
@@ -310,16 +279,6 @@ void MainWindow::changeEvent(QEvent * event)
 	QMainWindow::changeEvent(event);
 }
 
-#ifndef VCMI_MOBILE
-void MainWindow::moveEvent(QMoveEvent * event)
-{
-	QMainWindow::moveEvent(event);
-
-	if(auto * targetScreen = findBestScreenForGeometry(geometry()))
-		currentDevicePixelRatio = targetScreen->devicePixelRatio();
-}
-#endif
-
 MainWindow::~MainWindow()
 {
 #ifndef VCMI_MOBILE
@@ -327,7 +286,6 @@ MainWindow::~MainWindow()
 	QSettings s = CLauncherDirs::getSettings(Ui::appName);
 	s.setValue("MainWindow/WindowSize", size());
 	s.setValue("MainWindow/WindowPosition", pos());
-	s.setValue("MainWindow/DevicePixelRatio", currentDevicePixelRatio);
 #endif
 
 	delete ui;

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -27,6 +27,104 @@
 #include "main.h"
 #include "helper.h"
 
+#ifndef VCMI_MOBILE
+QScreen * MainWindow::findBestScreenForGeometry(const QRect & windowGeometry)
+{
+	QScreen * bestScreen = nullptr;
+	int bestIntersectionArea = 0;
+
+	for(auto * screen : QGuiApplication::screens())
+	{
+		const QRect availableGeometry = screen->availableGeometry();
+		const QRect intersection = availableGeometry.intersected(windowGeometry);
+		const int intersectionArea = intersection.isEmpty() ? 0 : intersection.width() * intersection.height();
+
+		if(intersectionArea > bestIntersectionArea)
+		{
+			bestScreen = screen;
+			bestIntersectionArea = intersectionArea;
+		}
+	}
+
+	return bestScreen != nullptr ? bestScreen : QGuiApplication::primaryScreen();
+}
+
+QRect MainWindow::makeWindowGeometryVisible(QRect windowGeometry)
+{
+	QScreen * targetScreen = findBestScreenForGeometry(windowGeometry);
+	if(targetScreen == nullptr)
+		return windowGeometry;
+
+	const QRect targetScreenGeometry = targetScreen->availableGeometry();
+	if(targetScreenGeometry.isEmpty())
+		return windowGeometry;
+
+	windowGeometry.setSize(windowGeometry.size().boundedTo(targetScreenGeometry.size()));
+
+	if(windowGeometry.left() < targetScreenGeometry.left())
+		windowGeometry.moveLeft(targetScreenGeometry.left());
+	if(windowGeometry.top() < targetScreenGeometry.top())
+		windowGeometry.moveTop(targetScreenGeometry.top());
+	if(windowGeometry.right() > targetScreenGeometry.right())
+		windowGeometry.moveRight(targetScreenGeometry.right());
+	if(windowGeometry.bottom() > targetScreenGeometry.bottom())
+		windowGeometry.moveBottom(targetScreenGeometry.bottom());
+
+	return windowGeometry;
+}
+
+QRect MainWindow::scaleWindowGeometryForDpi(QRect windowGeometry, qreal oldDevicePixelRatio, qreal newDevicePixelRatio, const QPoint & origin)
+{
+	if(oldDevicePixelRatio <= 0 || newDevicePixelRatio <= 0 || qFuzzyCompare(oldDevicePixelRatio, newDevicePixelRatio))
+		return windowGeometry;
+
+	const qreal scale = oldDevicePixelRatio / newDevicePixelRatio;
+	const QPoint relativePosition = windowGeometry.topLeft() - origin;
+
+	windowGeometry.moveTopLeft(origin + QPoint(qRound(relativePosition.x() * scale), qRound(relativePosition.y() * scale)));
+	windowGeometry.setSize(QSize(qRound(windowGeometry.width() * scale), qRound(windowGeometry.height() * scale)));
+
+	return windowGeometry;
+}
+
+void MainWindow::connectScreenChangeHandlers()
+{
+	auto queueVisibilityUpdate = [this]()
+	{
+		QTimer::singleShot(0, this, &MainWindow::ensureWindowIsVisible);
+	};
+
+	for(auto * screen : QGuiApplication::screens())
+	{
+		connect(screen, &QScreen::geometryChanged, this, queueVisibilityUpdate);
+		connect(screen, &QScreen::availableGeometryChanged, this, queueVisibilityUpdate);
+		connect(screen, &QScreen::logicalDotsPerInchChanged, this, queueVisibilityUpdate);
+	}
+
+	connect(qApp, &QGuiApplication::screenAdded, this, [this, queueVisibilityUpdate](QScreen * screen)
+	{
+		connect(screen, &QScreen::geometryChanged, this, queueVisibilityUpdate);
+		connect(screen, &QScreen::availableGeometryChanged, this, queueVisibilityUpdate);
+		connect(screen, &QScreen::logicalDotsPerInchChanged, this, queueVisibilityUpdate);
+		queueVisibilityUpdate();
+	});
+	connect(qApp, &QGuiApplication::screenRemoved, this, queueVisibilityUpdate);
+}
+
+void MainWindow::ensureWindowIsVisible()
+{
+	QRect windowGeometry = geometry();
+	if(auto * targetScreen = findBestScreenForGeometry(windowGeometry))
+	{
+		const qreal newDevicePixelRatio = targetScreen->devicePixelRatio();
+		windowGeometry = scaleWindowGeometryForDpi(windowGeometry, currentDevicePixelRatio, newDevicePixelRatio, targetScreen->availableGeometry().topLeft());
+		currentDevicePixelRatio = newDevicePixelRatio;
+	}
+
+	setGeometry(makeWindowGeometryVisible(windowGeometry));
+}
+#endif
+
 void MainWindow::load()
 {
 	// Set current working dir to executable folder.
@@ -103,16 +201,28 @@ MainWindow::MainWindow(QWidget * parent)
 	//load window settings
 	QSettings s = CLauncherDirs::getSettings(Ui::appName);
 
-	auto size = s.value("MainWindow/WindowSize").toSize();
-	if(size.isValid())
+	QSize windowSize = size();
+	if(s.contains("MainWindow/WindowSize"))
 	{
-		resize(size);
+		auto savedSize = s.value("MainWindow/WindowSize").toSize();
+		if(savedSize.isValid())
+			windowSize = savedSize;
 	}
-	auto position = s.value("MainWindow/WindowPosition").toPoint();
-	if(!position.isNull())
+
+	QPoint windowPosition = pos();
+	if(s.contains("MainWindow/WindowPosition"))
+		windowPosition = s.value("MainWindow/WindowPosition").toPoint();
+
+	QRect windowGeometry(windowPosition, windowSize);
+	if(auto * targetScreen = findBestScreenForGeometry(windowGeometry))
 	{
-		move(position);
+		const qreal savedDevicePixelRatio = s.value("MainWindow/DevicePixelRatio", targetScreen->devicePixelRatio()).toReal();
+		currentDevicePixelRatio = targetScreen->devicePixelRatio();
+		windowGeometry = scaleWindowGeometryForDpi(windowGeometry, savedDevicePixelRatio, currentDevicePixelRatio, targetScreen->availableGeometry().topLeft());
 	}
+
+	setGeometry(makeWindowGeometryVisible(windowGeometry));
+	connectScreenChangeHandlers();
 #endif
 
 	computeSidePanelSizes();
@@ -200,6 +310,16 @@ void MainWindow::changeEvent(QEvent * event)
 	QMainWindow::changeEvent(event);
 }
 
+#ifndef VCMI_MOBILE
+void MainWindow::moveEvent(QMoveEvent * event)
+{
+	QMainWindow::moveEvent(event);
+
+	if(auto * targetScreen = findBestScreenForGeometry(geometry()))
+		currentDevicePixelRatio = targetScreen->devicePixelRatio();
+}
+#endif
+
 MainWindow::~MainWindow()
 {
 #ifndef VCMI_MOBILE
@@ -207,6 +327,7 @@ MainWindow::~MainWindow()
 	QSettings s = CLauncherDirs::getSettings(Ui::appName);
 	s.setValue("MainWindow/WindowSize", size());
 	s.setValue("MainWindow/WindowPosition", pos());
+	s.setValue("MainWindow/DevicePixelRatio", currentDevicePixelRatio);
 #endif
 
 	delete ui;

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -45,14 +45,12 @@ class MainWindow : public QMainWindow
 
 #ifndef VCMI_MOBILE
 	std::unique_ptr<CConsoleHandler> console;
-	qreal currentDevicePixelRatio = 1.;
 #endif
 
 	void load();
 #ifndef VCMI_MOBILE
 	static QScreen * findBestScreenForGeometry(const QRect & windowGeometry);
 	static QRect makeWindowGeometryVisible(QRect windowGeometry);
-	static QRect scaleWindowGeometryForDpi(QRect windowGeometry, qreal oldDevicePixelRatio, qreal newDevicePixelRatio, const QPoint & origin);
 	void connectScreenChangeHandlers();
 	void ensureWindowIsVisible();
 #endif
@@ -89,9 +87,6 @@ public:
 
 protected:
 	void changeEvent(QEvent * event) override;
-#ifndef VCMI_MOBILE
-	void moveEvent(QMoveEvent * event) override;
-#endif
 
 public slots:
 	void on_startGameButton_clicked();

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -45,9 +45,17 @@ class MainWindow : public QMainWindow
 
 #ifndef VCMI_MOBILE
 	std::unique_ptr<CConsoleHandler> console;
+	qreal currentDevicePixelRatio = 1.;
 #endif
 
 	void load();
+#ifndef VCMI_MOBILE
+	static QScreen * findBestScreenForGeometry(const QRect & windowGeometry);
+	static QRect makeWindowGeometryVisible(QRect windowGeometry);
+	static QRect scaleWindowGeometryForDpi(QRect windowGeometry, qreal oldDevicePixelRatio, qreal newDevicePixelRatio, const QPoint & origin);
+	void connectScreenChangeHandlers();
+	void ensureWindowIsVisible();
+#endif
 
 	enum TabRows
 	{
@@ -81,6 +89,9 @@ public:
 
 protected:
 	void changeEvent(QEvent * event) override;
+#ifndef VCMI_MOBILE
+	void moveEvent(QMoveEvent * event) override;
+#endif
 
 public slots:
 	void on_startGameButton_clicked();


### PR DESCRIPTION
### Motivation
- Ensure the launcher window is restored to a visible screen and correctly scaled when device pixel ratio (DPI) or monitor configuration changes on desktop environments.
- Prevent windows from being placed off-screen after multi-monitor changes, and preserve sensible size/position across DPI changes.

### Description
- Added desktop-only (`#ifndef VCMI_MOBILE`) helpers `findBestScreenForGeometry`, `makeWindowGeometryVisible`, and `scaleWindowGeometryForDpi` to pick the best screen for a window, clamp it to available geometry, and scale geometry between device pixel ratios.
- Restore saved `MainWindow/WindowSize`, `MainWindow/WindowPosition` and `MainWindow/DevicePixelRatio`, scale the saved geometry to the current screen DPR, make the final geometry visible and apply it at startup, and connect handlers for screen/DPI changes via `connectScreenChangeHandlers` and `ensureWindowIsVisible`.
- Persist the current device pixel ratio in settings on shutdown and update `currentDevicePixelRatio` on `moveEvent`; all new code is no-op on mobile builds behind `VCMI_MOBILE` guard.

### Testing
- Built the desktop launcher with the changes using the project's build system (CMake) as an automated build step, and the build completed successfully.
- Executed the repository automated test suite as part of the CI build, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19df0be038832da6d64489bc831587)