### PR TITLE
Fix campaign victory save flow

### DIFF
--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1349,10 +1349,10 @@ void CPlayerInterface::showGarrisonDialog(const CArmedInstance * up, const CGHer
 
 void CPlayerInterface::requestSent(const CPackForServer * pack, int requestID)
 {
-	if(dynamic_cast<const SaveGame *>(pack) && nextSaveConfirmationCallback)
+	if(dynamic_cast<const SaveGame *>(pack) && nextSaveResultCallback)
 	{
-		saveConfirmationCallbacks.emplace(requestID, std::move(nextSaveConfirmationCallback));
-		nextSaveConfirmationCallback = {};
+		saveResultCallbacks.emplace(requestID, std::move(nextSaveResultCallback));
+		nextSaveResultCallback = {};
 	}
 }
 
@@ -1368,13 +1368,18 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 		movementController->onQueryReplyApplied();
 	}
 
-	auto saveCallback = saveConfirmationCallbacks.find(pa->requestID);
-	if(saveCallback != saveConfirmationCallbacks.end())
+	auto saveCallback = saveResultCallbacks.find(pa->requestID);
+	if(saveCallback != saveResultCallbacks.end())
 	{
 		auto callback = std::move(saveCallback->second);
-		saveConfirmationCallbacks.erase(saveCallback);
+		saveResultCallbacks.erase(saveCallback);
 		waitForAllDialogs();
-		ENGINE->dispatchMainThread(callback);
+		ENGINE->dispatchMainThread(
+			[callback, result = pa->result]()
+			{
+				callback(result);
+			}
+		);
 	}
 }
 
@@ -1901,10 +1906,10 @@ void CPlayerInterface::proposeLoadingGame()
 	);
 }
 
-void CPlayerInterface::saveGameWithConfirmation(const std::string & path, std::function<void()> onConfirmationClosed)
+void CPlayerInterface::saveGameWithConfirmation(const std::string & path, std::function<void(bool)> onResultConfirmationClosed)
 {
-	assert(!nextSaveConfirmationCallback);
-	nextSaveConfirmationCallback = std::move(onConfirmationClosed);
+	assert(!nextSaveResultCallback);
+	nextSaveResultCallback = std::move(onResultConfirmationClosed);
 	makingTurn = true;
 	cb->save(path, true);
 }

--- a/client/CPlayerInterface.cpp
+++ b/client/CPlayerInterface.cpp
@@ -1347,6 +1347,15 @@ void CPlayerInterface::showGarrisonDialog(const CArmedInstance * up, const CGHer
 	ENGINE->windows().pushWindow(cgw);
 }
 
+void CPlayerInterface::requestSent(const CPackForServer * pack, int requestID)
+{
+	if(dynamic_cast<const SaveGame *>(pack) && nextSaveConfirmationCallback)
+	{
+		saveConfirmationCallbacks.emplace(requestID, std::move(nextSaveConfirmationCallback));
+		nextSaveConfirmationCallback = {};
+	}
+}
+
 void CPlayerInterface::requestRealized( PackageApplied *pa )
 {
 	if(pa->packType == CTypeList::getInstance().getTypeID<MoveHero>(nullptr))
@@ -1357,6 +1366,15 @@ void CPlayerInterface::requestRealized( PackageApplied *pa )
 		if(pendingLevelUpRequestID == static_cast<int>(pa->requestID))
 			closePendingLevelUpDialog();
 		movementController->onQueryReplyApplied();
+	}
+
+	auto saveCallback = saveConfirmationCallbacks.find(pa->requestID);
+	if(saveCallback != saveConfirmationCallbacks.end())
+	{
+		auto callback = std::move(saveCallback->second);
+		saveConfirmationCallbacks.erase(saveCallback);
+		waitForAllDialogs();
+		ENGINE->dispatchMainThread(callback);
 	}
 }
 
@@ -1881,6 +1899,14 @@ void CPlayerInterface::proposeLoadingGame()
 		},
 		nullptr
 	);
