### PR TITLE
Keep launcher window on existing screens

### DIFF
--- a/config/schemas/settings.json
+++ b/config/schemas/settings.json
@@ -720,7 +720,8 @@
 				"ignoreSslErrors",
 				"updateOnStartup",
 				"updateConfigUrl",
-				"trackClipboardState"
+				"trackClipboardState",
+				"mainWindow"
 			],
 			"properties" : {
 				"defaultRepositoryEnabled" : {
@@ -770,6 +771,27 @@
 					"defaultAndroid": false,
 					"defaultDesktop" : true
 
+				},
+				"mainWindow" : {
+					"type" : "object",
+					"default" : {},
+					"additionalProperties" : false,
+					"required" : [ "geometry" ],
+					"properties" : {
+						"geometry" : {
+							"type" : "object",
+							"default" : {},
+							"additionalProperties" : false,
+							"required" : [ "valid", "x", "y", "width", "height" ],
+							"properties" : {
+								"valid" : { "type" : "boolean", "default" : false },
+								"x" : { "type" : "number", "default" : 0 },
+								"y" : { "type" : "number", "default" : 0 },
+								"width" : { "type" : "number", "default" : 0 },
+								"height" : { "type" : "number", "default" : 0 }
+							}
+						}
+					}
 				}
 			}
 		},

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -142,9 +142,12 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 	// Prefer the screen containing the saved/current frame center: before show(), Qt may
 	// still report the primary screen via windowHandle(), even when the saved position
 	// belongs to another connected monitor. If no screen contains the frame, fall back
-	// to the window handle screen and then to the primary screen.
+	// to the window handle screen and then to the primary screen. In that fallback case
+	// the old coordinates belong to a missing display, so center the window instead of
+	// pinning it to the nearest edge.
 	QRect windowGeometry = frameGeometry();
 	auto * targetScreen = QGuiApplication::screenAt(windowGeometry.center());
+	bool centerWindow = targetScreen == nullptr;
 	if(targetScreen == nullptr && windowHandle())
 		targetScreen = windowHandle()->screen();
 	if(targetScreen == nullptr)
@@ -166,6 +169,10 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 	}
 
 	QPoint windowPosition = windowGeometry.topLeft();
+	if(centerWindow)
+		windowPosition = QPoint(availableGeometry.left() + (availableGeometry.width() - windowSize.width()) / 2,
+			availableGeometry.top() + (availableGeometry.height() - windowSize.height()) / 2);
+
 	if(windowSize.width() >= availableGeometry.width())
 		windowPosition.setX(availableGeometry.left());
 	else

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -197,10 +197,10 @@ void MainWindow::saveWindowSettings()
 	//save window settings
 	Settings windowGeometry = settings.write["launcher"]["mainWindow"]["geometry"];
 	windowGeometry["valid"].Bool() = true;
-	windowGeometry["x"].Float() = pos().x();
-	windowGeometry["y"].Float() = pos().y();
-	windowGeometry["width"].Float() = size().width();
-	windowGeometry["height"].Float() = size().height();
+	windowGeometry["x"].Integer() = pos().x();
+	windowGeometry["y"].Integer() = pos().y();
+	windowGeometry["width"].Integer() = size().width();
+	windowGeometry["height"].Integer() = size().height();
 #endif
 }
 

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -139,10 +139,14 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 {
 #ifndef VCMI_MOBILE
 	// Work with frame geometry so native window decorations are kept on-screen too.
-	// If Qt has already associated the window with a screen, clamp the frame to that
-	// screen; otherwise fall back to the primary screen and persist that safe position.
+	// Prefer the screen containing the saved/current frame center: before show(), Qt may
+	// still report the primary screen via windowHandle(), even when the saved position
+	// belongs to another connected monitor. If no screen contains the frame, fall back
+	// to the window handle screen and then to the primary screen.
 	QRect windowGeometry = frameGeometry();
-	auto * targetScreen = windowHandle() ? windowHandle()->screen() : nullptr;
+	auto * targetScreen = QGuiApplication::screenAt(windowGeometry.center());
+	if(targetScreen == nullptr && windowHandle())
+		targetScreen = windowHandle()->screen();
 	if(targetScreen == nullptr)
 		targetScreen = QGuiApplication::primaryScreen();
 

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -94,10 +94,7 @@ MainWindow::MainWindow(QWidget * parent)
 #ifndef VCMI_MOBILE
 	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
 	{
-		QTimer::singleShot(0, this, [this]()
-		{
-			saveWindowSettings();
-		});
+		QTimer::singleShot(0, this, &MainWindow::saveWindowSettings);
 	});
 #endif
 
