### PR TITLE
Add hover text to quick spell buttons

### DIFF
--- a/client/battle/QuickSpellPanel.cpp
+++ b/client/battle/QuickSpellPanel.cpp
@@ -28,6 +28,7 @@
 #include "../../lib/json/JsonUtils.h"
 #include "../../lib/mapObjects/CGHeroInstance.h"
 #include "../../lib/spells/CSpellHandler.h"
+#include "../../lib/texts/MetaString.h"
 
 QuickSpellPanel::QuickSpellPanel(BattleInterface & owner)
 	: CIntObject(0)
@@ -107,12 +108,25 @@ void QuickSpellPanel::create()
 		bool fromSettings;
 		std::tie(id, fromSettings) = spells[i];
 
-		auto button = std::make_shared<CButton>(Point(2, 7 + 50 * i), AnimationPath::builtin("spellint"), CButton::tooltip(), [this, id, hero](){
-													if(id.hasValue() && id.toSpell()->canBeCast(owner.getBattle().get(), spells::Mode::HERO, hero))
-													{
-														owner.castThisSpell(id);
-													}
-												});
+		MetaString tooltip;
+		if(id.hasValue())
+		{
+			tooltip.appendTextID("core.genrltxt.26");
+			tooltip.replaceName(id);
+		}
+
+		auto button = std::make_shared<CButton>(
+			Point(2, 7 + 50 * i),
+			AnimationPath::builtin("spellint"),
+			CButton::tooltip(tooltip.toString()),
+			[this, id, hero]()
+			{
+				if(id.hasValue() && id.toSpell()->canBeCast(owner.getBattle().get(), spells::Mode::HERO, hero))
+				{
+					owner.castThisSpell(id);
+				}
+			}
+		);
 		button->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("spellint"), id != SpellID::NONE ? id.num + 1 : 0));
 		button->addPopupCallback([this, i, hero](){
 			ENGINE->input().hapticFeedback();

--- a/client/battle/QuickSpellPanel.cpp
+++ b/client/battle/QuickSpellPanel.cpp
@@ -108,25 +108,22 @@ void QuickSpellPanel::create()
 		bool fromSettings;
 		std::tie(id, fromSettings) = spells[i];
 
-		MetaString tooltip;
+		std::string hoverText;
 		if(id.hasValue())
 		{
+			MetaString tooltip;
 			tooltip.appendTextID("core.genrltxt.26");
 			tooltip.replaceName(id);
+			hoverText = tooltip.toString();
 		}
 
-		auto button = std::make_shared<CButton>(
-			Point(2, 7 + 50 * i),
-			AnimationPath::builtin("spellint"),
-			CButton::tooltip(tooltip.toString()),
-			[this, id, hero]()
-			{
-				if(id.hasValue() && id.toSpell()->canBeCast(owner.getBattle().get(), spells::Mode::HERO, hero))
-				{
-					owner.castThisSpell(id);
-				}
-			}
-		);
+		const auto & callback = [this, id, hero]()
+		{
+			if(id.hasValue() && id.toSpell()->canBeCast(owner.getBattle().get(), spells::Mode::HERO, hero))
+				owner.castThisSpell(id);
+		};
+
+		auto button = std::make_shared<CButton>(Point(2, 7 + 50 * i), AnimationPath::builtin("spellint"), CButton::tooltip(hoverText), callback);
 		button->setOverlay(std::make_shared<CAnimImage>(AnimationPath::builtin("spellint"), id != SpellID::NONE ? id.num + 1 : 0));
 		button->addPopupCallback([this, i, hero](){
 			ENGINE->input().hapticFeedback();


### PR DESCRIPTION
### Motivation

- The battle action panel already shows hover text describing spells and actions, while the Quick Spell panel lacked equivalent hover feedback; add the same localized "Cast <spell>" hover for quick-spell buttons to improve UX.

### Description

- Added `#include "../../lib/texts/MetaString.h"` and build a `MetaString` tooltip for each populated quick-spell slot using the localization key `core.genrltxt.26` and `replaceName(id)`.
- Pass the resulting string to the button constructor via `CButton::tooltip(tooltip.toString())`, leaving empty slots without hover text.
- Preserved existing behavior: left-click still casts the spell and right-click still opens the spell-selection popup (no change to popup callbacks).
- Modified file: `client/battle/QuickSpellPanel.cpp` (tooltip creation and button construction).

### Testing

- Ran `git diff --check` with no whitespace issues reported.
- Ran formatting checks with `git clang-format --diff HEAD -- client/battle/QuickSpellPanel.cpp` / `clang-format -i` to ensure style, and no formatting errors remained.
- Attempted a CMake configuration (`cmake -S . -B /tmp/vcmi-build -G Ninja -DENABLE_LAUNCHER=OFF -DENABLE_EDITOR=OFF -DENABLE_SERVER=OFF -DENABLE_TEST=OFF`), but configuration could not complete because required Boost components are missing in the environment (build environment dependency issue, not related to the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25d6edb0d0832d88e4e07afa1c9c56)