### PR TITLE
Fix UI-state access from asynchronous image scaling

### DIFF
--- a/client/renderSDL/SDLImage.cpp
+++ b/client/renderSDL/SDLImage.cpp
@@ -262,9 +262,9 @@ std::shared_ptr<SDLImageShared> SDLImageShared::createScaled(const SDLImageShare
 
 	auto scaler = std::make_shared<SDLImageScaler>(from->surf, Rect(from->margins, from->fullSize), true);
 
-	const auto & scalingTask = [self, algorithm, scaler]()
+	const auto & scalingTask = [self, integerScaleFactor, algorithm, scaler]()
 	{
-		scaler->scaleSurfaceIntegerFactor(ENGINE->screenHandler().getScalingFactor(), algorithm);
+		scaler->scaleSurfaceIntegerFactor(integerScaleFactor, algorithm);
 		self->surf = scaler->acquireResultSurface();
 		self->fullSize = scaler->getResultDimensions().dimensions();
 		self->margins = scaler->getResultDimensions().topLeft();


### PR DESCRIPTION
### Motivation

- Investigate Android SIGSEGV during "Preparing to start new game" pointed to a TBB-backed image-scaling task that queried UI-owned `ScreenHandler` from a worker thread, creating a race/lifetime risk; the change prevents cross-thread UI access.

### Description

- Capture the requested integer scaling factor in `SDLImageShared::createScaled` by changing the scaling task lambda in `client/renderSDL/SDLImage.cpp` to `[self, integerScaleFactor, algorithm, scaler]` and call `scaler->scaleSurfaceIntegerFactor(integerScaleFactor, algorithm)` instead of reading `ENGINE->screenHandler().getScalingFactor()` from the worker thread.

### Testing

- Ran `git diff --check` which reported no whitespace errors and the change was committed successfully.
- Attempted to build with `cmake --build build --target vcmiclient -j2` but the workspace has no configured `build` directory so a full build/test run could not be executed; no runtime symbolization was possible because the unstripped Android arm64 binary for the reported BuildId was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2483025818832d85cbeb70b252db21)