@@ -118,11 +115,8 @@ MainWindow::MainWindow(QWidget * parent)
 	{
 		resize(size);
 	}
-	if(s.contains("MainWindow/WindowPosition"))
-	{
-		auto position = s.value("MainWindow/WindowPosition").toPoint();
-		move(position);
-	}
+	if(const auto position = s.value("MainWindow/WindowPosition"); position.isValid())
+		move(position.toPoint());
 	ensureWindowVisibleOnExistingScreen();
 #endif
 
@@ -144,25 +138,11 @@ MainWindow::MainWindow(QWidget * parent)
 void MainWindow::ensureWindowVisibleOnExistingScreen()
 {
 #ifndef VCMI_MOBILE
-	const auto screens = QGuiApplication::screens();
-	if(screens.isEmpty())
-		return;
-
-	QRect windowGeometry(pos(), size());
-	QScreen * targetScreen = nullptr;
-	int bestIntersectionArea = 0;
-
-	for(QScreen * screen : screens)
-	{
-		const QRect intersection = screen->availableGeometry().intersected(windowGeometry);
-		const int intersectionArea = intersection.isEmpty() ? 0 : intersection.width() * intersection.height();
-		if(intersectionArea > bestIntersectionArea)
-		{
-			bestIntersectionArea = intersectionArea;
-			targetScreen = screen;
-		}
-	}
-
+	// Work with frame geometry so native window decorations are kept on-screen too.
+	// If Qt has already associated the window with a screen, clamp the frame to that
+	// screen; otherwise fall back to the primary screen and persist that safe position.
+	QRect windowGeometry = frameGeometry();
+	auto * targetScreen = windowHandle() ? windowHandle()->screen() : nullptr;
 	if(targetScreen == nullptr)
 		targetScreen = QGuiApplication::primaryScreen();
 
@@ -173,14 +153,15 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 	if(!availableGeometry.isValid())
 		return;
 
-	QSize windowSize = size();
+	QSize windowSize = windowGeometry.size();
 	if(windowSize.width() > availableGeometry.width() || windowSize.height() > availableGeometry.height())
 	{
 		windowSize = windowSize.boundedTo(availableGeometry.size());
+		windowGeometry.setSize(windowSize);
 		resize(windowSize);
 	}
 
-	QPoint windowPosition = pos();
+	QPoint windowPosition = windowGeometry.topLeft();
 	if(windowSize.width() >= availableGeometry.width())
 		windowPosition.setX(availableGeometry.left());
 	else
@@ -195,8 +176,7 @@ void MainWindow::ensureWindowVisibleOnExistingScreen()
 			windowPosition.y(),
 			availableGeometry.bottom() - windowSize.height() + 1));
 
-	if(windowPosition != pos())
-		move(windowPosition);
+	move(windowPosition);
 #endif
 }
 

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -91,6 +91,16 @@ MainWindow::MainWindow(QWidget * parent)
 
 	ui->setupUi(this);
 
+#ifndef VCMI_MOBILE
+	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
+	{
+		QTimer::singleShot(0, this, [this]()
+		{
+			saveWindowSettings();
+		});
+	});
+#endif
+
 	setAcceptDrops(true);
 
 	setWindowIcon(QIcon{":/icons/menu-game.png"});
@@ -108,11 +118,12 @@ MainWindow::MainWindow(QWidget * parent)
 	{
 		resize(size);
 	}
-	auto position = s.value("MainWindow/WindowPosition").toPoint();
-	if(!position.isNull())
+	if(s.contains("MainWindow/WindowPosition"))
 	{
+		auto position = s.value("MainWindow/WindowPosition").toPoint();
 		move(position);
 	}
+	ensureWindowVisibleOnExistingScreen();
 #endif
 
 	computeSidePanelSizes();
