### PR TITLE
Prevent duplicate left-clicks from touch gestures and add cancellation event

### DIFF
--- a/client/eventsSDL/InputSourceTouch.cpp
+++ b/client/eventsSDL/InputSourceTouch.cpp
@@ -33,7 +33,7 @@
 #include <SDL_timer.h>
 
 InputSourceTouch::InputSourceTouch()
-	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0)
+	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0), touchStartedWithLeftClick(false)
 {
 	params.useRelativeMode = settings["general"]["userRelativePointer"].Bool();
 	params.relativeModeSpeedFactor = settings["general"]["relativePointerSpeedMultiplier"].Float();
@@ -98,6 +98,11 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 			Point distance = convertTouchToMouse(tfinger) - lastTapPosition;
 			if ( std::abs(distance.x) > params.panningSensitivityThreshold || std::abs(distance.y) > params.panningSensitivityThreshold)
 			{
+				if(touchStartedWithLeftClick)
+				{
+					ENGINE->events().dispatchMouseLeftButtonCancelled(lastTapPosition);
+					touchStartedWithLeftClick = false;
+				}
 				state = state == TouchState::TAP_DOWN_SHORT ? TouchState::TAP_DOWN_PANNING : TouchState::TAP_DOWN_PANNING_POPUP;
 				ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			}
@@ -162,12 +167,20 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		{
 			lastTapPosition = convertTouchToMouse(tfinger);
 			ENGINE->input().setCursorPosition(lastTapPosition);
+			touchStartedWithLeftClick = !ENGINE->events().hasGestureReceiverAtPosition(lastTapPosition);
+			if(touchStartedWithLeftClick)
+				ENGINE->events().dispatchMouseLeftButtonPressed(lastTapPosition, params.touchToleranceDistance);
 			state = TouchState::TAP_DOWN_SHORT;
 			break;
 		}
 		case TouchState::TAP_DOWN_SHORT:
 		{
 			ENGINE->input().setCursorPosition(convertTouchToMouse(tfinger));
+			if(touchStartedWithLeftClick)
+			{
+				ENGINE->events().dispatchMouseLeftButtonCancelled(lastTapPosition);
+				touchStartedWithLeftClick = false;
+			}
 			ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			state = TouchState::TAP_DOWN_DOUBLE;
 			break;
@@ -220,18 +233,21 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 		case TouchState::TAP_DOWN_SHORT:
 		{
 			ENGINE->input().setCursorPosition(convertTouchToMouse(tfinger));
-			if(tfinger.timestamp - lastLeftClickTimeTicks < params.doubleTouchTimeMilliseconds && (convertTouchToMouse(tfinger) - lastLeftClickPosition).length() < params.doubleTouchToleranceDistance)
+			Point position = convertTouchToMouse(tfinger);
+			if(tfinger.timestamp - lastLeftClickTimeTicks < params.doubleTouchTimeMilliseconds && (position - lastLeftClickPosition).length() < params.doubleTouchToleranceDistance)
 			{
-				ENGINE->events().dispatchMouseDoubleClick(convertTouchToMouse(tfinger), params.touchToleranceDistance);
-				ENGINE->events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger), params.touchToleranceDistance);
+				ENGINE->events().dispatchMouseDoubleClick(position, params.touchToleranceDistance);
+				ENGINE->events().dispatchMouseLeftButtonReleased(position, params.touchToleranceDistance);
 			}
 			else
 			{
-				ENGINE->events().dispatchMouseLeftButtonPressed(convertTouchToMouse(tfinger), params.touchToleranceDistance);
-				ENGINE->events().dispatchMouseLeftButtonReleased(convertTouchToMouse(tfinger), params.touchToleranceDistance);
+				if(!touchStartedWithLeftClick)
+					ENGINE->events().dispatchMouseLeftButtonPressed(position, params.touchToleranceDistance);
+				ENGINE->events().dispatchMouseLeftButtonReleased(position, params.touchToleranceDistance);
 				lastLeftClickTimeTicks = tfinger.timestamp;
-				lastLeftClickPosition = convertTouchToMouse(tfinger);
+				lastLeftClickPosition = position;
 			}
+			touchStartedWithLeftClick = false;
 			state = TouchState::IDLE;
 			break;
 		}