+}
+
+void CPlayerInterface::saveGameWithConfirmation(const std::string & path, std::function<void()> onConfirmationClosed)
+{
+	assert(!nextSaveConfirmationCallback);
+	nextSaveConfirmationCallback = std::move(onConfirmationClosed);
+	makingTurn = true;
+	cb->save(path, true);
 }
 
 void CPlayerInterface::quickSaveGame()

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -75,8 +75,8 @@ class CPlayerInterface : public CGameInterface
 	std::list<PendingDialog> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
 	std::shared_ptr<WindowBase> pendingLevelUpDialog;
 	int pendingLevelUpRequestID = -1;
-	std::function<void()> nextSaveConfirmationCallback;
-	std::map<uint32_t, std::function<void()>> saveConfirmationCallbacks;
+	std::function<void(bool)> nextSaveResultCallback;
+	std::map<uint32_t, std::function<void(bool)>> saveResultCallbacks;
 
 	std::unique_ptr<HeroMovementController> movementController;
 	std::unique_ptr<PathfinderCache> pathfinderCache;
@@ -219,7 +219,7 @@ public: // public interface for use by client via GAME->interface() access
 	bool checkQuickLoadingGame(bool verbose = false);
 	void proposeQuickLoadingGame();
 	void quickSaveGame();
-	void saveGameWithConfirmation(const std::string & path, std::function<void()> onConfirmationClosed);
+	void saveGameWithConfirmation(const std::string & path, std::function<void(bool)> onResultConfirmationClosed);
 	void performAutosave();
 	void gamePause(bool pause);
 	void endNetwork();

--- a/client/CPlayerInterface.h
+++ b/client/CPlayerInterface.h
@@ -75,6 +75,8 @@ class CPlayerInterface : public CGameInterface
 	std::list<PendingDialog> dialogs; //queue of dialogs awaiting to be shown (not currently shown!)
 	std::shared_ptr<WindowBase> pendingLevelUpDialog;
 	int pendingLevelUpRequestID = -1;
+	std::function<void()> nextSaveConfirmationCallback;
+	std::map<uint32_t, std::function<void()>> saveConfirmationCallbacks;
 
 	std::unique_ptr<HeroMovementController> movementController;
 	std::unique_ptr<PathfinderCache> pathfinderCache;
@@ -148,6 +150,7 @@ protected: // Call-ins from server, should not be called directly, but only via 
 	void availableCreaturesChanged(const CGDwelling *town) override;
 	void heroBonusChanged(const CGHeroInstance *hero, const Bonus &bonus, bool gain) override;//if gain hero received bonus, else he lost it
 	void playerBonusChanged(const Bonus &bonus, bool gain) override;
+	void requestSent(const CPackForServer * pack, int requestID) override;
 	void requestRealized(PackageApplied *pa) override;
 	void heroExchangeStarted(ObjectInstanceID hero1, ObjectInstanceID hero2, QueryID query) override;
 	void centerView (int3 pos, int focusTime) override;
@@ -216,6 +219,7 @@ public: // public interface for use by client via GAME->interface() access
 	bool checkQuickLoadingGame(bool verbose = false);
 	void proposeQuickLoadingGame();
 	void quickSaveGame();
+	void saveGameWithConfirmation(const std::string & path, std::function<void()> onConfirmationClosed);
 	void performAutosave();
 	void gamePause(bool pause);
 	void endNetwork();

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -840,17 +840,24 @@ void CServerHandler::startCampaignScenario(HighScoreParameter param, std::shared
 		openSaveScreen();
 }
 
