### PR TITLE
Separate RMG output from client log

### DIFF
--- a/clientapp/EntryPoint.cpp
+++ b/clientapp/EntryPoint.cpp
@@ -203,6 +203,7 @@ int main(int argc, char * argv[])
 	boost::filesystem::path logPath = VCMIDirs::get().userLogsPath() / "VCMI_Client_log.txt";
 	if(vm.count("logLocation"))
 		logPath = vm["logLocation"].as<std::string>() + "/VCMI_Client_log.txt";
+	const boost::filesystem::path rmgLogPath = logPath.parent_path() / "VCMI_RMG_log.txt";
 
 #ifndef VCMI_IOS
 
@@ -215,15 +216,16 @@ int main(int argc, char * argv[])
 	CConsoleHandler console(callbackFunction);
 	console.start();
 
-	CBasicLogConfigurator logConfigurator(logPath, &console);
+	CBasicLogConfigurator logConfigurator(logPath, &console, rmgLogPath);
 #else
-	CBasicLogConfigurator logConfigurator(logPath, nullptr);
+	CBasicLogConfigurator logConfigurator(logPath, nullptr, rmgLogPath);
 #endif
 
 	logConfigurator.configureDefault();
 	logGlobal->info("Starting client of '%s'", GameConstants::VCMI_VERSION);
 	logGlobal->info("Creating console and configuring logger: %d ms", pomtime.getDiff());
 	logGlobal->info("The log file will be saved to %s", logPath);
+	logGlobal->info("The RMG log file will be saved to %s", rmgLogPath);
 
 	// Init filesystem and settings
 	try

--- a/include/vstd/CLoggerBase.h
+++ b/include/vstd/CLoggerBase.h
@@ -198,6 +198,7 @@ extern DLL_LINKAGE vstd::CLoggerBase * logAi;
 extern DLL_LINKAGE vstd::CLoggerBase * logAnim;
 extern DLL_LINKAGE vstd::CLoggerBase * logMod;
 extern DLL_LINKAGE vstd::CLoggerBase * logRng;
+extern DLL_LINKAGE vstd::CLoggerBase * logRmg;
 extern DLL_LINKAGE vstd::CLoggerBase * logScript;
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/logging/CBasicLogConfigurator.cpp
+++ b/lib/logging/CBasicLogConfigurator.cpp
@@ -16,14 +16,13 @@
 
 VCMI_LIB_NAMESPACE_BEGIN
 
-CBasicLogConfigurator::CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console) :
-	filePath(std::move(filePath)), console(console), appendToLogFile(false) {}
+CBasicLogConfigurator::CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console, boost::filesystem::path rmgFilePath) :
+	filePath(std::move(filePath)), rmgFilePath(std::move(rmgFilePath)), console(console), appendToLogFile(false) {}
 
 void CBasicLogConfigurator::configureDefault()
 {
 	CLogger::getGlobalLogger()->addTarget(std::make_unique<CLogConsoleTarget>(console));
-	CLogger::getGlobalLogger()->addTarget(std::make_unique<CLogFileTarget>(filePath, appendToLogFile));
-	appendToLogFile = true;
+	addFileTargets();
 }
 
 void CBasicLogConfigurator::configure()
@@ -80,16 +79,15 @@ void CBasicLogConfigurator::configure()
 		}
 		CLogger::getGlobalLogger()->addTarget(std::move(consoleTarget));
 
-		// Add file target
-		auto fileTarget = std::make_unique<CLogFileTarget>(filePath, appendToLogFile);
+		// Add file targets
 		const JsonNode & fileNode = loggingNode["file"];
-		if(!fileNode.isNull())
+		if(!fileNode.isNull() && !fileNode["format"].isNull())
 		{
-			const JsonNode & fileFormatNode = fileNode["format"];
-			if(!fileFormatNode.isNull()) fileTarget->setFormatter(CLogFormatter(fileFormatNode.String()));
+			CLogFormatter formatter(fileNode["format"].String());
+			addFileTargets(&formatter);
 		}
-		CLogger::getGlobalLogger()->addTarget(std::move(fileTarget));
-		appendToLogFile = true;
+		else
+			addFileTargets();
 	}
 	catch(const std::exception & e)
 	{
@@ -103,6 +101,28 @@ void CBasicLogConfigurator::configure()
 		logGlobal->info("[log level] %s => %s", domain,
                     ELogLevel::to_string(CLogger::getLogger(CLoggerDomain(domain))->getLevel()));
 	}
+}
+
+void CBasicLogConfigurator::addFileTargets(const CLogFormatter * formatter)
+{
+	auto fileTarget = std::make_unique<CLogFileTarget>(filePath, appendToLogFile);
+	if(formatter)
+		fileTarget->setFormatter(*formatter);
+
+	if(!rmgFilePath.empty())
+	{
+		const CLoggerDomain rmgDomain("rmg");
+		fileTarget->excludeDomain(rmgDomain);
+
+		auto rmgFileTarget = std::make_unique<CLogFileTarget>(rmgFilePath, appendToLogFile);
+		if(formatter)
+			rmgFileTarget->setFormatter(*formatter);
+		CLogger::getLogger(rmgDomain)->clearTargets();
+		CLogger::getLogger(rmgDomain)->addTarget(std::move(rmgFileTarget));
+	}
+
+	CLogger::getGlobalLogger()->addTarget(std::move(fileTarget));
+	appendToLogFile = true;
 }
 
 ELogLevel::ELogLevel CBasicLogConfigurator::getLogLevel(const std::string & level)
@@ -149,6 +169,8 @@ void CBasicLogConfigurator::deconfigure()
 	auto l = CLogger::getGlobalLogger();
 	if(l != nullptr)
 		l->clearTargets();
+	if(!rmgFilePath.empty())
+		CLogger::getLogger(CLoggerDomain("rmg"))->clearTargets();
 	appendToLogFile = true;
 }
 

--- a/lib/logging/CBasicLogConfigurator.h
+++ b/lib/logging/CBasicLogConfigurator.h
@@ -14,6 +14,7 @@ VCMI_LIB_NAMESPACE_BEGIN
 
 class CConsoleHandler;
 class JsonNode;
+class CLogFormatter;
 enum class EConsoleTextColor : int8_t;
 
 /// The class CBasicLogConfigurator reads log properties from settings.json and
@@ -22,16 +23,16 @@ enum class EConsoleTextColor : int8_t;
 class DLL_LINKAGE CBasicLogConfigurator
 {
 public:
-	CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console);
+	CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console, boost::filesystem::path rmgFilePath = {});
 
-	/// Configures the logging system by parsing the logging settings. It adds the console target and the file target to the global logger.
+	/// Configures the logging system by parsing the logging settings. It adds the console target and configured file targets.
 	/// Doesn't throw, but logs on success or fault.
 	void configure();
 
-	/// Configures a default logging system by adding the console target and the file target to the global logger.
+	/// Configures a default logging system by adding the console target and configured file targets.
 	void configureDefault();
 
-	/// Removes all targets from the global logger.
+	/// Removes all configured targets.
 	void deconfigure();
 
 
@@ -43,7 +44,10 @@ private:
 	// Throws: std::runtime_error
 	static EConsoleTextColor getConsoleColor(const std::string & colorName);
 