@@ -128,6 +139,77 @@ MainWindow::MainWindow(QWidget * parent)
 	
 	if(settings["launcher"]["updateOnStartup"].Bool())
 		UpdateDialog::showUpdateDialog(false);
+}
+
+void MainWindow::ensureWindowVisibleOnExistingScreen()
+{
+#ifndef VCMI_MOBILE
+	const auto screens = QGuiApplication::screens();
+	if(screens.isEmpty())
+		return;
+
+	QRect windowGeometry(pos(), size());
+	QScreen * targetScreen = nullptr;
+	int bestIntersectionArea = 0;
+
+	for(QScreen * screen : screens)
+	{
+		const QRect intersection = screen->availableGeometry().intersected(windowGeometry);
+		const int intersectionArea = intersection.isEmpty() ? 0 : intersection.width() * intersection.height();
+		if(intersectionArea > bestIntersectionArea)
+		{
+			bestIntersectionArea = intersectionArea;
+			targetScreen = screen;
+		}
+	}
+
+	if(targetScreen == nullptr)
+		targetScreen = QGuiApplication::primaryScreen();
+
+	if(targetScreen == nullptr)
+		return;
+
+	const QRect availableGeometry = targetScreen->availableGeometry();
+	if(!availableGeometry.isValid())
+		return;
+
+	QSize windowSize = size();
+	if(windowSize.width() > availableGeometry.width() || windowSize.height() > availableGeometry.height())
+	{
+		windowSize = windowSize.boundedTo(availableGeometry.size());
+		resize(windowSize);
+	}
+
+	QPoint windowPosition = pos();
+	if(windowSize.width() >= availableGeometry.width())
+		windowPosition.setX(availableGeometry.left());
+	else
+		windowPosition.setX(qBound(availableGeometry.left(),
+			windowPosition.x(),
+			availableGeometry.right() - windowSize.width() + 1));
+
+	if(windowSize.height() >= availableGeometry.height())
+		windowPosition.setY(availableGeometry.top());
+	else
+		windowPosition.setY(qBound(availableGeometry.top(),
+			windowPosition.y(),
+			availableGeometry.bottom() - windowSize.height() + 1));
+
+	if(windowPosition != pos())
+		move(windowPosition);
+#endif
+}
+
+void MainWindow::saveWindowSettings()
+{
+#ifndef VCMI_MOBILE
+	ensureWindowVisibleOnExistingScreen();
+
+	//save window settings
+	QSettings s = CLauncherDirs::getSettings(Ui::appName);
+	s.setValue("MainWindow/WindowSize", size());
+	s.setValue("MainWindow/WindowPosition", pos());
+#endif
 }
 
 void MainWindow::detectPreferredLanguage()
@@ -202,12 +284,7 @@ void MainWindow::changeEvent(QEvent * event)
 
 MainWindow::~MainWindow()
 {
-#ifndef VCMI_MOBILE
-	//save window settings
-	QSettings s = CLauncherDirs::getSettings(Ui::appName);
-	s.setValue("MainWindow/WindowSize", size());
-	s.setValue("MainWindow/WindowPosition", pos());
-#endif
+	saveWindowSettings();
 
 	delete ui;
 }

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -21,8 +21,6 @@
 #include "../lib/texts/Languages.h"
 #include "../lib/ExceptionsCommon.h"
 
-#include "../vcmiqt/launcherdirs.h"
-
 #include "updatedialog_moc.h"
 #include "main.h"
 #include "helper.h"
@@ -108,15 +106,15 @@ MainWindow::MainWindow(QWidget * parent)
 
 #ifndef VCMI_MOBILE
 	//load window settings
-	QSettings s = CLauncherDirs::getSettings(Ui::appName);
-
-	auto size = s.value("MainWindow/WindowSize").toSize();
-	if(size.isValid())
+	const auto & windowGeometry = settings["launcher"]["mainWindow"]["geometry"];
+	if(windowGeometry["valid"].Bool())
 	{
-		resize(size);
+		QSize windowSize(windowGeometry["width"].Integer(), windowGeometry["height"].Integer());
+		if(windowSize.isValid())
+			resize(windowSize);
+
+		move(windowGeometry["x"].Integer(), windowGeometry["y"].Integer());
 	}