-void CServerHandler::showCampaignSaveScreen(std::function<void()> continueCampaign)
+void CServerHandler::showCampaignSaveScreen(std::function<void()> continueCampaign, std::shared_ptr<CLoadingScreen> background)
 {
+	if(!background)
+	{
+		background = std::make_shared<CLoadingScreen>();
+		ENGINE->windows().pushWindow(background);
+	}
+
 	ENGINE->windows().createAndPushWindow<CSavingScreen>(
-		[this, continueCampaign = std::move(continueCampaign)](bool success)
+		[this, continueCampaign = std::move(continueCampaign), background](bool success)
 		{
 			if(!success)
 			{
-				showCampaignSaveScreen(continueCampaign);
+				showCampaignSaveScreen(continueCampaign, background);
 				return;
 			}
 
+			ENGINE->windows().popWindow(background);
 			endGameplay();
 			continueCampaign();
 		}

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -23,9 +23,10 @@
 
 #include "gui/WindowHandler.h"
 
-#include "lobby/CSelectionBase.h"
-#include "lobby/CLobbyScreen.h"
 #include "lobby/CBonusSelection.h"
+#include "lobby/CLobbyScreen.h"
+#include "lobby/CSavingScreen.h"
+#include "lobby/CSelectionBase.h"
 
 #include "netlag/NetworkLagCompensator.h"
 
@@ -787,51 +788,63 @@ void CServerHandler::startCampaignScenario(HighScoreParameter param, std::shared
 	if (!cs)
 		ourCampaign = si->campState;
 
-	param.campaignName = cs->getNameTranslated();
-	cs->highscoreParameters.push_back(param);
+	param.campaignName = ourCampaign->getNameTranslated();
+	ourCampaign->highscoreParameters.push_back(param);
 	auto campaignScoreCalculator = std::make_shared<HighScoreCalculation>();
 	campaignScoreCalculator->isCampaign = true;
-	campaignScoreCalculator->parameters = cs->highscoreParameters;
+	campaignScoreCalculator->parameters = ourCampaign->highscoreParameters;
 
-	endGameplay();
-
-	auto & epilogue = ourCampaign->scenario(*ourCampaign->lastScenario()).epilog;
-	auto finisher = [ourCampaign, campaignScoreCalculator, statistic]()
+	auto continueCampaign = [this, ourCampaign, campaignScoreCalculator, statistic]()
 	{
-		if(ourCampaign->campaignSet != "" && ourCampaign->isCampaignFinished())
-		{
-			Settings entry = persistentStorage.write["completedCampaigns"][ourCampaign->getFilename()];
-			entry->Bool() = true;
-		}
+		endGameplay();
 
-		if(!ourCampaign->isCampaignFinished())
-			GAME->mainmenu()->openCampaignLobby(ourCampaign);
+		auto & epilogue = ourCampaign->scenario(*ourCampaign->lastScenario()).epilog;
+		auto finisher = [ourCampaign, campaignScoreCalculator, statistic]()
+		{
+			if(ourCampaign->campaignSet != "" && ourCampaign->isCampaignFinished())
+			{
+				Settings entry = persistentStorage.write["completedCampaigns"][ourCampaign->getFilename()];
+				entry->Bool() = true;
+			}
+
+			if(!ourCampaign->isCampaignFinished())
+				GAME->mainmenu()->openCampaignLobby(ourCampaign);
+			else
+			{
+				GAME->mainmenu()->openCampaignScreen(ourCampaign->campaignSet);
+				if(!ourCampaign->getOutroVideo().empty() && ENGINE->video().open(ourCampaign->getOutroVideo(), 1))
+				{
+					ENGINE->music().stopMusic();
+					auto rim = ourCampaign->getVideoRim().empty() ? ImagePath::builtin("INTRORIM") : ourCampaign->getVideoRim();
+					if(ourCampaign->getVideoRim() == ImagePath::builtin("NONE"))
+						rim = ImagePath();
+					ENGINE->windows().createAndPushWindow<VideoWindow>(
+						ourCampaign->getOutroVideo(),
+						rim,
+						false,
+						1,
+						[campaignScoreCalculator, statistic](bool skipped)
+						{
+							ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
+						}
+					);
+				}
+				else
+					ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
+			}
+		};
+
+		if(epilogue.hasPrologEpilog)
+		{
+			ENGINE->windows().createAndPushWindow<CPrologEpilogVideo>(epilogue, finisher);
+		}
 		else
 		{
-			GAME->mainmenu()->openCampaignScreen(ourCampaign->campaignSet);
-			if(!ourCampaign->getOutroVideo().empty() && ENGINE->video().open(ourCampaign->getOutroVideo(), 1))
-			{
-				ENGINE->music().stopMusic();
-				auto rim = ourCampaign->getVideoRim().empty() ? ImagePath::builtin("INTRORIM") : ourCampaign->getVideoRim();
-				if(ourCampaign->getVideoRim() == ImagePath::builtin("NONE"))
-					rim = ImagePath();
-				ENGINE->windows().createAndPushWindow<VideoWindow>(ourCampaign->getOutroVideo(), rim, false, 1, [campaignScoreCalculator, statistic](bool skipped){
-					ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
-				});
-			}
-			else
-				ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
+			finisher();
 		}
 	};
 
-	if(epilogue.hasPrologEpilog)
-	{
-		ENGINE->windows().createAndPushWindow<CPrologEpilogVideo>(epilogue, finisher);
-	}
-	else
-	{
-		finisher();
-	}
+	ENGINE->windows().createAndPushWindow<CSavingScreen>(continueCampaign);
 }
 
 void CServerHandler::showServerError(const std::string & txt) const

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -794,57 +794,72 @@ void CServerHandler::startCampaignScenario(HighScoreParameter param, std::shared
 	campaignScoreCalculator->isCampaign = true;
 	campaignScoreCalculator->parameters = ourCampaign->highscoreParameters;
 
-	auto continueCampaign = [this, ourCampaign, campaignScoreCalculator, statistic]()
+	auto continueCampaign = [ourCampaign, campaignScoreCalculator, statistic]()
 	{
-		endGameplay();
-
-		auto & epilogue = ourCampaign->scenario(*ourCampaign->lastScenario()).epilog;
-		auto finisher = [ourCampaign, campaignScoreCalculator, statistic]()
+		if(ourCampaign->campaignSet != "" && ourCampaign->isCampaignFinished())
 		{
-			if(ourCampaign->campaignSet != "" && ourCampaign->isCampaignFinished())
-			{
-				Settings entry = persistentStorage.write["completedCampaigns"][ourCampaign->getFilename()];
-				entry->Bool() = true;
-			}
-
-			if(!ourCampaign->isCampaignFinished())
-				GAME->mainmenu()->openCampaignLobby(ourCampaign);
-			else
-			{
-				GAME->mainmenu()->openCampaignScreen(ourCampaign->campaignSet);
-				if(!ourCampaign->getOutroVideo().empty() && ENGINE->video().open(ourCampaign->getOutroVideo(), 1))
-				{
-					ENGINE->music().stopMusic();
-					auto rim = ourCampaign->getVideoRim().empty() ? ImagePath::builtin("INTRORIM") : ourCampaign->getVideoRim();
-					if(ourCampaign->getVideoRim() == ImagePath::builtin("NONE"))
-						rim = ImagePath();
-					ENGINE->windows().createAndPushWindow<VideoWindow>(
-						ourCampaign->getOutroVideo(),
-						rim,
-						false,
-						1,
-						[campaignScoreCalculator, statistic](bool skipped)
-						{
-							ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
-						}
-					);
-				}
-				else
-					ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
-			}
-		};
-
-		if(epilogue.hasPrologEpilog)
-		{
-			ENGINE->windows().createAndPushWindow<CPrologEpilogVideo>(epilogue, finisher);
+			Settings entry = persistentStorage.write["completedCampaigns"][ourCampaign->getFilename()];
+			entry->Bool() = true;
 		}
+
+		if(!ourCampaign->isCampaignFinished())
+			GAME->mainmenu()->openCampaignLobby(ourCampaign);
 		else
 		{
-			finisher();
+			GAME->mainmenu()->openCampaignScreen(ourCampaign->campaignSet);
+			if(!ourCampaign->getOutroVideo().empty() && ENGINE->video().open(ourCampaign->getOutroVideo(), 1))
+			{
+				ENGINE->music().stopMusic();
+				auto rim = ourCampaign->getVideoRim().empty() ? ImagePath::builtin("INTRORIM") : ourCampaign->getVideoRim();
+				if(ourCampaign->getVideoRim() == ImagePath::builtin("NONE"))
+					rim = ImagePath();
+				ENGINE->windows().createAndPushWindow<VideoWindow>(
+					ourCampaign->getOutroVideo(),
+					rim,
+					false,
+					1,
+					[campaignScoreCalculator, statistic](bool skipped)
+					{
+						ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
+					}
+				);
+			}
+			else
+				ENGINE->windows().createAndPushWindow<CHighScoreInputScreen>(true, *campaignScoreCalculator, statistic);
 		}
 	};
 
-	ENGINE->windows().createAndPushWindow<CSavingScreen>(continueCampaign);
+	auto showSaveScreen = std::make_shared<std::function<void()>>();
+	std::weak_ptr<std::function<void()>> weakShowSaveScreen = showSaveScreen;
+	*showSaveScreen = [this, continueCampaign, weakShowSaveScreen]()
+	{
+		auto retrySave = weakShowSaveScreen.lock();
+		assert(retrySave);
+		ENGINE->windows().createAndPushWindow<CSavingScreen>(
+			[this, continueCampaign, retrySave](bool success)
+			{
+				if(success)
+				{
+					endGameplay();
+					continueCampaign();
+				}
+				else
+				{
+					(*retrySave)();
+				}
+			}
+		);
+	};
+
+	auto openSaveScreen = [showSaveScreen]()
+	{
+		(*showSaveScreen)();
+	};
+	auto & epilogue = ourCampaign->scenario(*ourCampaign->lastScenario()).epilog;
+	if(epilogue.hasPrologEpilog)
+		ENGINE->windows().createAndPushWindow<CPrologEpilogVideo>(epilogue, openSaveScreen);
+	else
+		openSaveScreen();
 }
 
 void CServerHandler::showServerError(const std::string & txt) const

--- a/client/CServerHandler.cpp
+++ b/client/CServerHandler.cpp
@@ -829,37 +829,32 @@ void CServerHandler::startCampaignScenario(HighScoreParameter param, std::shared
 		}
 	};
 
-	auto showSaveScreen = std::make_shared<std::function<void()>>();
-	std::weak_ptr<std::function<void()>> weakShowSaveScreen = showSaveScreen;
-	*showSaveScreen = [this, continueCampaign, weakShowSaveScreen]()
+	auto openSaveScreen = [this, continueCampaign]()
 	{
-		auto retrySave = weakShowSaveScreen.lock();
-		assert(retrySave);
-		ENGINE->windows().createAndPushWindow<CSavingScreen>(
-			[this, continueCampaign, retrySave](bool success)
-			{
-				if(success)
-				{
-					endGameplay();
-					continueCampaign();
-				}
-				else
-				{
-					(*retrySave)();
-				}
-			}
-		);
-	};
-
-	auto openSaveScreen = [showSaveScreen]()
-	{
-		(*showSaveScreen)();
+		showCampaignSaveScreen(continueCampaign);
 	};
 	auto & epilogue = ourCampaign->scenario(*ourCampaign->lastScenario()).epilog;
 	if(epilogue.hasPrologEpilog)
 		ENGINE->windows().createAndPushWindow<CPrologEpilogVideo>(epilogue, openSaveScreen);
 	else
 		openSaveScreen();
+}
+
+void CServerHandler::showCampaignSaveScreen(std::function<void()> continueCampaign)
+{
+	ENGINE->windows().createAndPushWindow<CSavingScreen>(
+		[this, continueCampaign = std::move(continueCampaign)](bool success)
+		{
+			if(!success)
+			{
+				showCampaignSaveScreen(continueCampaign);
+				return;
+			}
+
+			endGameplay();
+			continueCampaign();
+		}
+	);
 }
 
 void CServerHandler::showServerError(const std::string & txt) const

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -41,6 +41,7 @@ class CBaseForLobbyApply;
 class GlobalLobbyClient;
 class GameChatHandler;
 class IServerRunner;
