### PR TITLE
Keep gold last in market resource panels

### DIFF
--- a/client/widgets/markets/TradePanels.cpp
+++ b/client/widgets/markets/TradePanels.cpp
@@ -268,6 +268,13 @@ ResourcesPanel::ResourcesPanel(const CTradeableItem::ClickPressedFunctor & click
 	OBJECT_CONSTRUCTION;
 
 	resourcesForTrade = LIBRARY->resourceTypeHandler->getAllObjects();
+	const auto goldIt = std::find(resourcesForTrade.begin(), resourcesForTrade.end(), GameResID::GOLD);
+	if(goldIt != resourcesForTrade.end())
+	{
+		const auto gold = *goldIt;
+		resourcesForTrade.erase(goldIt);
+		resourcesForTrade.push_back(gold);
+	}
 
 	int lines = vstd::divideAndCeil(resourcesForTrade.size(), 3);
 	if(lines > 3)


### PR DESCRIPTION
### Motivation
- Ensure gold is always displayed as the last resource in market resource panels so newly configured resources appear before gold in the GUI.

### Description
- After loading resources with `LIBRARY->resourceTypeHandler->getAllObjects()` the code finds `GameResID::GOLD` and moves it to the end of `resourcesForTrade`, while preserving the existing 7-resource layout behavior.

### Testing
- Ran `git diff --check`, which completed without errors and the change was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a046e6874832daa083b847adf5d0f)