-	if(const auto position = s.value("MainWindow/WindowPosition"); position.isValid())
-		move(position.toPoint());
 	ensureWindowVisibleOnExistingScreen();
 #endif
 
@@ -197,9 +195,12 @@ void MainWindow::saveWindowSettings()
 	ensureWindowVisibleOnExistingScreen();
 
 	//save window settings
-	QSettings s = CLauncherDirs::getSettings(Ui::appName);
-	s.setValue("MainWindow/WindowSize", size());
-	s.setValue("MainWindow/WindowPosition", pos());
+	Settings windowGeometry = settings.write["launcher"]["mainWindow"]["geometry"];
+	windowGeometry["valid"].Bool() = true;
+	windowGeometry["x"].Float() = pos().x();
+	windowGeometry["y"].Float() = pos().y();
+	windowGeometry["width"].Float() = size().width();
+	windowGeometry["height"].Float() = size().height();
 #endif
 }
 

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -67,7 +67,6 @@ public:
 	void updateTranslation();
 	void computeSidePanelSizes();
 	void ensureWindowVisibleOnExistingScreen();
-	void saveWindowSettings();
 	
 	void detectPreferredLanguage();
 	void enterSetup();
@@ -85,6 +84,7 @@ protected:
 	void changeEvent(QEvent * event) override;
 
 public slots:
+	void saveWindowSettings();
 	void on_startGameButton_clicked();
 	
 private slots:

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -66,6 +66,8 @@ public:
 
 	void updateTranslation();
 	void computeSidePanelSizes();
+	void ensureWindowVisibleOnExistingScreen();
+	void saveWindowSettings();
 	
 	void detectPreferredLanguage();
 	void enterSetup();

--- a/launcher/settingsView/csettingsview_moc.cpp
+++ b/launcher/settingsView/csettingsview_moc.cpp
@@ -86,15 +86,22 @@ void CSettingsView::setDisplayList()
 	for (const auto screen : QGuiApplication::screens())
 		list << QString{"%1 - %2"}.arg(screen->name(), resolutionToString(screen->size()));
 
+	int displayIndex = settings["video"]["displayIndex"].Integer();
+	if(displayIndex < 0 || displayIndex >= list.count())
+	{
+		displayIndex = 0;
+		Settings node = settings.write["video"]["displayIndex"];
+		node->Float() = displayIndex;
+	}
+
 	if(list.count() < 2)
 	{
 		ui->comboBoxDisplayIndex->hide();
 		ui->labelDisplayIndex->hide();
-		fillValidResolutionsForScreen(0);
+		fillValidResolutionsForScreen(displayIndex);
 	}
 	else
 	{
-		int displayIndex = settings["video"]["displayIndex"].Integer();
 		ui->comboBoxDisplayIndex->addItems(list);
 		// calls fillValidResolutions() in slot
 		ui->comboBoxDisplayIndex->setCurrentIndex(displayIndex);
@@ -340,6 +347,11 @@ QSize CSettingsView::getPreferredRenderingResolution()
 		return QSize(resX, resY);
 	}
 #endif
+	const auto screens = QGuiApplication::screens();
+	int displayIndex = settings["video"]["displayIndex"].Integer();
+	if(displayIndex >= 0 && displayIndex < screens.size())
+		return screens[displayIndex]->geometry().size() * screens[displayIndex]->devicePixelRatio();
+
 	return QApplication::primaryScreen()->geometry().size() * QApplication::primaryScreen()->devicePixelRatio();
 }
 
@@ -391,7 +403,7 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 
 	int modesCount = SDL_GetNumDisplayModes(displayIndex);
 
-	for (int i =0; i < modesCount; ++i)
+	for (int i = 0; i < modesCount; ++i)
 	{
 		SDL_DisplayMode mode;
 		if (SDL_GetDisplayMode(displayIndex, i, &mode) != 0)
@@ -408,6 +420,20 @@ static QVector<QSize> findAvailableResolutions(int displayIndex)
 	});
 
 	result.erase(boost::unique(result).end(), result.end());
