### PR TITLE
Fix die, fool command to use normal shutdown path

### DIFF
--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -51,7 +51,10 @@
 
 void ClientCommandManager::handleQuitCommand()
 {
-		exit(EXIT_SUCCESS);
+	if(ENGINE->amIGuiThread())
+		GAME->onShutdownRequested(false);
+	else
+		ENGINE->dispatchMainThread([]() { GAME->onShutdownRequested(false); });
 }
 
 void ClientCommandManager::handleSaveCommand(std::istringstream & singleWordBuffer)

--- a/client/ClientCommandManager.cpp
+++ b/client/ClientCommandManager.cpp
@@ -51,6 +51,9 @@
 
 void ClientCommandManager::handleQuitCommand()
 {
+	if(!ENGINE)
+		exit(EXIT_SUCCESS);
+
 	if(ENGINE->amIGuiThread())
 		GAME->onShutdownRequested(false);
 	else


### PR DESCRIPTION
### Motivation
- Prevent abrupt process termination and crash dumps by routing the `die, fool` command through the engine's normal shutdown flow and ensuring the shutdown runs on the GUI thread.

### Description
- Replace direct `exit(EXIT_SUCCESS)` in `ClientCommandManager::handleQuitCommand()` with a call to `GAME->onShutdownRequested(false)`, and dispatch that call via `ENGINE->dispatchMainThread()` when invoked from a non-GUI thread.

### Testing
- Ran `git diff --check` to validate the diff and ran `rg` searches for `void ClientCommandManager::handleQuitCommand`, `onShutdownRequested(false)`, and `die, fool` to verify updated references, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47e6f29a5c832dac763678236621a3)