### PR TITLE
Enable PCH for windows-msvc-ninja-release CMake preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -261,6 +261,7 @@
                 "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
                 "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
                 "ENABLE_MULTI_PROCESS_BUILDS": "OFF",
+                "ENABLE_PCH": "ON",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "CMAKE_C_FLAGS_RELWITHDEBINFO": "/O2 /Ob1 /DNDEBUG /Z7",
                 "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "/O2 /Ob1 /DNDEBUG /Z7"


### PR DESCRIPTION
### Motivation

- Enable precompiled headers for the Ninja MSVC release preset to improve build times for the `windows-msvc-ninja-release` configuration.

### Description

- Updated `CMakePresets.json` to set `"ENABLE_PCH": "ON"` in the `cacheVariables` of the `windows-msvc-ninja-release` preset.

### Testing

- Ran `cmake --preset=windows-msvc-ninja-release` to validate configure/generation with the updated preset and the step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e52899cc8832d8bd0c5eb3fdecb57)