+class CLoadingScreen;
 
 enum class ESelectionScreen : ui8;
 enum class ELoadMode : ui8;
@@ -123,7 +124,7 @@ class CServerHandler final : public IServerAPI, public LobbyInfo, public INetwor
 	void onTimer() override;
 
 	void applyPackOnLobbyScreen(CPackForLobby & pack);
-	void showCampaignSaveScreen(std::function<void()> continueCampaign);
+	void showCampaignSaveScreen(std::function<void()> continueCampaign, std::shared_ptr<CLoadingScreen> background = {});
 
 	std::string serverHostname;
 	ui16 serverPort;

--- a/client/CServerHandler.h
+++ b/client/CServerHandler.h
@@ -123,6 +123,7 @@ class CServerHandler final : public IServerAPI, public LobbyInfo, public INetwor
 	void onTimer() override;
 
 	void applyPackOnLobbyScreen(CPackForLobby & pack);
+	void showCampaignSaveScreen(std::function<void()> continueCampaign);
 
 	std::string serverHostname;
 	ui16 serverPort;

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -43,7 +43,7 @@ CSavingScreen::CSavingScreen(std::function<void(bool)> onSaveResultConfirmationC
 		
 	buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRSAV.DEF"), LIBRARY->generaltexth->zelp[103], std::bind(&CSavingScreen::saveGame, this), EShortcut::LOBBY_SAVE_GAME);
 	if(onSaveResultConfirmationClosed)
-		buttonBack->block(true);
+		buttonBack->disable();
 
 	GAME->interface()->gamePause(true);
 }

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -28,8 +28,8 @@
 #include "../../lib/mapping/CMapHeader.h"
 #include "../../lib/GameLibrary.h"
 
