### PR TITLE
Enable unity build for Windows Ninja RelWithDebInfo preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -261,6 +261,8 @@
                 "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
                 "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
                 "ENABLE_MULTI_PROCESS_BUILDS": "OFF",
+                "CMAKE_UNITY_BUILD": "ON",
+                "CMAKE_UNITY_BUILD_BATCH_SIZE": "16",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "CMAKE_C_FLAGS_RELWITHDEBINFO": "/O2 /Ob1 /DNDEBUG /Z7",
                 "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "/O2 /Ob1 /DNDEBUG /Z7"


### PR DESCRIPTION
### Motivation
- Reduce build times and improve linker throughput for the Windows Ninja RelWithDebInfo preset by enabling unity builds for that configuration.

### Description
- Added `CMAKE_UNITY_BUILD` = `ON` and `CMAKE_UNITY_BUILD_BATCH_SIZE` = `16` to the `windows-msvc-ninja-release` preset in `CMakePresets.json`.

### Testing
- Ran `cmake --preset windows-msvc-ninja-release` and `cmake --build --preset windows-msvc-ninja-release` on Windows x64 and the configuration and build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e52899cc8832d8bd0c5eb3fdecb57)