+	void addFileTargets(const CLogFormatter * formatter = nullptr);
+
 	boost::filesystem::path filePath;
+	boost::filesystem::path rmgFilePath;
 	CConsoleHandler * console;
 	bool appendToLogFile;
 };

--- a/lib/logging/CLogger.cpp
+++ b/lib/logging/CLogger.cpp
@@ -98,6 +98,7 @@ DLL_LINKAGE vstd::CLoggerBase * logAi = CLogger::getLogger(CLoggerDomain("ai"));
 DLL_LINKAGE vstd::CLoggerBase * logAnim = CLogger::getLogger(CLoggerDomain("animation"));
 DLL_LINKAGE vstd::CLoggerBase * logMod = CLogger::getLogger(CLoggerDomain("mod"));
 DLL_LINKAGE vstd::CLoggerBase * logRng = CLogger::getLogger(CLoggerDomain("rng"));
+DLL_LINKAGE vstd::CLoggerBase * logRmg = CLogger::getLogger(CLoggerDomain("rmg"));
 DLL_LINKAGE vstd::CLoggerBase * logScript = CLogger::getLogger(CLoggerDomain("script"));
 
 CLogger * CLogger::getLogger(const CLoggerDomain & domain)
@@ -434,6 +435,14 @@ CLogFileTarget::CLogFileTarget(const boost::filesystem::path & filePath, bool ap
 
 void CLogFileTarget::write(const LogRecord & record)
 {
+	for(CLoggerDomain domain = record.domain; ; domain = domain.getParent())
+	{
+		if(excludedDomains.contains(domain.getName()))
+			return;
+		if(domain.isGlobalDomain())
+			break;
+	}
+
 	std::string message = formatter.format(record); //formatting is slow, do it outside the lock
 	std::lock_guard _(mx);
 	file << message << std::endl;
@@ -441,6 +450,7 @@ void CLogFileTarget::write(const LogRecord & record)
 
 const CLogFormatter & CLogFileTarget::getFormatter() const { return formatter; }
 void CLogFileTarget::setFormatter(const CLogFormatter & formatter) { this->formatter = formatter; }
+void CLogFileTarget::excludeDomain(const CLoggerDomain & domain) { excludedDomains.insert(domain.getName()); }
 
 CLogFileTarget::~CLogFileTarget()
 {

--- a/lib/logging/CLogger.h
+++ b/lib/logging/CLogger.h
@@ -214,12 +214,14 @@ public:
 
 	const CLogFormatter & getFormatter() const;
 	void setFormatter(const CLogFormatter & formatter);
+	void excludeDomain(const CLoggerDomain & domain);
 
 	void write(const LogRecord & record) override;
 
 private:
 	std::fstream file;
 	CLogFormatter formatter;
+	std::set<std::string> excludedDomains;
 	mutable std::mutex mx;
 };
 

--- a/lib/rmg/CMapGenOptions.cpp
+++ b/lib/rmg/CMapGenOptions.cpp
@@ -328,7 +328,7 @@ void CMapGenOptions::resetPlayersMap()
 		}
 		else
 		{
-			logGlobal->warn("Adding settings for player %s", color);
+			logRmg->warn("Adding settings for player %s", color);
 			// Usually, all players should be initialized in initPlayersMap()
 			CPlayerSettings settings;
 			players[color] = settings;
@@ -488,8 +488,8 @@ void CMapGenOptions::setPlayerTeam(const PlayerColor & color, const TeamID & tea
 
 void CMapGenOptions::finalize(vstd::RNG & rand)
 {
-	logGlobal->info("RMG map: %dx%d, %s underground", getWidth(), getHeight(), getLevels() >= 2 ? "WITH" : "NO");
-	logGlobal->info("RMG settings: players %d, teams %d, computer players %d, computer teams %d, water %d, monsters %d",
+	logRmg->info("RMG map: %dx%d, %s underground", getWidth(), getHeight(), getLevels() >= 2 ? "WITH" : "NO");
+	logRmg->info("RMG settings: players %d, teams %d, computer players %d, computer teams %d, water %d, monsters %d",
 		static_cast<int>(getHumanOrCpuPlayerCount()), static_cast<int>(getTeamCount()), static_cast<int>(getCompOnlyPlayerCount()),
 		static_cast<int>(getCompOnlyTeamCount()), static_cast<int>(getWaterContent()), static_cast<int>(getMonsterStrength()));
 
@@ -499,7 +499,7 @@ void CMapGenOptions::finalize(vstd::RNG & rand)
 	}
 	assert(mapTemplate);
 	
-	logGlobal->info("RMG template name: %s", mapTemplate->getName());
+	logRmg->info("RMG template name: %s", mapTemplate->getName());
 
 	auto maxPlayers = getMaxPlayersCount();
 	if (getHumanOrCpuPlayerCount() == RANDOM_SIZE)
@@ -569,7 +569,7 @@ void CMapGenOptions::finalize(vstd::RNG & rand)
 	assert (vstd::iswithin(waterContent, EWaterContent::NONE, EWaterContent::ISLANDS));
 	assert (vstd::iswithin(monsterStrength, EMonsterStrength::GLOBAL_WEAK, EMonsterStrength::GLOBAL_STRONG));
 
-	logGlobal->trace("Player config:");
+	logRmg->trace("Player config:");
 	int cpuOnlyPlayers = 0;
 	for(const auto & player : players)
 	{
@@ -589,9 +589,9 @@ void CMapGenOptions::finalize(vstd::RNG & rand)
 			default:
 				assert(false);
 		}
-		logGlobal->trace("Player %d: %s", player.second.getColor(), playerType);
+		logRmg->trace("Player %d: %s", player.second.getColor(), playerType);
 	}
-	logGlobal->info("Final player config: %d total, %d cpu-only", players.size(), cpuOnlyPlayers);
+	logRmg->info("Final player config: %d total, %d cpu-only", players.size(), cpuOnlyPlayers);
 }
 
 void CMapGenOptions::updatePlayers()
@@ -638,7 +638,7 @@ void CMapGenOptions::updateCompOnlyPlayers()
 
 	if (compOnlyPlayersToAdd < 0)
 	{
-		logGlobal->error("Incorrect number of players to add. Requested players %d, current players %d", humanOrCpuPlayerCount, players.size());
+		logRmg->error("Incorrect number of players to add. Requested players %d, current players %d", humanOrCpuPlayerCount, players.size());
 		assert (compOnlyPlayersToAdd < 0);
 	}
 	for(int i = 0; i < compOnlyPlayersToAdd; ++i)
@@ -676,7 +676,7 @@ PlayerColor CMapGenOptions::getNextPlayerColor() const
 			return i;
 		}
 	}
-	logGlobal->error("Failed to get next player color");
+	logRmg->error("Failed to get next player color");
 	assert(false);
 	return PlayerColor(0);
 }

--- a/lib/rmg/CMapGenerator.cpp
+++ b/lib/rmg/CMapGenerator.cpp
@@ -84,7 +84,7 @@ void CMapGenerator::loadConfig()
 	for(auto & i : randomMapJson["quests"]["rewardValue"].Vector())
 		config.questRewardValues.push_back(i.Integer());
 	config.seerHutValue = randomMapJson["quests"]["seerHutValue"].Integer();