+
+	SDL_Quit();
+
+	return result;
+}
+
+static QSize findDesktopResolution(int displayIndex)
+{
+	SDL_Init(SDL_INIT_VIDEO);
+
+	SDL_DisplayMode mode;
+	QSize result;
+	if(SDL_GetDesktopDisplayMode(displayIndex, &mode) == 0)
+		result = QSize(mode.w, mode.h);
 
 	SDL_Quit();
 
@@ -431,7 +457,16 @@ void CSettingsView::fillValidResolutionsForScreen(int screenIndex)
 	{
 		QVector<QSize> resolutions = findAvailableResolutions(screenIndex);
 
-		if(!resolutions.contains(currentRes))
+		// Windowed mode allows custom resolutions, but only while they still fit on
+		// the selected display. This prevents stale 4K TV resolutions from keeping
+		// oversized scaling ranges after switching to a smaller monitor.
+		QSize desktopResolution = findDesktopResolution(screenIndex);
+		bool currentWindowedResolutionFits = !fullscreen
+			&& desktopResolution.isValid()
+			&& currentRes.width() <= desktopResolution.width()
+			&& currentRes.height() <= desktopResolution.height();
+
+		if(currentWindowedResolutionFits && !resolutions.contains(currentRes))
 			resolutions.append(currentRes);
 
 		for(const auto & entry : resolutions)
@@ -447,8 +482,15 @@ void CSettingsView::fillValidResolutionsForScreen(int screenIndex)
 	ui->comboBoxResolution->setCurrentIndex(resIndex);
 
 	// if selected resolution no longer exists, force update value to the largest (last) resolution
-	if(resIndex == -1)
+	if(resIndex == -1 && ui->comboBoxResolution->count() > 0)
+	{
 		ui->comboBoxResolution->setCurrentIndex(ui->comboBoxResolution->count() - 1);
+		QStringList selectedResolution = ui->comboBoxResolution->currentText().split("x");
+
+		Settings node = settings.write["video"]["resolution"];
+		node["width"].Float() = selectedResolution[0].toInt();
+		node["height"].Float() = selectedResolution[1].toInt();
+	}
 }
 
 void CSettingsView::fillValidRenderers()
@@ -538,6 +580,7 @@ void CSettingsView::on_comboBoxDisplayIndex_currentIndexChanged(int index)
 	node["displayIndex"].Float() = index;
 
 	fillValidResolutionsForScreen(index);
+	fillValidScalingRange();
 }
 
 void CSettingsView::on_comboBoxFriendlyAI_currentIndexChanged(int index)


### PR DESCRIPTION
### Motivation

- Fix cases where the Launcher stays on a disconnected monitor after unplugging or after restart by ensuring it is always placed on an existing screen. 
- Prevent saving window coordinates that refer to non-existing monitors so restored positions are valid on next start.

### Description

- Added `MainWindow::ensureWindowVisibleOnExistingScreen()` which selects the best available `QScreen` (largest intersection or primary) and clamps/resizes/moves the window into that screen's `availableGeometry` when needed. 
- Added `MainWindow::saveWindowSettings()` that first validates the window position via `ensureWindowVisibleOnExistingScreen()` and then writes `MainWindow/WindowSize` and `MainWindow/WindowPosition` into `QSettings`. 
- Connected `QGuiApplication::screenRemoved` to run `saveWindowSettings()` (via a `QTimer::singleShot(0, ...)`) so the launcher corrects and persists a safe position when a monitor is removed. 
- Validate and adjust restored position on startup (use `s.contains("MainWindow/WindowPosition")` and call `ensureWindowVisibleOnExistingScreen()` after applying stored size/position), and call `saveWindowSettings()` from the destructor to persist corrected values on shutdown.

### Testing

- Ran `git diff --check` with no issues reported. 
- Ran CMake configuration with `cmake -S . -B /tmp/vcmi-build -DENABLE_LAUNCHER=ON -DENABLE_CLIENT=OFF -DENABLE_SERVER=OFF -DENABLE_EDITOR=OFF -DENABLE_TEST=OFF -DENABLE_TRANSLATIONS=OFF`, which failed due to missing Boost development packages in the environment (external dependency), so full build / runtime verification could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c6a9b3ac0832db83ea108396c6375)