-CSavingScreen::CSavingScreen(std::function<void()> onSaveConfirmationClosed)
-	: CSelectionBase(ESelectionScreen::saveGame), onSaveConfirmationClosed(std::move(onSaveConfirmationClosed))
+CSavingScreen::CSavingScreen(std::function<void(bool)> onSaveResultConfirmationClosed)
+	: CSelectionBase(ESelectionScreen::saveGame), onSaveResultConfirmationClosed(std::move(onSaveResultConfirmationClosed))
 {
 	OBJECT_CONSTRUCTION;
 	center(pos);
@@ -42,7 +42,7 @@ CSavingScreen::CSavingScreen(std::function<void()> onSaveConfirmationClosed)
 	curTab = tabSel;
 		
 	buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRSAV.DEF"), LIBRARY->generaltexth->zelp[103], std::bind(&CSavingScreen::saveGame, this), EShortcut::LOBBY_SAVE_GAME);
-	if(onSaveConfirmationClosed)
+	if(onSaveResultConfirmationClosed)
 		buttonBack->block(true);
 
 	GAME->interface()->gamePause(true);
@@ -87,8 +87,8 @@ void CSavingScreen::saveGame()
 	{
 		Settings lastSave = settings.write["general"]["lastSave"];
 		lastSave->String() = path;
-		if(onSaveConfirmationClosed)
-			GAME->interface()->saveGameWithConfirmation(path, onSaveConfirmationClosed);
+		if(onSaveResultConfirmationClosed)
+			GAME->interface()->saveGameWithConfirmation(path, onSaveResultConfirmationClosed);
 		else
 			GAME->interface()->cb->save(path, true);
 		close();

--- a/client/lobby/CSavingScreen.cpp
+++ b/client/lobby/CSavingScreen.cpp
@@ -28,8 +28,8 @@
 #include "../../lib/mapping/CMapHeader.h"
 #include "../../lib/GameLibrary.h"
 
-CSavingScreen::CSavingScreen()
-	: CSelectionBase(ESelectionScreen::saveGame)
+CSavingScreen::CSavingScreen(std::function<void()> onSaveConfirmationClosed)
+	: CSelectionBase(ESelectionScreen::saveGame), onSaveConfirmationClosed(std::move(onSaveConfirmationClosed))
 {
 	OBJECT_CONSTRUCTION;
 	center(pos);
@@ -42,7 +42,9 @@ CSavingScreen::CSavingScreen()
 	curTab = tabSel;
 		
 	buttonStart = std::make_shared<CButton>(Point(411, 535), AnimationPath::builtin("SCNRSAV.DEF"), LIBRARY->generaltexth->zelp[103], std::bind(&CSavingScreen::saveGame, this), EShortcut::LOBBY_SAVE_GAME);
-	
+	if(onSaveConfirmationClosed)
+		buttonBack->block(true);
+
 	GAME->interface()->gamePause(true);
 }
 
@@ -85,7 +87,10 @@ void CSavingScreen::saveGame()
 	{
 		Settings lastSave = settings.write["general"]["lastSave"];
 		lastSave->String() = path;
-		GAME->interface()->cb->save(path, true);
+		if(onSaveConfirmationClosed)
+			GAME->interface()->saveGameWithConfirmation(path, onSaveConfirmationClosed);
+		else
+			GAME->interface()->cb->save(path, true);
 		close();
 	};
 

--- a/client/lobby/CSavingScreen.h
+++ b/client/lobby/CSavingScreen.h
@@ -22,10 +22,12 @@ class CSelectionBase;
 
 class CSavingScreen : public CSelectionBase
 {
+	std::function<void()> onSaveConfirmationClosed;
+
 public:
 	std::shared_ptr<CMapInfo> localMi;
 
-	CSavingScreen();
+	explicit CSavingScreen(std::function<void()> onSaveConfirmationClosed = {});
 
 	void changeSelection(std::shared_ptr<CMapInfo> to);
 	void saveGame();

--- a/client/lobby/CSavingScreen.h
+++ b/client/lobby/CSavingScreen.h
@@ -22,12 +22,12 @@ class CSelectionBase;
 
 class CSavingScreen : public CSelectionBase
 {
-	std::function<void()> onSaveConfirmationClosed;
+	std::function<void(bool)> onSaveResultConfirmationClosed;
 
 public:
 	std::shared_ptr<CMapInfo> localMi;
 
-	explicit CSavingScreen(std::function<void()> onSaveConfirmationClosed = {});
+	explicit CSavingScreen(std::function<void(bool)> onSaveResultConfirmationClosed = {});
 
 	void changeSelection(std::shared_ptr<CMapInfo> to);
 	void saveGame();

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -520,13 +520,14 @@ void CGameHandler::handleReceivedPack(GameConnectionID connection, CPackForServe
 			result = false;
 		}
 
+		const bool isSaveGame = dynamic_cast<const SaveGame *>(&pack) != nullptr;
 		if(result)
 			logGlobal->trace("Message %s successfully applied!", typeid(pack).name());
-		else if(dynamic_cast<SaveGame *>(&pack) == nullptr)
+		else if(!isSaveGame)
 			complain((boost::format("Got false in applying %s... that request must have been fishy!")
 				% typeid(pack).name()).str());
 
-		sendPackageResponse(dynamic_cast<SaveGame *>(&pack) != nullptr ? result : true);
+		sendPackageResponse(isSaveGame ? result : true);
 	}
 }
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -522,11 +522,11 @@ void CGameHandler::handleReceivedPack(GameConnectionID connection, CPackForServe
 
 		if(result)
 			logGlobal->trace("Message %s successfully applied!", typeid(pack).name());
-		else
+		else if(dynamic_cast<SaveGame *>(&pack) == nullptr)
 			complain((boost::format("Got false in applying %s... that request must have been fishy!")
 				% typeid(pack).name()).str());
 
-		sendPackageResponse(true);
+		sendPackageResponse(dynamic_cast<SaveGame *>(&pack) != nullptr ? result : true);
 	}
 }
 
@@ -1638,12 +1638,11 @@ bool CGameHandler::responseStatistic(PlayerColor player)
 	return true;
 }
 