-	logGlobal->info("Seer Hut value: %d", config.seerHutValue);
+	logRmg->info("Seer Hut value: %d", config.seerHutValue);
 	config.pandoraMultiplierGold = randomMapJson["pandoras"]["valueMultiplierGold"].Integer();
 	config.pandoraMultiplierExperience = randomMapJson["pandoras"]["valueMultiplierExperience"].Integer();
 	config.pandoraMultiplierSpells = randomMapJson["pandoras"]["valueMultiplierSpells"].Integer();
@@ -142,7 +142,7 @@ std::unique_ptr<CMap> CMapGenerator::generate()
 	}
 	catch (rmgException &e)
 	{
-		logGlobal->error("Random map generation received exception: %s", e.what());
+		logRmg->error("Random map generation received exception: %s", e.what());
 		throw;
 	}
 	Load::Progress::finish();
@@ -283,7 +283,7 @@ void CMapGenerator::addPlayerInfo()
 			}
 			teamOffset += teamCountNorm;
 		}
-		logGlobal->info("Current player settings size: %d",  mapGenOptions.getPlayersSettings().size());
+		logRmg->info("Current player settings size: %d",  mapGenOptions.getPlayersSettings().size());
 
 		// Team numbers are assigned randomly to every player
 		//TODO: allow to customize teams in rmg template
@@ -306,7 +306,7 @@ void CMapGenerator::addPlayerInfo()
 			{
 				if (teamNumbers[j].empty())
 				{
-					logGlobal->error("Not enough places in team for %s player", ((j == CPUONLY) ? "CPU" : "CPU or human"));
+					logRmg->error("Not enough places in team for %s player", ((j == CPUONLY) ? "CPU" : "CPU or human"));
 					assert (teamNumbers[j].size());
 				}
 				auto itTeam = RandomGeneratorUtil::nextItem(teamNumbers[j], *rand);
@@ -317,7 +317,7 @@ void CMapGenerator::addPlayerInfo()
 			map->getMap(this).players[pSettings.getColor().getNum()] = player;
 		}
 
-		logGlobal->info("Current team count: %d", teamsTotal.size());
+		logRmg->info("Current team count: %d", teamsTotal.size());
 
 	}
 	// FIXME: 0
@@ -336,7 +336,7 @@ void CMapGenerator::genZones()
 	CRoadRandomizer roadRandomizer(*map);
 	roadRandomizer.dropRandomRoads(rand.get());
 
-	logGlobal->info("Zones generated successfully");
+	logRmg->info("Zones generated successfully");
 }
 
 void CMapGenerator::addWaterTreasuresInfo()
@@ -355,7 +355,7 @@ void CMapGenerator::fillZones()
 {
 	addWaterTreasuresInfo();
 
-	logGlobal->info("Started filling zones");
+	logRmg->info("Started filling zones");
 
 	size_t numZones = map->getZones().size();
 
@@ -454,7 +454,7 @@ void CMapGenerator::fillZones()
 	map->getMap(this).grailPos = *RandomGeneratorUtil::nextItem(grailZone->freePaths()->getTiles(), *rand);
 	map->getMap(this).reindexObjects();
 
-	logGlobal->info("Zones filled successfully");
+	logRmg->info("Zones filled successfully");
 
 	Load::Progress::set(250);
 }

--- a/lib/rmg/CRmgTemplate.cpp
+++ b/lib/rmg/CRmgTemplate.cpp
@@ -389,14 +389,14 @@ void ZoneOptions::setRoadOption(int connectionId, rmg::ERoadOption roadOption)
 		if(connection.getId() == connectionId)
 		{
 			connection.setRoadOption(roadOption);
-			logGlobal->info("Set road option for connection %d between zones %d and %d to %s", 
+			logRmg->info("Set road option for connection %d between zones %d and %d to %s",
 				connectionId, connection.getZoneA(), connection.getZoneB(), 
 				roadOption == rmg::ERoadOption::ROAD_TRUE ? "true" : 
 				roadOption == rmg::ERoadOption::ROAD_FALSE ? "false" : "random");
 			return;
 		}
 	}
-	logGlobal->warn("Failed to find connection with ID %d in zone %d", connectionId, id);
+	logRmg->warn("Failed to find connection with ID %d in zone %d", connectionId, id);
 }
 
 std::vector<TRmgTemplateZoneId> ZoneOptions::getConnectedZoneIds() const