@@ -281,6 +297,11 @@ void InputSourceTouch::handleUpdate()
 		uint32_t currentTime = SDL_GetTicks();
 		if (currentTime > lastTapTimeTicks + params.longTouchTimeMilliseconds)
 		{
+			if(touchStartedWithLeftClick)
+			{
+				ENGINE->events().dispatchMouseLeftButtonCancelled(lastTapPosition);
+				touchStartedWithLeftClick = false;
+			}
 			ENGINE->events().dispatchShowPopup(ENGINE->getCursorPosition(), params.touchToleranceDistance);
 
 			if (ENGINE->windows().isTopWindowPopup())

--- a/client/eventsSDL/InputSourceTouch.h
+++ b/client/eventsSDL/InputSourceTouch.h
@@ -110,6 +110,7 @@ class InputSourceTouch
 	uint32_t lastLeftClickTimeTicks;
 	Point lastLeftClickPosition;
 	int numTouchFingers;
+	bool touchStartedWithLeftClick;
 
 	std::map<SDL_FingerID, float> motionAccumulatedX;
 	std::map<SDL_FingerID, float> motionAccumulatedY;

--- a/client/gui/EventDispatcher.cpp
+++ b/client/gui/EventDispatcher.cpp
@@ -165,6 +165,23 @@ void EventDispatcher::dispatchMouseLeftButtonReleased(const Point & position, in
 	handleLeftButtonClick(position, tolerance, false);
 }
 
+void EventDispatcher::dispatchMouseLeftButtonCancelled(const Point & position)
+{
+	auto hlp = lclickable;
+
+	for(auto & i : hlp)
+	{
+		if(!vstd::contains(lclickable, i))
+			continue;
+
+		if(i->mouseClickedState)
+		{
+			i->mouseClickedState = false;
+			i->clickCancel(position);
+		}
+	}
+}
+
 AEventsReceiver * EventDispatcher::findElementInToleranceRange(const EventReceiversList & list, const Point & position, int eventToTest, int tolerance)
 {
 	AEventsReceiver * bestElement = nullptr;
@@ -358,6 +375,17 @@ void EventDispatcher::dispatchInputModeChanged(const InputMode & modi)
 	{
 		it->inputModeChanged(modi);
 	}
+}
+
+bool EventDispatcher::hasGestureReceiverAtPosition(const Point & position) const
+{
+	for(auto it : panningInterested)
+	{
+		if(it->receiveEvent(position, AEventsReceiver::GESTURE))
+			return true;
+	}
+
+	return false;
 }
 
 void EventDispatcher::dispatchGesturePanningStarted(const Point & initialPosition)

--- a/client/gui/EventDispatcher.h
+++ b/client/gui/EventDispatcher.h
@@ -67,6 +67,7 @@ public:
 	/// Mouse events
 	void dispatchMouseLeftButtonPressed(const Point & position, int tolerance);
 	void dispatchMouseLeftButtonReleased(const Point & position, int tolerance);
+	void dispatchMouseLeftButtonCancelled(const Point & position);
 	void dispatchMouseScrolled(const Point & distance, const Point & position);
 	void dispatchMouseDoubleClick(const Point & position, int tolerance);
 	void dispatchMouseMoved(const Point & distance, const Point & position);
@@ -81,6 +82,7 @@ public:
 	void dispatchGesturePanningEnded(const Point & initialPosition, const Point & finalPosition);
 	void dispatchGesturePanning(const Point & initialPosition, const Point & currentPosition, const Point & lastUpdateDistance);
 	void dispatchGesturePinch(const Point & initialPosition, double distance);
+	bool hasGestureReceiverAtPosition(const Point & position) const;
 
 	/// Text input events
 	void dispatchTextInput(const std::string & text);


### PR DESCRIPTION
### Motivation

- Touch interactions that start over gesture-receiving elements could generate redundant mouse left-click events leading to unexpected UI activation.
- Panning or long-press gestures should cancel any in-progress synthetic left-clicks to avoid duplicate/incorrect clicks.
- A way to query whether a gesture receiver exists at a position is needed to decide whether to synthesize a left-click.

### Description

- Added a `touchStartedWithLeftClick` flag to `InputSourceTouch` to track whether a touch began as a synthesized left-click and used it to gate produced left-click events and cancellations. 
- On finger down, the code now calls `EventDispatcher::hasGestureReceiverAtPosition` and only dispatches `dispatchMouseLeftButtonPressed` when no gesture receiver is present. 
- On panning start, double-tap transitions, and long-press timeouts the code will dispatch a new `dispatchMouseLeftButtonCancelled` to cancel any in-progress synthetic left-clicks and clear the tracking flag. 
- Introduced `dispatchMouseLeftButtonCancelled` and `hasGestureReceiverAtPosition` in `EventDispatcher` to support cancelling left-click state and checking for gesture receivers, and refactored short-tap handling to use a single `position` local variable to avoid repeated conversions.

### Testing

- Project was built after the changes and compilation succeeded. 
- No new automated tests were added in this change. 
- Existing automated test suite was executed and passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22c787b78c832d8e36dacc9d75dd1c)