### PR TITLE
Disable MMAI AI library by default in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ option(ENABLE_GOLDMASTER "Build in public release mode in which some debug routi
 option(ENABLE_NULLKILLER2_AI "Enable compilation of Nullkiller2AI library" ON)
 option(ENABLE_STUPID_AI "Enable compilation of StupidAI library" ON)
 option(ENABLE_BATTLE_AI "Enable compilation of BattleAI library" ON)
-option(ENABLE_MMAI "Enable compilation of MMAI AI library" ON)
+option(ENABLE_MMAI "Enable compilation of MMAI AI library" OFF)
 
 # Compilation options
 


### PR DESCRIPTION
### Motivation
- Reduce default build scope and optional dependency footprint by disabling the MMAI AI module by default so that builds do not enable it unless explicitly requested.  

### Description
- Change default value of the CMake option `ENABLE_MMAI` from `ON` to `OFF` in `CMakeLists.txt`.  

### Testing
- No automated tests were executed for this trivial CMake flag change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ac6cea9fc832db6bab13fe2329059)