@@ -976,7 +976,7 @@ T CRmgTemplate::inheritZoneProperty(std::shared_ptr<rmg::ZoneOptions> zone,
 {
 	if (iteration >= 50)
 	{
-		logGlobal->error("Infinite recursion for %s detected in template %s", propertyString, name);
+		logRmg->error("Infinite recursion for %s detected in template %s", propertyString, name);
 		return T();
 	}
 	
@@ -1057,7 +1057,7 @@ void CRmgTemplate::inheritTownProperties(std::shared_ptr<rmg::ZoneOptions> zone,
 {
 	if (iteration >= 50)
 	{
-		logGlobal->error("Infinite recursion for town properties detected in template %s", name);
+		logRmg->error("Infinite recursion for town properties detected in template %s", name);
 		return;
 	}
 

--- a/lib/rmg/CRmgTemplateStorage.cpp
+++ b/lib/rmg/CRmgTemplateStorage.cpp
@@ -47,7 +47,7 @@ void CRmgTemplateStorage::loadObject(std::string scope, std::string name, const 
 	}
 	catch(const std::exception & e)
 	{
-		logGlobal->error("Template %s has errors. Message: %s.", name, std::string(e.what()));
+		logRmg->error("Template %s has errors. Message: %s.", name, std::string(e.what()));
 	}
 }
 

--- a/lib/rmg/CRoadRandomizer.cpp
+++ b/lib/rmg/CRoadRandomizer.cpp
@@ -51,7 +51,7 @@ Random road generation requirements:
 
 void CRoadRandomizer::dropRandomRoads(vstd::RNG * rand)
 {
-	logGlobal->info("Starting road randomization");
+	logRmg->info("Starting road randomization");
 
 	auto zones = map.getZones();
 	
@@ -84,7 +84,7 @@ void CRoadRandomizer::dropRandomRoads(vstd::RNG * rand)
 		}
 	}
 	
-	logGlobal->info("Found %d zones with towns", zonesWithTowns.size());
+	logRmg->info("Found %d zones with towns", zonesWithTowns.size());
 	
 	if(zonesWithTowns.empty())
 	{
@@ -179,7 +179,7 @@ void CRoadRandomizer::dropRandomRoads(vstd::RNG * rand)
 			// but never connect two non-town components together.
 			if(townInA || townInB)
 			{
-				logGlobal->info("Setting RANDOM road to TRUE for connection %d between zones %d and %d to connect town components.", connection.getId(), zoneA, zoneB);
+				logRmg->info("Setting RANDOM road to TRUE for connection %d between zones %d and %d to connect town components.", connection.getId(), zoneA, zoneB);
 				setRoadOptionForConnection(connection.getId(), rmg::ERoadOption::ROAD_TRUE);
 				
 				// Union the sets
@@ -227,14 +227,14 @@ void CRoadRandomizer::dropRandomRoads(vstd::RNG * rand)
 			// If exactly one road enters this zone, remove it
 			if(roadCount == 1)
 			{
-				logGlobal->info("Trimming loose end: removing road connection %d from zone %d (no town)", looseEndConnectionId, zoneId);
+				logRmg->info("Trimming loose end: removing road connection %d from zone %d (no town)", looseEndConnectionId, zoneId);
 				setRoadOptionForConnection(looseEndConnectionId, rmg::ERoadOption::ROAD_FALSE);
 				changed = true;
 			}
 		}
 	}
 
-	logGlobal->info("Finished road generation - created minimal spanning tree connecting all towns");
+	logRmg->info("Finished road generation - created minimal spanning tree connecting all towns");
 }
 
 VCMI_LIB_NAMESPACE_END

--- a/lib/rmg/CZoneGridPlacer.cpp
+++ b/lib/rmg/CZoneGridPlacer.cpp
@@ -406,13 +406,13 @@ void CZoneGridPlacer::logPlacement(
 {
 	if (!decision.foundPos)
 	{
-		logGlobal->warn("Could not find place for zone %d on level %d grid size %d", zone->getId(), level, gridSize);
+		logRmg->warn("Could not find place for zone %d on level %d grid size %d", zone->getId(), level, gridSize);
 		return;
 	}
 
 	if (decision.hasScore)
 	{
-		logGlobal->trace(
+		logRmg->trace(
 			"placeOnGrid: zone %d level %d grid %s score %.6g",
 			zone->getId(),
 			level,
@@ -421,7 +421,7 @@ void CZoneGridPlacer::logPlacement(
 	}
 	else
 	{
-		logGlobal->trace(
+		logRmg->trace(
 			"placeOnGrid: zone %d level %d grid %s",
 			zone->getId(),
 			level,
@@ -437,7 +437,7 @@ void CZoneGridPlacer::logInitialGrid(
 
 #define ZONE_PLACEMENT_LOG
 #ifdef ZONE_PLACEMENT_LOG
-	logGlobal->trace("Initial zone grid:");
+	logRmg->trace("Initial zone grid:");
 	for (int level = 0; level < mapLevels; ++level)
 	{
 		if (!grids[level])
@@ -445,7 +445,7 @@ void CZoneGridPlacer::logInitialGrid(
 
 		const auto & grid = *grids[level];
 		size_t gridSize = gridSizes[level];
-		logGlobal->trace("Level %d:", level);
+		logRmg->trace("Level %d:", level);
 
 		for (size_t x = 0; x < gridSize; ++x)
 		{
@@ -457,7 +457,7 @@ void CZoneGridPlacer::logInitialGrid(
 				else
 					s += " -- ";
 			}
-			logGlobal->trace(s);
+			logRmg->trace(s);
 		}
 	}
 #endif

--- a/lib/rmg/CZonePlacer.cpp
+++ b/lib/rmg/CZonePlacer.cpp
@@ -127,7 +127,7 @@ float CZonePlacer::scaleForceBetweenZones(const std::shared_ptr<Zone> zoneA, con
 
 void CZonePlacer::placeZones(vstd::RNG * rand)
 {
-	logGlobal->info("Starting zone placement");
+	logRmg->info("Starting zone placement");
 
 	width = map.getMapGenOptions().getWidth();
 	height = map.getMapGenOptions().getHeight();
@@ -196,7 +196,7 @@ void CZonePlacer::placeZones(vstd::RNG * rand)
 		}
 
 #ifdef ZONE_PLACEMENT_LOG
-		logGlobal->trace("Total distance between zones after this iteration: %2.4f, Total overlap: %2.4f, Improved: %s", totalDistance, totalOverlap , improvement);
+		logRmg->trace("Total distance between zones after this iteration: %2.4f, Total overlap: %2.4f, Improved: %s", totalDistance, totalOverlap , improvement);
 #endif
 
 		return improvement;
@@ -240,12 +240,12 @@ void CZonePlacer::placeZones(vstd::RNG * rand)
 
 	}
 
-	logGlobal->trace("Best fitness reached: total distance %2.4f, total overlap %2.4f", bestTotalDistance, bestTotalOverlap);
+	logRmg->trace("Best fitness reached: total distance %2.4f, total overlap %2.4f", bestTotalDistance, bestTotalOverlap);
 	for(const auto & zone : zones) //finalize zone positions
 	{
 		zone.second->setPos (cords (bestSolution[zone.second]));
 #ifdef ZONE_PLACEMENT_LOG
-		logGlobal->trace("Placed zone %d at relative position %s and coordinates %s", zone.first, zone.second->getCenter().toString(), zone.second->getPos().toString());
+		logRmg->trace("Placed zone %d at relative position %s and coordinates %s", zone.first, zone.second->getCenter().toString(), zone.second->getPos().toString());
 #endif
 	}
 }
@@ -324,7 +324,7 @@ void CZonePlacer::prepareZones(TZoneMap &zones, TZoneVector &zonesVector, const 
 			}
 			else
 			{
-				logGlobal->trace("Player %d (starting zone %d) does not participate in game", player.getNum(), zone.first);
+				logRmg->trace("Player %d (starting zone %d) does not participate in game", player.getNum(), zone.first);
 			}
 
 			if (faction == FactionID::RANDOM) //TODO: check this after a town has already been randomized
@@ -577,7 +577,7 @@ void CZonePlacer::moveOneZone(TZoneMap& zones, TForceVector& totalForces, TDista
 	});
 
 #ifdef ZONE_PLACEMENT_LOG
-	logGlobal->trace("Worst misplacement/movement ratio: %3.2f", misplacedZones.front().first);
+	logRmg->trace("Worst misplacement/movement ratio: %3.2f", misplacedZones.front().first);
 #endif
 
 	if (misplacedZones.size() >= 2)
@@ -620,7 +620,7 @@ void CZonePlacer::moveOneZone(TZoneMap& zones, TForceVector& totalForces, TDista
 		if (secondZone)
 		{
 #ifdef ZONE_PLACEMENT_LOG
-			logGlobal->trace("Swapping two misplaced zones %d and %d", firstZone->getId(), secondZone->getId());
+			logRmg->trace("Swapping two misplaced zones %d and %d", firstZone->getId(), secondZone->getId());
 #endif
 
 			auto firstCenter = firstZone->getCenter();
@@ -665,7 +665,7 @@ void CZonePlacer::moveOneZone(TZoneMap& zones, TForceVector& totalForces, TDista
 			float3 vec = targetZone->getCenter() - ourCenter;
 			float newDistanceBetweenZones = (std::max(misplacedZone->getSize(), targetZone->getSize())) / mapSize;
 #ifdef ZONE_PLACEMENT_LOG
-			logGlobal->trace("Trying to move zone %d %s towards %d %s. Direction is %s", misplacedZone->getId(), ourCenter.toString(), targetZone->getId(), targetZone->getCenter().toString(), vec.toString());
+			logRmg->trace("Trying to move zone %d %s towards %d %s. Direction is %s", misplacedZone->getId(), ourCenter.toString(), targetZone->getId(), targetZone->getCenter().toString(), vec.toString());
 #endif
 
 			misplacedZone->setCenter(targetZone->getCenter() - vec.unitVector() * newDistanceBetweenZones); //zones should now overlap by half size
@@ -695,7 +695,7 @@ void CZonePlacer::moveOneZone(TZoneMap& zones, TForceVector& totalForces, TDista
 			float3 vec = ourCenter - targetZone->getCenter();
 			float newDistanceBetweenZones = (misplacedZone->getSize() + targetZone->getSize()) / mapSize;
 #ifdef ZONE_PLACEMENT_LOG
-			logGlobal->trace("Trying to move zone %d %s away from %d %s. Direction is %s", misplacedZone->getId(), ourCenter.toString(), targetZone->getId(), targetZone->getCenter().toString(), vec.toString());
+			logRmg->trace("Trying to move zone %d %s away from %d %s. Direction is %s", misplacedZone->getId(), ourCenter.toString(), targetZone->getId(), targetZone->getCenter().toString(), vec.toString());
 #endif
 
 			misplacedZone->setCenter(targetZone->getCenter() + vec.unitVector() * newDistanceBetweenZones); //zones should now be just separated
@@ -713,7 +713,7 @@ float CZonePlacer::metric (const int3 &A, const int3 &B) const
 
 void CZonePlacer::assignZones(vstd::RNG * rand)
 {
-	logGlobal->info("Starting zone colouring");
+	logRmg->info("Starting zone colouring");
 
 	auto width = map.getMapGenOptions().getWidth();
 	auto height = map.getMapGenOptions().getHeight();
@@ -831,10 +831,10 @@ void CZonePlacer::assignZones(vstd::RNG * rand)
 			if(zone.second->area()->empty())
 			{
 				// FIXME: Some vertices are duplicated, but it's not a source of problem
-				logGlobal->error("Zone %d at %s is empty, dumping Penrose tiling", zone.second->getId(), zone.second->getCenter().toString());
+				logRmg->error("Zone %d at %s is empty, dumping Penrose tiling", zone.second->getId(), zone.second->getCenter().toString());
 				for (const auto & vertex : vertices)
 				{
-					logGlobal->warn("Penrose Vertex: %s", vertex.toString());
+					logRmg->warn("Penrose Vertex: %s", vertex.toString());
 				}
 				throw rmgException("Empty zone after Penrose tiling");
 			}
@@ -863,7 +863,7 @@ void CZonePlacer::assignZones(vstd::RNG * rand)
 			map.getMapProxy()->drawTerrain(*rand, v, ETerrainId::SUBTERRANEAN);
 		}
 	}
-	logGlobal->info("Finished zone colouring");
+	logRmg->info("Finished zone colouring");
 }
 
 void CZonePlacer::RemoveRoadsForWideConnections()

--- a/lib/rmg/Functions.cpp
+++ b/lib/rmg/Functions.cpp
@@ -32,7 +32,7 @@ void replaceWithCurvedPath(rmg::Path & path, Zone & zone, const int3 & src, bool
 
 	if(tiles.size() < 2)
 	{
-		logGlobal->warn("Zone too small for curved path");
+		logRmg->warn("Zone too small for curved path");
 		return;
 	}
 
@@ -53,7 +53,7 @@ void replaceWithCurvedPath(rmg::Path & path, Zone & zone, const int3 & src, bool
 	}
 	else
 	{
-		logGlobal->warn("Failed to create curved path to %s", src.toString());
+		logRmg->warn("Failed to create curved path to %s", src.toString());
 	}
 }
 

--- a/lib/rmg/ObjectConfig.cpp
+++ b/lib/rmg/ObjectConfig.cpp
@@ -27,7 +27,7 @@ void ObjectConfig::addBannedObject(const CompoundMapObjectID & objid)
 
 	bannedObjects.push_back(objid);
 
-	logGlobal->debug("Banned object of type %d.%d", objid.primaryID, objid.secondaryID);
+	logRmg->debug("Banned object of type %d.%d", objid.primaryID, objid.secondaryID);
 }
 
 void ObjectConfig::addCustomObject(const ObjectInfo & object)
@@ -40,14 +40,14 @@ void ObjectConfig::addCustomObject(const ObjectInfo & object)
 	bannedObjects.push_back(CompoundMapObjectID(object.primaryID, object.secondaryID));
 
 	assert(lastObject.templates.size() > 0);
-	logGlobal->debug("Added custom object of type %d.%d", object.primaryID, object.secondaryID);
+	logRmg->debug("Added custom object of type %d.%d", object.primaryID, object.secondaryID);
 }
 
 void ObjectConfig::addRequiredObject(const CompoundMapObjectID & objid, ui16 count, std::optional<ui32> guardLevel)
 {
 	requiredObjects[objid] = std::pair{count, guardLevel};
 
-	logGlobal->debug("Added required object of type %d.%d, count: %d, guard level: %d",
+	logRmg->debug("Added required object of type %d.%d, count: %d, guard level: %d",
 		objid.primaryID, objid.secondaryID, count,
 		guardLevel.has_value() ? std::to_string(guardLevel.value()) : "none");
 }

--- a/lib/rmg/Zone.cpp
+++ b/lib/rmg/Zone.cpp
@@ -310,7 +310,7 @@ void Zone::fractalize()
 	float blockDistance = minDistance * spanFactor; //More obstacles in the Underground
 	freeDistance = freeDistance * marginFactor;
 	vstd::amax(freeDistance, 4 * 4);
-	logGlobal->trace("Zone %d: treasureValue %d blockDistance: %2.f, freeDistance: %2.f", getId(), treasureValue, blockDistance, freeDistance);
+	logRmg->trace("Zone %d: treasureValue %d blockDistance: %2.f, freeDistance: %2.f", getId(), treasureValue, blockDistance, freeDistance);
 
 	Lock lock(areaMutex);
 

--- a/lib/rmg/modificators/ConnectionsPlacer.cpp
+++ b/lib/rmg/modificators/ConnectionsPlacer.cpp
@@ -473,9 +473,9 @@ void ConnectionsPlacer::collectNeighbourZones()
 bool ConnectionsPlacer::shouldGenerateRoad(const rmg::ZoneConnection& connection) const
 {
 	if (connection.getRoadOption() == rmg::ERoadOption::ROAD_RANDOM)
-		logGlobal->error("Random road between zones %d and %d", connection.getZoneA(), connection.getZoneB());
+		logRmg->error("Random road between zones %d and %d", connection.getZoneA(), connection.getZoneB());
 	else
-		logGlobal->info("Should generate road between zones %d and %d: %d", connection.getZoneA(), connection.getZoneB(), connection.getRoadOption() == rmg::ERoadOption::ROAD_TRUE);
+		logRmg->info("Should generate road between zones %d and %d: %d", connection.getZoneA(), connection.getZoneB(), connection.getRoadOption() == rmg::ERoadOption::ROAD_TRUE);
 	return connection.getRoadOption() == rmg::ERoadOption::ROAD_TRUE;
 }
 

--- a/lib/rmg/modificators/MinePlacer.cpp
+++ b/lib/rmg/modificators/MinePlacer.cpp
@@ -34,7 +34,7 @@ void MinePlacer::process()
 	auto * manager = zone.getModificator<ObjectManager>();
 	if(!manager)
 	{
-		logGlobal->error("ObjectManager doesn't exist for zone %d, skip modificator %s", zone.getId(), getName());
+		logRmg->error("ObjectManager doesn't exist for zone %d, skip modificator %s", zone.getId(), getName());
 		return;
 	}
 
@@ -70,7 +70,7 @@ bool MinePlacer::placeMines(ObjectManager & manager)
 
 			if(compatibleMineHandlers.empty())
 			{
-				logGlobal->error("No mine for resource %s found!", res.toResource()->getJsonKey());
+				logRmg->error("No mine for resource %s found!", res.toResource()->getJsonKey());
 				continue;
 			}
 

--- a/lib/rmg/modificators/Modificator.cpp
+++ b/lib/rmg/modificators/Modificator.cpp
@@ -80,7 +80,7 @@ void Modificator::run()
 
 	if(!finished)
 	{
-		logGlobal->trace("Modificator zone %d - %s - started", zone.getId(), getName());
+		logRmg->trace("Modificator zone %d - %s - started", zone.getId(), getName());
 		CStopWatch processTime;
 		try
 		{
@@ -88,13 +88,13 @@ void Modificator::run()
 		}
 		catch(rmgException &e)
 		{
-			logGlobal->error("Modificator %s, exception: %s", getName(), e.what());
+			logRmg->error("Modificator %s, exception: %s", getName(), e.what());
 		}
 #ifdef RMG_DUMP
 		dump();
 #endif
 		finished = true;
-		logGlobal->trace("Modificator zone %d - %s - done (%d ms)", zone.getId(), getName(), processTime.getDiff());
+		logRmg->trace("Modificator zone %d - %s - done (%d ms)", zone.getId(), getName(), processTime.getDiff());
 	}
 }
 

--- a/lib/rmg/modificators/ObjectDistributor.cpp
+++ b/lib/rmg/modificators/ObjectDistributor.cpp
@@ -66,7 +66,7 @@ void ObjectDistributor::distributeLimitedObjects()
 				{
 					if(excludedIDs.find(primaryID) != excludedIDs.end())
 					{
-						logGlobal->error("ObjectDistributor: Object %s does not support per-map limit", handler->getJsonKey());
+						logRmg->error("ObjectDistributor: Object %s does not support per-map limit", handler->getJsonKey());
 						continue;
 					}
 

--- a/lib/rmg/modificators/ObjectManager.cpp
+++ b/lib/rmg/modificators/ObjectManager.cpp
@@ -401,7 +401,7 @@ rmg::Path ObjectManager::placeAndConnectObject(const rmg::Area & searchArea, rmg
 bool ObjectManager::createMonoliths()
 {
 	// Special case for Junction zone only
-	logGlobal->trace("Creating Monoliths");
+	logRmg->trace("Creating Monoliths");
 	for(const auto & objInfo : requiredObjects)
 	{
 		if (objInfo.obj->ID != Obj::MONOLITH_TWO_WAY)
@@ -418,7 +418,7 @@ bool ObjectManager::createMonoliths()
 		
 		if(!path.valid())
 		{
-			logGlobal->error("Failed to fill zone %d due to lack of space", zone.getId());
+			logRmg->error("Failed to fill zone %d due to lack of space", zone.getId());
 			return false;
 		}
 
@@ -440,7 +440,7 @@ bool ObjectManager::createMonoliths()
 
 bool ObjectManager::createRequiredObjects()
 {
-	logGlobal->trace("Creating required objects");
+	logRmg->trace("Creating required objects");
 	
 	RecursiveLock lock(externalAccessMutex); //In case someone adds more objects
 	for(const auto & objInfo : requiredObjects)
@@ -454,7 +454,7 @@ bool ObjectManager::createRequiredObjects()
 		
 		if(!path.valid())
 		{
-			logGlobal->error("Failed to fill zone %d due to lack of space", zone.getId());
+			logRmg->error("Failed to fill zone %d due to lack of space", zone.getId());
 			return false;
 		}
 
@@ -504,7 +504,7 @@ bool ObjectManager::createRequiredObjects()
 		
 		if(!path.valid())
 		{
-			logGlobal->error("Failed to fill zone %d due to lack of space", zone.getId());
+			logRmg->error("Failed to fill zone %d due to lack of space", zone.getId());
 			return false;
 		}
 		
@@ -541,7 +541,7 @@ bool ObjectManager::createRequiredObjects()
 		{
 			for (auto* instance : rmgNearObject.instances())
 			{
-				logGlobal->error("Failed to connect nearby object %s at %s",
+				logRmg->error("Failed to connect nearby object %s at %s",
 					instance->object().getObjectName(), instance->getPosition(true).toString());
 				mapProxy->removeObject(&instance->object());
 			}

--- a/lib/rmg/modificators/ObjectPlacer.cpp
+++ b/lib/rmg/modificators/ObjectPlacer.cpp
@@ -21,7 +21,7 @@ void ObjectPlacer::process()
 	auto * manager = zone.getModificator<ObjectManager>();
 	if(!manager)
 	{
-		logGlobal->error("ObjectManager doesn't exist for zone %d, skip modificator %s", zone.getId(), getName());
+		logRmg->error("ObjectManager doesn't exist for zone %d, skip modificator %s", zone.getId(), getName());
 		return;
 	}
 
@@ -51,7 +51,7 @@ bool ObjectPlacer::placeRequiredObjects(ObjectManager & manager)
 				auto subObjects = LIBRARY->objtypeh->knownSubObjects(objid.primaryID);
 				if(subObjects.empty())
 				{
-					logGlobal->error("No subobjects for object type %d", objid.primaryID);
+					logRmg->error("No subobjects for object type %d", objid.primaryID);
 					continue;
 				}
 				secondaryID = *RandomGeneratorUtil::nextItem(subObjects, zone.getRand());

--- a/lib/rmg/modificators/ObstaclePlacer.cpp
+++ b/lib/rmg/modificators/ObstaclePlacer.cpp
@@ -45,13 +45,13 @@ void ObstaclePlacer::process()
 
 	if (!prepareBiome(filter, zone.getRand()))
 	{
-		logGlobal->warn("Failed to prepare biome, using all possible obstacles");
+		logRmg->warn("Failed to prepare biome, using all possible obstacles");
 		// Use all if we fail to create proper biome
 		collectPossibleObstacles(zone.getTerrainType());
 	}
 	else
 	{
-		logGlobal->info("Biome prepared successfully for zone %d", zone.getId());
+		logRmg->info("Biome prepared successfully for zone %d", zone.getId());
 	}
 	
 	{

--- a/lib/rmg/modificators/QuestArtifactPlacer.cpp
+++ b/lib/rmg/modificators/QuestArtifactPlacer.cpp
@@ -43,7 +43,7 @@ void QuestArtifactPlacer::addQuestArtZone(std::shared_ptr<Zone> otherZone)
 
 void QuestArtifactPlacer::addQuestArtifact(const ArtifactID& id, ui32 desiredValue)
 {
-	logGlobal->trace("Need to place quest artifact %s (desired value %u)",
+	logRmg->trace("Need to place quest artifact %s (desired value %u)",
 		LIBRARY->artifacts()->getById(id)->getNameTranslated(),
 		desiredValue);
 	RecursiveLock lock(externalAccessMutex);
@@ -52,7 +52,7 @@ void QuestArtifactPlacer::addQuestArtifact(const ArtifactID& id, ui32 desiredVal
 
 void QuestArtifactPlacer::removeQuestArtifact(const ArtifactID& id)
 {
-	logGlobal->trace("Will not try to place quest artifact %s", LIBRARY->artifacts()->getById(id)->getNameTranslated());
+	logRmg->trace("Will not try to place quest artifact %s", LIBRARY->artifacts()->getById(id)->getNameTranslated());
 	RecursiveLock lock(externalAccessMutex);
 	vstd::erase_if(questArtifactsToPlace, [&id](const QuestArtifactRequest& request)
 	{
@@ -124,7 +124,7 @@ void QuestArtifactPlacer::findZonesForQuestArts()
 		}
 	}
 
-	logGlobal->trace("Number of nearby zones suitable for quest artifacts: %d", questArtZones.size());
+	logRmg->trace("Number of nearby zones suitable for quest artifacts: %d", questArtZones.size());
 }
 
 void QuestArtifactPlacer::placeQuestArtifacts(vstd::RNG & rand)
@@ -146,7 +146,7 @@ void QuestArtifactPlacer::placeQuestArtifacts(vstd::RNG & rand)
 			if (!objectToReplace)
 				continue;
 
-			logGlobal->trace("Replacing %s at %s with the quest artifact %s (desired value %u)",
+			logRmg->trace("Replacing %s at %s with the quest artifact %s (desired value %u)",
 				objectToReplace->getObjectName(),
 				objectToReplace->anchorPos().toString(),
 				LIBRARY->artifacts()->getById(questRequest.id)->getNameTranslated(),

--- a/lib/rmg/modificators/RiverPlacer.cpp
+++ b/lib/rmg/modificators/RiverPlacer.cpp
@@ -312,7 +312,7 @@ void RiverPlacer::preprocess()
 	
 	if(source.empty())
 	{
-		logGlobal->info("River source is empty!");
+		logRmg->info("River source is empty!");
 		
 		//looking outside map
 		
@@ -325,7 +325,7 @@ void RiverPlacer::preprocess()
 	
 	if(sink.empty())
 	{
-		logGlobal->error("River sink is empty!");
+		logRmg->error("River sink is empty!");
 		for(auto & i : heightMap)
 		{
 			if(i.second <= 0)
@@ -371,7 +371,7 @@ void RiverPlacer::connectRiver(const int3 & tile)
 	
 	if(pathToSource.getPathArea().empty() || pathToSink.getPathArea().empty())
 	{
-		logGlobal->error("Cannot build river");
+		logRmg->error("Cannot build river");
 		return;
 	}
 	

--- a/lib/rmg/modificators/RoadPlacer.cpp
+++ b/lib/rmg/modificators/RoadPlacer.cpp
@@ -113,7 +113,7 @@ bool RoadPlacer::createRoad(const int3 & destination)
 		res = createRoadDesperate(path, destination);
 		if (!res.valid())
 		{
-			logGlobal->warn("Failed to create road to node %s", destination.toString());
+			logRmg->warn("Failed to create road to node %s", destination.toString());
 			return false;
 		}
 	}
@@ -229,11 +229,11 @@ void RoadPlacer::connectRoads()
 		}
 		catch (const rmgException& e)
 		{
-			logGlobal->warn("Handled exception while drawing road to node %s: %s", node.toString(), e.what());
+			logRmg->warn("Handled exception while drawing road to node %s: %s", node.toString(), e.what());
 		}
 		catch (const std::exception & e)
 		{
-			logGlobal->error("Unhandled exception while drawing road to node %s: %s", node.toString(), e.what());
+			logRmg->error("Unhandled exception while drawing road to node %s: %s", node.toString(), e.what());
 			throw;
 		}
 	}

--- a/lib/rmg/modificators/TerrainPainter.cpp
+++ b/lib/rmg/modificators/TerrainPainter.cpp
@@ -87,7 +87,7 @@ void TerrainPainter::initTerrainType()
 
 			if (terrainType <= ETerrainId::NONE)
 			{
-				logGlobal->warn("Town %s has invalid terrain type: %d", zone.getTownType(), terrainType);
+				logRmg->warn("Town %s has invalid terrain type: %d", zone.getTownType(), terrainType);
 				zone.setTerrainType(ETerrainId::DIRT);
 			}
 			else

--- a/lib/rmg/modificators/TownPlacer.cpp
+++ b/lib/rmg/modificators/TownPlacer.cpp
@@ -38,7 +38,7 @@ void TownPlacer::process()
 	auto * manager = zone.getModificator<ObjectManager>();
 	if(!manager)
 	{
-		logGlobal->error("ObjectManager doesn't exist for zone %d, skip modificator %s", zone.getId(), getName());
+		logRmg->error("ObjectManager doesn't exist for zone %d, skip modificator %s", zone.getId(), getName());
 		return;
 	}
 	
@@ -49,23 +49,23 @@ void TownPlacer::init()
 {
 	for(auto & townHint : zone.getTownHints())
 	{
-		logGlobal->info("Town hint of zone %d: %d", zone.getId(), townHint.likeZone);
+		logRmg->info("Town hint of zone %d: %d", zone.getId(), townHint.likeZone);
 		if(townHint.likeZone != rmg::ZoneOptions::NO_ZONE)
 		{
-			logGlobal->info("Dependency on town type of zone %d", townHint.likeZone);
+			logRmg->info("Dependency on town type of zone %d", townHint.likeZone);
 			dependency(map.getZones().at(townHint.likeZone)->getModificator<TownPlacer>());
 		}
 		else if(!townHint.notLikeZone.empty())
 		{
 			for(auto zoneId : townHint.notLikeZone)
 			{
-				logGlobal->info("Dependency on town unlike type of zone %d", zoneId);
+				logRmg->info("Dependency on town unlike type of zone %d", zoneId);
 				dependency(map.getZones().at(zoneId)->getModificator<TownPlacer>());
 			}
 		}
 		else if(townHint.relatedToZoneTerrain != rmg::ZoneOptions::NO_ZONE)
 		{
-			logGlobal->info("Dependency on town related to zone terrain of zone %d", townHint.relatedToZoneTerrain);
+			logRmg->info("Dependency on town related to zone terrain of zone %d", townHint.relatedToZoneTerrain);
 			dependency(map.getZones().at(townHint.relatedToZoneTerrain)->getModificator<TownPlacer>());
 		}
 	}
@@ -81,7 +81,7 @@ void TownPlacer::placeTowns(ObjectManager & manager)
 	if(zone.getOwner() && ((zone.getType() == ETemplateZoneType::CPU_START) || (zone.getType() == ETemplateZoneType::PLAYER_START)))
 	{
 		//set zone types to player faction, generate main town
-		logGlobal->info("Preparing playing zone");
+		logRmg->info("Preparing playing zone");
 		int player_id = *zone.getOwner() - 1;
 		const auto & playerSettings = map.getMapGenOptions().getPlayersSettings();
 		PlayerColor player;
@@ -120,7 +120,7 @@ void TownPlacer::placeTowns(ObjectManager & manager)
 		
 		if(player.isValidPlayer()) //configure info for owning player
 		{
-			logGlobal->trace("Fill player info %d", player_id);
+			logRmg->trace("Fill player info %d", player_id);
 			
 			// Update player info
 			auto & playerInfo = map.getPlayer(player.getNum());

--- a/lib/rmg/modificators/TreasurePlacer.cpp
+++ b/lib/rmg/modificators/TreasurePlacer.cpp
@@ -80,17 +80,17 @@ void TreasurePlacer::addObjectToRandomPool(const ObjectInfo& oi)
 {
 	if (oi.templates.empty())
 	{
-		logGlobal->error("Attempt to add ObjectInfo with no templates! Value: %d", oi.value);
+		logRmg->error("Attempt to add ObjectInfo with no templates! Value: %d", oi.value);
 		return;
 	}
 	if (!oi.generateObject)
 	{
-		logGlobal->error("Attempt to add ObjectInfo with no generateObject function! Value: %d", oi.value);
+		logRmg->error("Attempt to add ObjectInfo with no generateObject function! Value: %d", oi.value);
 		return;
 	}
 	if (!oi.maxPerZone)
 	{
-		logGlobal->warn("Attempt to add ObjectInfo with 0 maxPerZone! Value: %d", oi.value);
+		logRmg->warn("Attempt to add ObjectInfo with 0 maxPerZone! Value: %d", oi.value);
 		return;
 	}
 	RecursiveLock lock(externalAccessMutex);
@@ -778,7 +778,7 @@ rmg::Object TreasurePlacer::constructTreasurePile(const std::vector<ObjectInfo*>
 			object->rmgValue = oi->value;
 			if(oi->templates.empty())
 			{
-				logGlobal->warn("Deleting randomized object with no templates: %s", object->getObjectName());
+				logRmg->warn("Deleting randomized object with no templates: %s", object->getObjectName());
 				if (oi->destroyObject)
 					oi->destroyObject(*object);
 				continue;
@@ -786,7 +786,7 @@ rmg::Object TreasurePlacer::constructTreasurePile(const std::vector<ObjectInfo*>
 		}
 		else
 		{
-			logGlobal->error("ObjectInfo has no generateObject function! Templates: %d", oi->templates.size());
+			logRmg->error("ObjectInfo has no generateObject function! Templates: %d", oi->templates.size());
 			continue;
 		}
 		
@@ -1174,7 +1174,7 @@ void TreasurePlacer::ObjectPool::patchWithZoneConfig(const Zone & zone, Treasure
 			auto category = getObjectCategory(oi.getCompoundID());
 			if (categoriesSet.count(category))
 			{
-				logGlobal->debug("Removing object %s from possible objects", oi.templates.front()->stringID);
+				logRmg->debug("Removing object %s from possible objects", oi.templates.front()->stringID);
 				return true;
 			}
 			return false;
@@ -1191,7 +1191,7 @@ void TreasurePlacer::ObjectPool::patchWithZoneConfig(const Zone & zone, Treasure
 				if (bannedObjectsSet.count(key) || bannedObjectsSet.count(keyGroup))
 				{
 					// FIXME: Stopped working, nothing is banned
-					logGlobal->debug("Banning object %s from possible objects", templ->stringID);
+					logRmg->debug("Banning object %s from possible objects", templ->stringID);
 					return true;
 				}
 			}
@@ -1206,7 +1206,7 @@ void TreasurePlacer::ObjectPool::patchWithZoneConfig(const Zone & zone, Treasure
 	{
 		tp->setBasicProperties(object, object.getCompoundID());
 		addObject(object);
-		logGlobal->debug("Added custom object of type %d.%d", object.primaryID, object.secondaryID);
+		logRmg->debug("Added custom object of type %d.%d", object.primaryID, object.secondaryID);
 	}
 	// TODO: Overwrite or add to possibleObjects
 

--- a/lib/rmg/modificators/WaterProxy.cpp
+++ b/lib/rmg/modificators/WaterProxy.cpp
@@ -167,7 +167,7 @@ RouteInfo WaterProxy::waterRoute(Zone & dst)
 			//Don't place shipyard or boats on the very small lake
 			if (lake.area.getTilesVector().size() < 25)
 			{
-				logGlobal->info("Skipping very small lake at zone %d", dst.getId());
+				logRmg->info("Skipping very small lake at zone %d", dst.getId());
 				continue;
 			}
 						
@@ -185,18 +185,18 @@ RouteInfo WaterProxy::waterRoute(Zone & dst)
 			{
 				if(placeShipyard(dst, lake, generator.getConfig().shipyardGuard, createRoad, result))
 				{
-					logGlobal->info("Shipyard successfully placed at zone %d", dst.getId());
+					logRmg->info("Shipyard successfully placed at zone %d", dst.getId());
 				}
 				else
 				{
-					logGlobal->warn("Shipyard placement failed, trying boat at zone %d", dst.getId());
+					logRmg->warn("Shipyard placement failed, trying boat at zone %d", dst.getId());
 					if(placeBoat(dst, lake, createRoad, result))
 					{
-						logGlobal->warn("Boat successfully placed at zone %d", dst.getId());
+						logRmg->warn("Boat successfully placed at zone %d", dst.getId());
 					}
 					else
 					{
-						logGlobal->error("Boat placement failed at zone %d", dst.getId());
+						logRmg->error("Boat placement failed at zone %d", dst.getId());
 					}
 				}
 			}
@@ -204,11 +204,11 @@ RouteInfo WaterProxy::waterRoute(Zone & dst)
 			{
 				if(placeBoat(dst, lake,  createRoad, result))
 				{
-					logGlobal->info("Boat successfully placed at zone %d", dst.getId());
+					logRmg->info("Boat successfully placed at zone %d", dst.getId());
 				}
 				else
 				{
-					logGlobal->error("Boat placement failed at zone %d", dst.getId());
+					logRmg->error("Boat placement failed at zone %d", dst.getId());
 				}
 			}
 		}


### PR DESCRIPTION
### Motivation
- RMG (random map generator) log messages were mixed into the main client log, making RMG output hard to filter and manage separately.
- Provide a way to write RMG-generation logs to a dedicated file while keeping normal console output and existing formatting for other domains.

### Description
- Added a dedicated `rmg` logging domain and global `logRmg` logger and switched RMG sources to use `logRmg` instead of `logGlobal` in `lib/rmg` sources.
- Extended `CLogFileTarget` with an `excludeDomain` mechanism so a file target can ignore specific logger domains when writing to disk.
- Extended `CBasicLogConfigurator` to accept an optional `rmgFilePath`, to create two file targets: the main client log and a separate `VCMI_RMG_log.txt`, and to exclude the `rmg` domain from the main client file target while routing `rmg` domain messages into the dedicated file target.
- Updated client startup (`clientapp/EntryPoint.cpp`) to create `VCMI_RMG_log.txt` next to `VCMI_Client_log.txt` and to show the RMG log path in the startup messages.

### Testing
- Ran `git diff --check` and static source checks; no whitespace/merge issues reported.
- Verified via search that `lib/rmg` now uses `logRmg` and no longer uses `logGlobal` (checked with `rg` checks for `logGlobal->` / `logRmg->`).
- Attempted project configure with `cmake --preset linux-gcc-test`, which failed in the environment due to missing Boost development components, so a full build/test run could not be completed in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283c10001c832dba02466d1d55a1cb)