### PR TITLE
Fix Lua scripting in static Android builds

### DIFF
--- a/lib/ScriptHandler.cpp
+++ b/lib/ScriptHandler.cpp
@@ -194,10 +194,14 @@ ScriptHandler::ScriptHandler()
 
 	filePath = VCMIDirs::get().fullLibraryPath("scripting", "vcmiLua");
 
+#ifdef STATIC_LUA
+	lua = CDynLibHandler::getNewScriptingModule(filePath);
+#else
 	if (boost::filesystem::exists(filePath))
 	{
 		lua = CDynLibHandler::getNewScriptingModule(filePath);
 	}
+#endif
 }
 
 ScriptHandler::~ScriptHandler() = default;

--- a/lib/callback/CDynLibHandler.cpp
+++ b/lib/callback/CDynLibHandler.cpp
@@ -12,6 +12,10 @@
 
 #include "CGlobalAI.h"
 
+#ifdef STATIC_LUA
+# include "../../scripting/lua/LuaScriptModule.h"
+#endif
+
 #include "../VCMIDirs.h"
 
 #ifdef STATIC_AI
@@ -150,7 +154,11 @@ std::shared_ptr<CBattleGameInterface> CDynLibHandler::getNewBattleAI(const std::
 #if SCRIPTING_ENABLED
 std::shared_ptr<scripting::Module> CDynLibHandler::getNewScriptingModule(const boost::filesystem::path & dllname)
 {
+#ifdef STATIC_LUA
+	return std::make_shared<scripting::LuaScriptModule>();
+#else
 	return createAny<scripting::Module>(dllname, "GetNewModule");
+#endif
 }
 #endif
 

--- a/scripting/lua/CMakeLists.txt
+++ b/scripting/lua/CMakeLists.txt
@@ -82,17 +82,31 @@ set(lib_HDRS
 		api/StackInstance.h
 )
 
-add_library(vcmiLua SHARED ${lib_SRCS} ${lib_HDRS})
-target_link_libraries(vcmiLua Boost::boost luajit::luajit vcmi)
+if(ENABLE_STATIC_LIBS)
+	# Static platforms cannot load vcmiLua at runtime. Embed every object so API registrations are retained.
+	add_library(vcmiLua OBJECT ${lib_SRCS} ${lib_HDRS})
+	target_link_libraries(vcmiLua PRIVATE Boost::boost luajit::luajit)
+	target_compile_definitions(vcmiLua PRIVATE STATIC_LUA)
+	if(APPLE_IOS OR ANDROID)
+		target_compile_definitions(vcmiLua PRIVATE VCMI_LIB_NAMESPACE=VCMI)
+	endif()
 
-vcmi_set_output_dir(vcmiLua "scripting")
-enable_pch(vcmiLua)
-
-if(APPLE_IOS)
-	install(TARGETS vcmiLua LIBRARY DESTINATION ${SCRIPTING_LIB_DIR})
+	target_sources(vcmi PRIVATE $<TARGET_OBJECTS:vcmiLua>)
+	target_link_libraries(vcmi PUBLIC luajit::luajit)
+	target_compile_definitions(vcmi PRIVATE STATIC_LUA)
 else()
-	install(TARGETS vcmiLua DESTINATION ${SCRIPTING_LIB_DIR})
+	add_library(vcmiLua SHARED ${lib_SRCS} ${lib_HDRS})
+	target_link_libraries(vcmiLua Boost::boost luajit::luajit vcmi)
+	vcmi_set_output_dir(vcmiLua "scripting")
+
+	if(APPLE_IOS)
+		install(TARGETS vcmiLua LIBRARY DESTINATION ${SCRIPTING_LIB_DIR})
+	else()
+		install(TARGETS vcmiLua DESTINATION ${SCRIPTING_LIB_DIR})
+	endif()
 endif()
+
+enable_pch(vcmiLua)
 
 #manually copy lua dll from vcpkg folder to build directory on windows since vcpkg deps copy feature has flaws, using hardcoded paths based on vcmi windows deps package 1.1 from github
 if(MSVC)

--- a/scripting/lua/LuaScriptModule.cpp
+++ b/scripting/lua/LuaScriptModule.cpp
@@ -17,9 +17,10 @@
 #define strcpy_s(a, b, c) strncpy(a, c, b)
 #endif
 
-static const char * const g_cszAiName = "Lua interpreter";
-
 VCMI_LIB_NAMESPACE_BEGIN
+
+#ifndef STATIC_LUA
+static const char * const g_cszAiName = "Lua interpreter";
 
 extern "C" DLL_EXPORT void GetAiName(char * name)
 {
@@ -30,6 +31,7 @@ extern "C" DLL_EXPORT void GetNewModule(std::shared_ptr<scripting::Module> & out
 {
 	out = std::make_shared<scripting::LuaScriptModule>();
 }
+#endif
 
 namespace scripting
 {


### PR DESCRIPTION
### Motivation
- Android builds enable `ENABLE_STATIC_LIBS` and `ENABLE_LUA` which left the Lua scripting module built as a shared library while the static runtime cannot load dynamic scripting modules. 
- After recent changes that require Lua during game initialization, the missing/failed Lua module caused immediate startup failures on Android (protocol errors followed by mutex/join cleanup errors).
- The goal is to ensure Lua API registrations and module initialization are available in static builds so game startup does not depend on loading a separate `vcmiLua` shared library.

### Description
- When `ENABLE_STATIC_LIBS` is set, build the Lua scripting sources as an OBJECT library and embed those objects into the `vcmi` library so Lua API registrations are linked into the static binary (`scripting/lua/CMakeLists.txt`).
- Add `STATIC_LUA` compile define and ensure `vcmi` links against `luajit` for static builds so Lua functionality is available in-process.
- Make `CDynLibHandler::getNewScriptingModule` return an instance of the embedded `LuaScriptModule` when `STATIC_LUA` is defined, avoiding attempts to dlopen a `vcmiLua` shared module (`lib/callback/CDynLibHandler.cpp`).
- Initialize the Lua scripting module unconditionally on static platforms in the script loader, skipping the file-existence check for a runtime `vcmiLua` (`lib/ScriptHandler.cpp`).
- Guard dynamic module entry points (`GetAiName` / `GetNewModule`) out of the static build so they are only emitted for the shared `vcmiLua` variant (`scripting/lua/LuaScriptModule.cpp`).

### Testing
- Ran repository checks (`diff --check`) and basic repository integrity checks which reported no problems. (passed)
- Performed a CMake smoke configure of the Lua subdirectory in a simulated static-Android configuration which generated build files successfully. (passed)
- Attempted a full project configure for a complete static-Lua build but the environment lacked Boost development packages, causing configuration to fail; this is an environment issue, not a code regression. (configuration failed due to missing system deps)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a294d488630832d9af9d0a253d977ff)