### PR TITLE
Oprava odloženého level-upu po boji u chráněných objektů

### DIFF
--- a/server/battles/BattleResultProcessor.cpp
+++ b/server/battles/BattleResultProcessor.cpp
@@ -355,7 +355,7 @@ void BattleResultProcessor::endBattleConfirm(const CBattleInfoCallback & battle)
 		if (winnerHero)
 		{
 			gameHandler->giveExperienceWithoutLevelUp(winnerHero, battleResult->exp[finishingBattle->winnerSide]);
-			battleQuery->heroesWithDeferredLevelUp.push_back(winnerHero->id);
+			typedBattleQuery->heroesWithDeferredLevelUp.push_back(winnerHero->id);
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Po sloučení reworku dotazů (PR 7308) se objevil regres: při návštěvě objektu, který dává odměnu a zároveň vedl k boji, se okamžitě vyskočil level-up a výběr skillu padal; původní záměr (PR 7437) byl nejdříve zobrazit odměny a až poté vyvolat level-up.
- Příčina byla nesprávné použití obecného `QueryPtr` při zapisování odložených level-upů po ukončení boje, což rozbil předchozí logiku odložení level-upu na `CBattleQuery`.

### Description
- Ve `server/battles/BattleResultProcessor.cpp` je nyní odložený level-up vítěze ukládán na ověřený/typovaný `CBattleQuery` (`typedBattleQuery->heroesWithDeferredLevelUp`) místo obecného `QueryPtr`.
- Toto vrací chování kompatibilní s mechanikou zpracování odměn z navštívených objektů: odložené level-upy jsou vyzvednuty a aplikovány až po zobrazení/uložení odměn objektu v `VisitQueries`/`MapQueries`.
- Změna je úzká a cílená (opravuje přístup k poli `heroesWithDeferredLevelUp`) a nezměnila veřejné API dotazů ani logiku vykreslování dialogů na klientu.

### Testing
- Spuštěné kontroly: `git diff --check` (bez chyb) a vyhledání starého používání `battleQuery->heroesWithDeferredLevelUp` (žádné zbylé výskyty) proběhly úspěšně.
- Pokus o konfiguraci buildu přes `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTS=ON` selhal kvůli chybějícím závislostem Boost v prostředí (není chyba změny), takže úplné přeložení/testy nebyly v tomto prostředí možné.
- Změna minimalizuje rozsah úprav a obnovuje očekávané pořadí: objektové odměny se nyní zobrazí před level-up dialogem, čímž by se měl odstranit crash při výběru skillu ve zmíněném scénáři.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2844a4e354832da8aed3a052322e38)