-void CGameHandler::save(const std::string & filename, PlayerColor playerToNotifyOnSuccess)
+bool CGameHandler::save(const std::string & filename, PlayerColor playerToNotifyOnSuccess)
 {
 	logGlobal->info("Saving to %s", filename);
 	ResourcePath savePath(filename, EResType::SAVEGAME);
 	const auto savefname = savePath.getOriginalName() + ".vsgm1";
-	CResourceHandler::get("local")->createResource(savefname);
 
 	std::string filenameWithoutPath;
 	auto pos = filename.find_last_of("/\\");
@@ -1656,6 +1655,7 @@ void CGameHandler::save(const std::string & filename, PlayerColor playerToNotify
 
 	try
 	{
+		CResourceHandler::get("local")->createResource(savefname);
 		CSaveFile save;
 		gameState().saveGame(save);
 		logGlobal->info("Saving server state");
@@ -1669,6 +1669,7 @@ void CGameHandler::save(const std::string & filename, PlayerColor playerToNotify
 			sendAndApply(iw);
 		}
 		logGlobal->info("Game has been successfully saved!");
+		return true;
 	}
 	catch(std::exception &e)
 	{
@@ -1679,6 +1680,7 @@ void CGameHandler::save(const std::string & filename, PlayerColor playerToNotify
 			sendAndApply(iw);
 		}
 		logGlobal->error("Failed to save game: %s", e.what());
+		return false;
 	}
 }
 

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -235,7 +235,7 @@ public:
 	bool bulkMergeStacks(SlotID slotSrc, ObjectInstanceID srcOwner);
 	bool bulkSplitAndRebalanceStack(SlotID slotSrc, ObjectInstanceID srcOwner);
 	bool responseStatistic(PlayerColor player);
-	void save(const std::string &fname, PlayerColor playerToNotifyOnSuccess);
+	bool save(const std::string & fname, PlayerColor playerToNotifyOnSuccess);
 	void load(const StartInfo &info);
 
 	void onPlayerTurnStarted(PlayerColor which);

--- a/server/NetPacksServer.cpp
+++ b/server/NetPacksServer.cpp
@@ -29,9 +29,9 @@
 
 void ApplyGhNetPackVisitor::visitSaveGame(SaveGame & pack)
 {
-	gh.save(pack.fname, pack.notifySuccess ? pack.player : PlayerColor::CANNOT_DETERMINE);
-	logGlobal->info("Game has been saved as %s", pack.fname);
-	result = true;
+	result = gh.save(pack.fname, pack.notifySuccess ? pack.player : PlayerColor::CANNOT_DETERMINE);
+	if(result)
+		logGlobal->info("Game has been saved as %s", pack.fname);
 }
 
 void ApplyGhNetPackVisitor::visitGamePause(GamePause & pack)


### PR DESCRIPTION
### Motivation
- Campaign scenarios previously proceeded to epilogue/next-screen immediately after victory without offering a mandatory save dialog and confirmation, so players could not save their campaign progress at the expected point.
- The intent is to always require the player to save after a campaign victory, show the save-success/failure InfoWindow, and only then continue to epilogue / next scenario selection.

### Description
- Show the save-screen before leaving a completed campaign scenario by creating `CSavingScreen` with a continuation callback from `CServerHandler::startCampaignScenario` and run the continuation only after save confirmation. (changes in `client/CServerHandler.cpp`)
- Add a `onSaveConfirmationClosed` callback to `CSavingScreen` so campaign flow can pass a continuation; block the Back button when this callback is present to prevent bypassing the required save. (changes in `client/lobby/CSavingScreen.h` and `client/lobby/CSavingScreen.cpp`)
- Extend `CPlayerInterface` to support a save-with-confirmation flow by adding `saveGameWithConfirmation`, tracking a pending callback mapped to the server `requestID` when a `SaveGame` request is sent, and invoking the continuation when the server acknowledges the package (`PackageApplied`). The continuation is dispatched to the main thread. (changes in `client/CPlayerInterface.h` and `client/CPlayerInterface.cpp`)
- Wire `CSavingScreen` to call `saveGameWithConfirmation` for campaign saves; normal save-screen behavior remains unchanged for other uses. (changes in `client/lobby/CSavingScreen.cpp`)

### Testing
- Ran static checks: `git diff --check` and `git clang-format --diff` against modified files; both reported no formatting issues.
- Performed a configure attempt with `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_TEST=OFF`; configuration failed in the container due to missing Boost development libraries (`date_time`, `filesystem`, `program_options`, `iostreams`), so full build/run tests could not be executed here.
- Verified local source diffs and that the new control flow triggers the save-screen continuation callback and waits for the server `PackageApplied` acknowledgement (code-level review and integration of callback paths succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28751a7044832da1ae91904519d18a)