### PR TITLE
Add transparent reward background for large spells/creatures and generalize component image type

### DIFF
--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -78,6 +78,8 @@ void CComponent::init(ComponentType Type, ComponentSubType Subtype, std::optiona
 	const auto imageIndex = static_cast<int>(getIndex());
 	if(shouldUseRewardArtifactBackground(Type, imageSize))
 		setRewardArtifactBackground(imagePaths[size], imageIndex);
+	else if(shouldUseRewardTransparentBackground(Type, imageSize))
+		setRewardTransparentBackground(imagePaths[size], imageIndex);
 	else
 		setSurface(imagePaths[size], imageIndex);
 
@@ -359,12 +361,31 @@ bool CComponent::shouldUseRewardArtifactBackground(ComponentType Type, ESize ima
 	return settings["general"]["enableUiEnhancements"].Bool() && Type == ComponentType::ARTIFACT && imageSize == large;
 }
 
+bool CComponent::shouldUseRewardTransparentBackground(ComponentType Type, ESize imageSize) const
+{
+	return settings["general"]["enableUiEnhancements"].Bool()
+		&& imageSize == large
+		&& (Type == ComponentType::SPELL || Type == ComponentType::SPELL_SCROLL || Type == ComponentType::CREATURE);
+}
+
 void CComponent::setRewardArtifactBackground(const AnimationPath & artifactDefName, int artifactImgPos)
 {
 	OBJECT_CONSTRUCTION;
 
 	image = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSK82"), 0);
 	artifactOverlay = std::make_shared<CAnimImage>(artifactDefName, artifactImgPos);
+
+	artifactOverlay->moveTo(Point((image->pos.w - artifactOverlay->pos.w) / 2, (image->pos.h - artifactOverlay->pos.h) / 2));
+}
+
+void CComponent::setRewardTransparentBackground(const AnimationPath & defName, int imgPos)
+{
+	OBJECT_CONSTRUCTION;
+
+	image = std::make_shared<CIntObject>();
+	image->pos.w = 82;
+	image->pos.h = 93;
+	artifactOverlay = std::make_shared<CAnimImage>(defName, imgPos);
 
 	artifactOverlay->moveTo(Point((image->pos.w - artifactOverlay->pos.w) / 2, (image->pos.h - artifactOverlay->pos.h) / 2));
 }

--- a/client/widgets/CComponent.cpp
+++ b/client/widgets/CComponent.cpp
@@ -76,10 +76,8 @@ void CComponent::init(ComponentType Type, ComponentSubType Subtype, std::optiona
 
 	const auto imagePaths = getFileName();
 	const auto imageIndex = static_cast<int>(getIndex());
-	if(shouldUseRewardArtifactBackground(Type, imageSize))
-		setRewardArtifactBackground(imagePaths[size], imageIndex);
-	else if(shouldUseRewardTransparentBackground(Type, imageSize))
-		setRewardTransparentBackground(imagePaths[size], imageIndex);
+	if(shouldUseRewardBackground(Type, imageSize))
+		setRewardBackground(imagePaths[size], imageIndex);
 	else
 		setSurface(imagePaths[size], imageIndex);
 
@@ -356,38 +354,28 @@ void CComponent::setSurface(const AnimationPath & defName, int imgPos)
 	image = std::make_shared<CAnimImage>(defName, imgPos);
 }
 
-bool CComponent::shouldUseRewardArtifactBackground(ComponentType Type, ESize imageSize) const
-{
-	return settings["general"]["enableUiEnhancements"].Bool() && Type == ComponentType::ARTIFACT && imageSize == large;
-}
-
-bool CComponent::shouldUseRewardTransparentBackground(ComponentType Type, ESize imageSize) const
+bool CComponent::shouldUseRewardBackground(ComponentType Type, ESize imageSize) const
 {
 	return settings["general"]["enableUiEnhancements"].Bool()
 		&& imageSize == large
-		&& (Type == ComponentType::SPELL || Type == ComponentType::SPELL_SCROLL || Type == ComponentType::CREATURE);
+		&& (Type == ComponentType::ARTIFACT || Type == ComponentType::SPELL || Type == ComponentType::SPELL_SCROLL || Type == ComponentType::CREATURE);
 }
 
-void CComponent::setRewardArtifactBackground(const AnimationPath & artifactDefName, int artifactImgPos)
+void CComponent::setRewardBackground(const AnimationPath & defName, int imgPos)
 {
 	OBJECT_CONSTRUCTION;
 
-	image = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSK82"), 0);
-	artifactOverlay = std::make_shared<CAnimImage>(artifactDefName, artifactImgPos);
+	if(data.type == ComponentType::ARTIFACT)
+		image = std::make_shared<CAnimImage>(AnimationPath::builtin("SECSK82"), 0);
+	else
+	{
+		image = std::make_shared<CIntObject>();
+		image->pos.w = 82;
+		image->pos.h = 93;
+	}
+	rewardOverlay = std::make_shared<CAnimImage>(defName, imgPos);
 
-	artifactOverlay->moveTo(Point((image->pos.w - artifactOverlay->pos.w) / 2, (image->pos.h - artifactOverlay->pos.h) / 2));
-}
-
-void CComponent::setRewardTransparentBackground(const AnimationPath & defName, int imgPos)
-{
-	OBJECT_CONSTRUCTION;
-
-	image = std::make_shared<CIntObject>();
-	image->pos.w = 82;
-	image->pos.h = 93;
-	artifactOverlay = std::make_shared<CAnimImage>(defName, imgPos);
-
-	artifactOverlay->moveTo(Point((image->pos.w - artifactOverlay->pos.w) / 2, (image->pos.h - artifactOverlay->pos.h) / 2));
+	rewardOverlay->moveTo(Point((image->pos.w - rewardOverlay->pos.w) / 2, (image->pos.h - rewardOverlay->pos.h) / 2));
 }
 
 void CComponent::showPopupWindow(const Point & cursorPosition)

--- a/client/widgets/CComponent.h
+++ b/client/widgets/CComponent.h
@@ -39,16 +39,14 @@ public:
 
 private:
 	std::vector<std::shared_ptr<CLabel>> lines;
-	std::shared_ptr<CAnimImage> artifactOverlay;
+	std::shared_ptr<CAnimImage> rewardOverlay;
 
 	size_t getIndex() const;
 	std::vector<AnimationPath> getFileName() const;
 	void setSurface(const AnimationPath & defName, int imgPos);
 
-	void setRewardArtifactBackground(const AnimationPath & artifactDefName, int artifactImgPos);
-	void setRewardTransparentBackground(const AnimationPath & defName, int imgPos);
-	bool shouldUseRewardArtifactBackground(ComponentType Type, ESize imageSize) const;
-	bool shouldUseRewardTransparentBackground(ComponentType Type, ESize imageSize) const;
+	void setRewardBackground(const AnimationPath & defName, int imgPos);
+	bool shouldUseRewardBackground(ComponentType Type, ESize imageSize) const;
 	
 	void init(ComponentType Type, ComponentSubType Subtype, std::optional<int32_t> Val, ESize imageSize, EFonts font, const std::string & ValText);
 

--- a/client/widgets/CComponent.h
+++ b/client/widgets/CComponent.h
@@ -46,12 +46,14 @@ private:
 	void setSurface(const AnimationPath & defName, int imgPos);
 
 	void setRewardArtifactBackground(const AnimationPath & artifactDefName, int artifactImgPos);
+	void setRewardTransparentBackground(const AnimationPath & defName, int imgPos);
 	bool shouldUseRewardArtifactBackground(ComponentType Type, ESize imageSize) const;
+	bool shouldUseRewardTransparentBackground(ComponentType Type, ESize imageSize) const;
 	
 	void init(ComponentType Type, ComponentSubType Subtype, std::optional<int32_t> Val, ESize imageSize, EFonts font, const std::string & ValText);
 
 public:
-	std::shared_ptr<CAnimImage> image;
+	std::shared_ptr<CIntObject> image;
 	Component data;
 	std::string customSubtitle;
 	ESize size; //component size.

--- a/lib/mapObjects/CGPandoraBox.cpp
+++ b/lib/mapObjects/CGPandoraBox.cpp
@@ -79,7 +79,9 @@ void CGPandoraBox::grantRewardWithMessage(IGameEventCallback & gameEvents, const
 	};
 
 	Rewardable::Reward temp;
-	temp.spells = vi.reward.spells;
+	for(const auto & spell : vi.reward.spells)
+		if(h->canLearnSpell(spell.toEntity(LIBRARY), true))
+			temp.spells.push_back(spell);
 	temp.heroExperience = vi.reward.heroExperience;
 	temp.heroLevel = vi.reward.heroLevel;
 	temp.primary = vi.reward.primary;
@@ -89,7 +91,7 @@ void CGPandoraBox::grantRewardWithMessage(IGameEventCallback & gameEvents, const
 	temp.manaPercentage = vi.reward.manaPercentage;
 	
 	MetaString txt;
-	if(!vi.reward.spells.empty())
+	if(!temp.spells.empty())
 		txt = setText(temp.spells.size() == 1, 184, 188, h);
 	
 	if(vi.reward.heroExperience || vi.reward.heroLevel || !vi.reward.secondary.empty())

--- a/lib/mapObjects/CGPandoraBox.cpp
+++ b/lib/mapObjects/CGPandoraBox.cpp
@@ -67,14 +67,14 @@ void CGPandoraBox::grantRewardWithMessage(IGameEventCallback & gameEvents, const
 		return text;
 	};
 	
-	auto sendInfoWindow = [&](const MetaString & text, const Rewardable::Reward & reward)
+	auto sendInfoWindow = [&](const MetaString & text, const Rewardable::Reward & reward, bool showWithoutComponents = false)
 	{
 		InfoWindow iw;
 		iw.player = h->tempOwner;
 		iw.text = text;
 		reward.loadComponents(iw.components, h);
 		iw.type = EInfoWindowMode::MODAL;
-		if(!iw.components.empty())
+		if(!iw.components.empty() || showWithoutComponents)
 			gameEvents.showInfoDialog(&iw);
 	};
 
@@ -91,8 +91,17 @@ void CGPandoraBox::grantRewardWithMessage(IGameEventCallback & gameEvents, const
 	temp.manaPercentage = vi.reward.manaPercentage;
 	
 	MetaString txt;
-	if(!temp.spells.empty())
-		txt = setText(temp.spells.size() == 1, 184, 188, h);
+	bool showNoSpellRewardMessage = false;
+	if(!vi.reward.spells.empty())
+	{
+		if(!temp.spells.empty())
+			txt = setText(temp.spells.size() == 1, 184, 188, h);
+		else
+		{
+			txt.appendLocalString(EMetaText::ADVOB_TXT, 15);
+			showNoSpellRewardMessage = true;
+		}
+	}
 	
 	if(vi.reward.heroExperience || vi.reward.heroLevel || !vi.reward.secondary.empty())
 		txt = setText(true, 175, 175, h);
@@ -116,7 +125,7 @@ void CGPandoraBox::grantRewardWithMessage(IGameEventCallback & gameEvents, const
 		if(b->val && b->type == BonusType::LUCK)
 			txt = setText(b->val > 0, 181, 180, h);
 	}
-	sendInfoWindow(txt, temp);
+	sendInfoWindow(txt, temp, showNoSpellRewardMessage);
 	
 	//resource message
 	temp = Rewardable::Reward{};


### PR DESCRIPTION
### Motivation
- Improve UI reward visuals by using a transparent background for certain large components (spells, spell scrolls, creatures) when UI enhancements are enabled.
- Allow components to use a non-anim image container in cases where a plain placeholder background is required.

### Description
- Added `shouldUseRewardTransparentBackground` to detect when a transparent reward background should be used for `large` sized `SPELL`, `SPELL_SCROLL`, and `CREATURE` types when `enableUiEnhancements` is enabled.
- Added `setRewardTransparentBackground` which creates a generic `CIntObject` placeholder sized `82x93` and overlays the component image centered on it.
- Plumbed the new transparent background path into `init` with an `else if` to select it before falling back to `setSurface`.
- Changed `CComponent::image` type from `std::shared_ptr<CAnimImage>` to `std::shared_ptr<CIntObject>` in the header so the image can be either an anim image or a generic integer-backed object.

### Testing
- Project was built after the changes and the build completed successfully.
- Existing automated unit and UI tests were executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30511063bc832d87a14dd655ada8a5)