### PR TITLE
Use PYTHONPATH for test partial helper import

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -674,6 +674,7 @@ jobs:
       if: always()
       env:
         PLATFORM: ${{ matrix.platform }}
+        PYTHONPATH: ${{ github.workspace }}/CI
       run: |
         python3 CI/emit_test_partial.py
 

--- a/CI/emit_test_partial.py
+++ b/CI/emit_test_partial.py
@@ -5,8 +5,7 @@ import os
 import pathlib
 import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-from emit_partial import parse_ccache, run  # noqa: E402
+from emit_partial import parse_ccache, run
 
 
 def main() -> int:


### PR DESCRIPTION
### Motivation
- Avoid modifying `sys.path` at runtime in `CI/emit_test_partial.py` and use the environment to locate the helper module for cleaner CI behavior.

### Description
- Removed the `sys.path` insertion from `CI/emit_test_partial.py` and changed the import to a normal top-level import of `emit_partial`, and set `PYTHONPATH: ${{ github.workspace }}/CI` for the GitHub Actions step that runs the script in `.github/workflows/github.yml`.

### Testing
- Ran `PYTHONPATH=$PWD/CI PLATFORM=test python3 CI/emit_test_partial.py` which produced the expected `.summary` output file and exited successfully. 
- Ran `python3 -m py_compile CI/emit_test_partial.py CI/emit_partial.py` which succeeded with no syntax errors. 
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e7991c1c4832d98c0bc3e9316b147)