### PR TITLE
First-launch: add selectable data import actions, ZIP import and demo support

### DIFF
--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/util/FileUtil.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/util/FileUtil.java
@@ -126,17 +126,15 @@ public class FileUtil
 	private static void copyFileFromUri(String sourceFileUri, String destinationFile, Context context)
 	{
 		try (InputStream inputStream  = context.getContentResolver().openInputStream(Uri.parse(sourceFileUri));
-			 FileOutputStream outputStream = new FileOutputStream(new File(destinationFile))) {
-	            copyStream(inputStream, outputStream);
-		        // ensure data is flushed and durably written
-	            outputStream.flush();
-	            outputStream.getFD().sync();
-	        }
-
-	    catch (IOException e)
+			 FileOutputStream outputStream = new FileOutputStream(new File(destinationFile)))
 		{
-	        Log.e("FileUtil", "copyFileFromUri failed: " + sourceFileUri + " -> " + destinationFile, e);
-	    }
+			copyStream(inputStream, outputStream);
+			outputStream.flush();
+		}
+		catch (IOException e)
+		{
+			Log.e("FileUtil", "copyFileFromUri failed: " + sourceFileUri + " -> " + destinationFile, e);
+		}
 	}
 
 	@SuppressWarnings(Const.JNI_METHOD_SUPPRESS)

--- a/android/vcmi-app/src/main/java/eu/vcmi/vcmi/util/FileUtil.java
+++ b/android/vcmi-app/src/main/java/eu/vcmi/vcmi/util/FileUtil.java
@@ -130,6 +130,7 @@ public class FileUtil
 		{
 			copyStream(inputStream, outputStream);
 			outputStream.flush();
+			outputStream.getFD().sync();
 		}
 		catch (IOException e)
 		{

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -971,7 +971,7 @@ void FirstLaunchView::loadModPresets()
 
 void FirstLaunchView::createModPresetWidgets()
 {
-	int row = 2;
+	int row = 3;
 	for(auto & preset : modPresets)
 	{
 		auto button = std::make_unique<QToolButton>(ui->scrollAreaPresetModsContents);

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -473,20 +473,21 @@ void FirstLaunchView::selectCopySource()
 	// iOS can't display modal dialogs when called directly on button press
 	// https://bugreports.qt.io/browse/QTBUG-98651
 	MessageBoxCustom::showDialog(this, [this]{
-		const bool canUseFolderPicker = Helper::canUseFolderPicker();
+		if(!Helper::canUseFolderPicker())
+		{
+			selectZipSource();
+			return;
+		}
+
 		QMessageBox msg(this);
 		msg.setWindowTitle(tr("Select Heroes III data"));
-		msg.setText(canUseFolderPicker
-			? tr("Choose how to import existing Heroes III data files.")
-			: tr("Select a ZIP archive with Heroes III data files."));
-		QPushButton * folderButton = canUseFolderPicker
-			? msg.addButton(tr("Select folder"), QMessageBox::AcceptRole)
-			: nullptr;
+		msg.setText(tr("Choose how to import existing Heroes III data files."));
+		QPushButton * folderButton = msg.addButton(tr("Select folder"), QMessageBox::AcceptRole);
 		QPushButton * zipButton = msg.addButton(tr("Select ZIP archive"), QMessageBox::AcceptRole);
 		msg.addButton(QMessageBox::Cancel);
 		msg.exec();
 
-		if(folderButton && msg.clickedButton() == folderButton)
+		if(msg.clickedButton() == folderButton)
 		{
 			Helper::nativeFolderPicker(this, [this](const QString & picked){
 				if(!picked.isEmpty())
@@ -495,23 +496,28 @@ void FirstLaunchView::selectCopySource()
 		}
 		else if(msg.clickedButton() == zipButton)
 		{
-#if defined(VCMI_MOBILE)
-			QMessageBox::information(this, tr("File selection"), tr("Select a ZIP archive with Heroes III data files"));
-#endif
-			needPostCopyCheckZip = false;
-			QString archivePath = QFileDialog::getOpenFileName(this, tr("Select Heroes III data archive"), defaultStartDirForOpen(), tr("Zip archives (*.zip)"));
-			if(archivePath.isEmpty())
-				return;
-
-			QString errorText = checkFileMagic(archivePath, tr("Zip archives (*.zip)"), QByteArray{"PK"}, "ZIP", needPostCopyCheckZip);
-			if(!errorText.isEmpty())
-			{
-				QMessageBox::critical(this, tr("Invalid file selected"), errorText);
-				return;
-			}
-			copyHeroesDataFromZip(archivePath);
+			selectZipSource();
 		}
 	});
+}
+
+void FirstLaunchView::selectZipSource()
+{
+#if defined(VCMI_MOBILE)
+	QMessageBox::information(this, tr("File selection"), tr("Select a ZIP archive with Heroes III data files"));
+#endif
+	needPostCopyCheckZip = false;
+	QString archivePath = QFileDialog::getOpenFileName(this, tr("Select Heroes III data archive"), defaultStartDirForOpen(), tr("Zip archives (*.zip)"));
+	if(archivePath.isEmpty())
+		return;
+
+	QString errorText = checkFileMagic(archivePath, tr("Zip archives (*.zip)"), QByteArray{"PK"}, "ZIP", needPostCopyCheckZip);
+	if(!errorText.isEmpty())
+	{
+		QMessageBox::critical(this, tr("Invalid file selected"), errorText);
+		return;
+	}
+	copyHeroesDataFromZip(archivePath);
 }
 
 void FirstLaunchView::extractGogData()

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -866,11 +866,22 @@ void FirstLaunchView::copyHeroesDataFromZip(const QString & path)
 			overlay->setRange(static_cast<int>(files.size()));
 			for(int i = 0; i < static_cast<int>(files.size()); ++i)
 			{
-				overlay->setFileName(QString::fromUtf8(files[i].data(), static_cast<int>(files[i].size())));
+				const std::string & file = files[i];
+				overlay->setFileName(QString::fromUtf8(file.data(), static_cast<int>(file.size())));
 				overlay->setValue(i + 1);
 				qApp->processEvents();
-				if(!archive.extract(qstringToPath(tempDir.path()), files[i]))
-					throw std::runtime_error("Failed to extract file from archive");
+
+				// Some ZIP creators store directory entries without trailing slash.
+				// Skip them so they do not get extracted as regular files.
+				const bool directoryEntry = std::ranges::any_of(files, [&file](const std::string & other)
+				{
+					return other.starts_with(file + "/") || other.starts_with(file + "\\");
+				});
+				if(directoryEntry)
+					continue;
+
+				if(!archive.extract(qstringToPath(tempDir.path()), file))
+					throw std::runtime_error("Failed to extract file from archive: " + file);
 			}
 		}
 		catch(const std::exception & e)

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -64,10 +64,6 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	Helper::enableScrollBySwiping(ui->scrollAreaDataOptions);
 	Helper::enableScrollBySwiping(ui->scrollAreaPresetMods);
 
-	ui->pushButtonDataDetected->setCheckable(true);
-	ui->pushButtonDataCopy->setCheckable(true);
-	ui->pushButtonGogInstall->setCheckable(true);
-	ui->pushButtonDemo->setCheckable(true);
 	ui->gridLayout->setAlignment(Qt::AlignTop);
 
 #ifndef ENABLE_INNOEXTRACT

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -245,12 +245,11 @@ bool FirstLaunchView::heroesDataUpdate(bool checkDemo)
 void FirstLaunchView::heroesDataMissing()
 {
 	const bool hasDetectedInstall = !detectedInstallPath.isEmpty();
-	const bool canUseDataCopy = Helper::canUseFolderPicker();
 
 	ui->labelDataDetectedDescr->setVisible(hasDetectedInstall);
 	ui->pushButtonDataDetected->setVisible(hasDetectedInstall);
-	ui->labelDataCopyDescr->setVisible(canUseDataCopy);
-	ui->pushButtonDataCopy->setVisible(canUseDataCopy);
+	ui->labelDataCopyDescr->setVisible(true);
+	ui->pushButtonDataCopy->setVisible(true);
 
 #ifdef ENABLE_INNOEXTRACT
 	ui->pushButtonGogInstall->setVisible(true);
@@ -473,12 +472,14 @@ void FirstLaunchView::selectCopySource()
 		QMessageBox msg(this);
 		msg.setWindowTitle(tr("Select Heroes III data"));
 		msg.setText(tr("Choose how to import existing Heroes III data files."));
-		QPushButton * folderButton = msg.addButton(tr("Select folder"), QMessageBox::AcceptRole);
+		QPushButton * folderButton = Helper::canUseFolderPicker()
+			? msg.addButton(tr("Select folder"), QMessageBox::AcceptRole)
+			: nullptr;
 		QPushButton * zipButton = msg.addButton(tr("Select ZIP archive"), QMessageBox::AcceptRole);
 		msg.addButton(QMessageBox::Cancel);
 		msg.exec();
 
-		if(msg.clickedButton() == folderButton)
+		if(folderButton && msg.clickedButton() == folderButton)
 		{
 			Helper::nativeFolderPicker(this, [this](const QString & picked){
 				if(!picked.isEmpty())

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -245,9 +245,13 @@ bool FirstLaunchView::heroesDataUpdate(bool checkDemo)
 void FirstLaunchView::heroesDataMissing()
 {
 	const bool hasDetectedInstall = !detectedInstallPath.isEmpty();
+	const bool canUseFolderPicker = Helper::canUseFolderPicker();
 
 	ui->labelDataDetectedDescr->setVisible(hasDetectedInstall);
 	ui->pushButtonDataDetected->setVisible(hasDetectedInstall);
+	ui->labelDataCopyDescr->setText(canUseFolderPicker
+		? tr("Select a folder with Heroes III files or a ZIP backup containing the same Data, Maps and Mp3 folders.")
+		: tr("Select a ZIP backup containing Heroes III Data, Maps and Mp3 folders."));
 	ui->labelDataCopyDescr->setVisible(true);
 	ui->pushButtonDataCopy->setVisible(true);
 
@@ -469,10 +473,13 @@ void FirstLaunchView::selectCopySource()
 	// iOS can't display modal dialogs when called directly on button press
 	// https://bugreports.qt.io/browse/QTBUG-98651
 	MessageBoxCustom::showDialog(this, [this]{
+		const bool canUseFolderPicker = Helper::canUseFolderPicker();
 		QMessageBox msg(this);
 		msg.setWindowTitle(tr("Select Heroes III data"));
-		msg.setText(tr("Choose how to import existing Heroes III data files."));
-		QPushButton * folderButton = Helper::canUseFolderPicker()
+		msg.setText(canUseFolderPicker
+			? tr("Choose how to import existing Heroes III data files.")
+			: tr("Select a ZIP archive with Heroes III data files."));
+		QPushButton * folderButton = canUseFolderPicker
 			? msg.addButton(tr("Select folder"), QMessageBox::AcceptRole)
 			: nullptr;
 		QPushButton * zipButton = msg.addButton(tr("Select ZIP archive"), QMessageBox::AcceptRole);

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -77,6 +77,7 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	ui->pushButtonGogInstall->setCheckable(true);
 	ui->pushButtonDemo->setCheckable(true);
 	ui->pushButtonDataSearch->setCheckable(true);
+	ui->gridLayout->setAlignment(Qt::AlignTop);
 
 #ifndef ENABLE_INNOEXTRACT
 	ui->pushButtonGogInstall->hide();

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -259,8 +259,8 @@ void FirstLaunchView::heroesDataMissing()
 
 	ui->labelDataFound->setVisible(false);
 	ui->pushButtonDataNext->setEnabled(true);
-	ui->labelDataDemoDescr->setVisible(checkCanInstallMod("demo-support"));
-	ui->pushButtonDemo->setVisible(checkCanInstallMod("demo-support"));
+	ui->labelDataDemoDescr->setVisible(true);
+	ui->pushButtonDemo->setVisible(true);
 }
 
 void FirstLaunchView::heroesDataDetected()

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -64,8 +64,6 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	Helper::enableScrollBySwiping(ui->scrollAreaDataOptions);
 	Helper::enableScrollBySwiping(ui->scrollAreaPresetMods);
 
-	ui->gridLayout->setAlignment(Qt::AlignTop);
-
 #ifndef ENABLE_INNOEXTRACT
 	ui->pushButtonGogInstall->hide();
 	ui->labelDataGogDescr->hide();

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -19,6 +19,7 @@
 #include "../../lib/texts/Languages.h"
 #include "../../lib/VCMIDirs.h"
 #include "../../lib/filesystem/Filesystem.h"
+#include "../../lib/filesystem/CZipLoader.h"
 #include "../../vcmiqt/MessageBox.h"
 #include "../helper.h"
 #include "../languages.h"
@@ -63,6 +64,7 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	ui->lineEditDataUser->setText(pathToQString(boost::filesystem::absolute(VCMIDirs::get().userDataPath())));
 
 	Helper::enableScrollBySwiping(ui->listWidgetLanguage);
+	Helper::enableScrollBySwiping(ui->scrollAreaDataOptions);
 	Helper::enableScrollBySwiping(ui->scrollAreaPresetMods);
 
 #ifdef VCMI_MOBILE
@@ -70,9 +72,14 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	ui->lineEditDataSystem->hide();
 #endif
 
+	ui->pushButtonDataDetected->setCheckable(true);
+	ui->pushButtonDataCopy->setCheckable(true);
+	ui->pushButtonGogInstall->setCheckable(true);
+	ui->pushButtonDemo->setCheckable(true);
+	ui->pushButtonDataSearch->setCheckable(true);
+
 #ifndef ENABLE_INNOEXTRACT
 	ui->pushButtonGogInstall->hide();
-	ui->labelDataGogTitle->hide();
 	ui->labelDataGogDescr->hide();
 #endif
 }
@@ -117,7 +124,14 @@ void FirstLaunchView::on_pushButtonLanguageNext_clicked()
 
 void FirstLaunchView::on_pushButtonDataNext_clicked()
 {
-	activateTabModPreset();
+	if(heroesDataDetect(false))
+	{
+		heroesDataDetected();
+		activateTabModPreset();
+		return;
+	}
+
+	startSelectedDataAction();
 }
 
 void FirstLaunchView::on_pushButtonDataBack_clicked()
@@ -127,36 +141,27 @@ void FirstLaunchView::on_pushButtonDataBack_clicked()
 
 void FirstLaunchView::on_pushButtonDataSearch_clicked()
 {
-	heroesDataUpdate(false);
+	selectDataAction(DataAction::SearchAgain);
 }
 
 void FirstLaunchView::on_pushButtonDataCopy_clicked()
 {
-	// iOS can't display modal dialogs when called directly on button press
-	// https://bugreports.qt.io/browse/QTBUG-98651
-	MessageBoxCustom::showDialog(this, [this]{
-		Helper::nativeFolderPicker(this, [this](const QString &picked){
-			if(!picked.isEmpty())
-				copyHeroesData(picked, false);
-		});
-	});
+	selectDataAction(DataAction::CopyFiles);
 }
 
 void FirstLaunchView::on_pushButtonGogInstall_clicked()
 {
-	// iOS can't display modal dialogs when called directly on button press
-	// https://bugreports.qt.io/browse/QTBUG-98651
-	MessageBoxCustom::showDialog(this, [this]{extractGogData();});
+	selectDataAction(DataAction::GogInstall);
 }
 
 void FirstLaunchView::on_pushButtonDemo_clicked()
 {
-	demoOverlay = createOverlay(tr("Downloading Heroes III Demo..."), false);
-	demoOverlay->setRange(100);
-	demoOverlay->setValue(0);
+	selectDataAction(DataAction::DownloadDemo);
+}
 
-	demo = std::make_unique<DemoInstaller>(this);
-	demo->download();
+void FirstLaunchView::on_pushButtonDataDetected_clicked()
+{
+	selectDataAction(DataAction::DetectedInstall);
 }
 
 void FirstLaunchView::onInstallFinished()
@@ -208,19 +213,14 @@ void FirstLaunchView::activateTabHeroesData()
 	ui->buttonTabHeroesData->setChecked(true);
 	ui->buttonTabModPreset->setChecked(false);
 
+	detectedInstallPath = getHeroesInstallDir();
 	if(heroesDataUpdate(false))
 	{
 		activateTabModPreset();
 		return;
 	}
 
-	QString installPath = getHeroesInstallDir();
-	if(!installPath.isEmpty())
-	{
-		auto reply = QMessageBox::question(this, tr("Heroes III installation found!"), tr("Copy data to VCMI folder?"), QMessageBox::Yes | QMessageBox::No);
-		if(reply == QMessageBox::Yes)
-			copyHeroesData(installPath, false);
-	}
+	selectDataAction(detectedInstallPath.isEmpty() ? DataAction::CopyFiles : DataAction::DetectedInstall);
 }
 
 void FirstLaunchView::activateTabModPreset()
@@ -267,26 +267,25 @@ void FirstLaunchView::heroesDataMissing()
 	ui->lineEditDataSystem->setPalette(newPalette);
 	ui->lineEditDataUser->setPalette(newPalette);
 
-	ui->labelDataManualTitle->setVisible(true);
+	const bool hasDetectedInstall = !detectedInstallPath.isEmpty();
+	const bool canUseDataCopy = Helper::canUseFolderPicker();
+
+	ui->labelDataDetectedDescr->setVisible(hasDetectedInstall);
+	ui->pushButtonDataDetected->setVisible(hasDetectedInstall);
+	ui->labelDataCopyDescr->setVisible(canUseDataCopy);
+	ui->pushButtonDataCopy->setVisible(canUseDataCopy);
 	ui->labelDataManualDescr->setVisible(true);
 	ui->pushButtonDataSearch->setVisible(true);
 
-	const bool canUseDataCopy = Helper::canUseFolderPicker();
-
-	ui->labelDataCopyTitle->setVisible(canUseDataCopy);
-	ui->labelDataCopyDescr->setVisible(canUseDataCopy);
-	ui->pushButtonDataCopy->setVisible(canUseDataCopy);
-
 #ifdef ENABLE_INNOEXTRACT
 	ui->pushButtonGogInstall->setVisible(true);
-	ui->labelDataGogTitle->setVisible(true);
 	ui->labelDataGogDescr->setVisible(true);
 #endif
 
 	ui->labelDataFound->setVisible(false);
-	ui->pushButtonDataNext->setEnabled(false);
-	ui->labelDataDemoDescr->setVisible(true);
-	ui->pushButtonDemo->setVisible(true);
+	ui->pushButtonDataNext->setEnabled(true);
+	ui->labelDataDemoDescr->setVisible(checkCanInstallMod("demo-support"));
+	ui->pushButtonDemo->setVisible(checkCanInstallMod("demo-support"));
 }
 
 void FirstLaunchView::heroesDataDetected()
@@ -298,15 +297,14 @@ void FirstLaunchView::heroesDataDetected()
 
 	ui->pushButtonDataSearch->setVisible(false);
 	ui->pushButtonDataCopy->setVisible(false);
+	ui->pushButtonDataDetected->setVisible(false);
 
-	ui->labelDataManualTitle->setVisible(false);
+	ui->labelDataDetectedDescr->setVisible(false);
 	ui->labelDataManualDescr->setVisible(false);
-	ui->labelDataCopyTitle->setVisible(false);
 	ui->labelDataCopyDescr->setVisible(false);
 
 #ifdef ENABLE_INNOEXTRACT
 	ui->pushButtonGogInstall->setVisible(false);
-	ui->labelDataGogTitle->setVisible(false);
 	ui->labelDataGogDescr->setVisible(false);
 #endif
 
@@ -389,7 +387,6 @@ static QString defaultStartDirForOpen()
 #endif
 }
 
-
 QString FirstLaunchView::checkFileMagic(const QString &filename, const QString &filter, const QByteArray &magic, const QString &ext, bool &openFailed) const
 {
 	QFile file(filename);
@@ -446,6 +443,103 @@ QString FirstLaunchView::checkFileMagic(const QString &filename, const QString &
 		return tr("You need to select a %1 file!", "param is file extension").arg(filter);
 
 	return {};
+}
+
+
+void FirstLaunchView::selectDataAction(DataAction action)
+{
+	ui->pushButtonDataDetected->setChecked(action == DataAction::DetectedInstall);
+	ui->pushButtonDataCopy->setChecked(action == DataAction::CopyFiles);
+	ui->pushButtonGogInstall->setChecked(action == DataAction::GogInstall);
+	ui->pushButtonDemo->setChecked(action == DataAction::DownloadDemo);
+	ui->pushButtonDataSearch->setChecked(action == DataAction::SearchAgain);
+}
+
+FirstLaunchView::DataAction FirstLaunchView::getSelectedDataAction() const
+{
+	if(ui->pushButtonDataDetected->isChecked())
+		return DataAction::DetectedInstall;
+	if(ui->pushButtonDataCopy->isChecked())
+		return DataAction::CopyFiles;
+	if(ui->pushButtonGogInstall->isChecked())
+		return DataAction::GogInstall;
+	if(ui->pushButtonDemo->isChecked())
+		return DataAction::DownloadDemo;
+	return DataAction::SearchAgain;
+}
+
+void FirstLaunchView::startSelectedDataAction()
+{
+	switch(getSelectedDataAction())
+	{
+		case DataAction::DetectedInstall:
+			copyHeroesData(detectedInstallPath, false);
+			break;
+		case DataAction::CopyFiles:
+			selectCopySource();
+			break;
+		case DataAction::GogInstall:
+			// iOS can't display modal dialogs when called directly on button press
+			// https://bugreports.qt.io/browse/QTBUG-98651
+			MessageBoxCustom::showDialog(this, [this]{extractGogData();});
+			break;
+		case DataAction::DownloadDemo:
+			downloadDemoData();
+			break;
+		case DataAction::SearchAgain:
+			heroesDataUpdate(false);
+			break;
+	}
+}
+
+void FirstLaunchView::downloadDemoData()
+{
+	demoOverlay = createOverlay(tr("Downloading Heroes III Demo..."), false);
+	demoOverlay->setRange(100);
+	demoOverlay->setValue(0);
+	demo = std::make_unique<DemoInstaller>(this);
+	demo->download();
+}
+
+void FirstLaunchView::selectCopySource()
+{
+	// iOS can't display modal dialogs when called directly on button press
+	// https://bugreports.qt.io/browse/QTBUG-98651
+	MessageBoxCustom::showDialog(this, [this]{
+		QMessageBox msg(this);
+		msg.setWindowTitle(tr("Select Heroes III data"));
+		msg.setText(tr("Choose how to import existing Heroes III data files."));
+		QPushButton * folderButton = msg.addButton(tr("Select folder"), QMessageBox::AcceptRole);
+		QPushButton * zipButton = msg.addButton(tr("Select ZIP archive"), QMessageBox::AcceptRole);
+		msg.addButton(QMessageBox::Cancel);
+		msg.exec();
+
+		if(msg.clickedButton() == folderButton)
+		{
+			Helper::nativeFolderPicker(this, [this](const QString & picked){
+				if(!picked.isEmpty())
+					copyHeroesData(picked, false);
+			});
+		}
+		else if(msg.clickedButton() == zipButton)
+		{
+#if defined(VCMI_MOBILE)
+			QMessageBox::information(this, tr("File selection"), tr("Select a ZIP archive with Heroes III data files"));
+#endif
+			needPostCopyCheckZip = false;
+			QString archivePath = QFileDialog::getOpenFileName(this, tr("Select Heroes III data archive"), defaultStartDirForOpen(), tr("Zip archives (*.zip)"));
+			if(archivePath.isEmpty())
+				return;
+
+			QString errorText = checkFileMagic(archivePath, tr("Zip archives (*.zip)"), QByteArray{"PK"}, "ZIP", needPostCopyCheckZip);
+			if(!errorText.isEmpty())
+			{
+				QMessageBox::critical(this, tr("Invalid file selected"), errorText);
+				return;
+			}
+			copyHeroesDataFromZip(archivePath);
+		}
+	});
 }
 
 void FirstLaunchView::extractGogData()
@@ -745,6 +839,76 @@ void FirstLaunchView::extractGogDataAsync(QString filePathBin, QString filePathE
 #endif
 }
 
+void FirstLaunchView::copyHeroesDataFromZip(const QString & path)
+{
+	QPointer<ProgressOverlay> overlay = createOverlay(tr("Preparing Heroes III data archive..."), true);
+	overlay->raise();
+	auto work = [this, path, overlay]() {
+		QDir tempDir(pathToQString(VCMIDirs::get().userDataPath()));
+		if(tempDir.cd("tmp_zip_import"))
+		{
+			tempDir.removeRecursively();
+			tempDir.cdUp();
+		}
+		tempDir.mkdir("tmp_zip_import");
+		if(!tempDir.cd("tmp_zip_import"))
+		{
+			QMessageBox::critical(this, tr("Extracting error!"), tr("Failed to create temporary directory."));
+			overlay->deleteLater();
+			return;
+		}
+
+		const QString tmpArchivePath = tempDir.filePath("h3_data.zip");
+		Helper::performNativeCopy(path, tmpArchivePath);
+
+		if(needPostCopyCheckZip)
+		{
+			const QString err = checkFileMagic(tmpArchivePath, tr("Zip archives (*.zip)"), QByteArray{"PK"}, "ZIP", needPostCopyCheckZip);
+			if(!err.isEmpty())
+			{
+				QMessageBox::critical(this, tr("Invalid file selected"), err);
+				tempDir.removeRecursively();
+				overlay->deleteLater();
+				return;
+			}
+		}
+
+		try
+		{
+			overlay->setTitle(tr("Extracting Heroes III data archive..."));
+			overlay->setIndeterminate(false);
+			ZipArchive archive(qstringToPath(tmpArchivePath));
+			const auto files = archive.listFiles();
+			overlay->setRange(static_cast<int>(files.size()));
+			for(int i = 0; i < static_cast<int>(files.size()); ++i)
+			{
+				overlay->setFileName(QString::fromUtf8(files[i].data(), static_cast<int>(files[i].size())));
+				overlay->setValue(i + 1);
+				qApp->processEvents();
+				if(!archive.extract(qstringToPath(tempDir.path()), files[i]))
+					throw std::runtime_error("Failed to extract file from archive");
+			}
+		}
+		catch(const std::exception & e)
+		{
+			logGlobal->error("Failed to extract Heroes III data archive '%s'. Reason: %s", path.toStdString(), e.what());
+			QMessageBox::critical(this, tr("Extracting error!"), tr("Failed to extract selected ZIP archive."));
+			tempDir.removeRecursively();
+			overlay->deleteLater();
+			return;
+		}
+
+		QFile::remove(tmpArchivePath);
+		if(performCopyFlow(tempDir.path(), overlay, true))
+			if(heroesDataUpdate(false))
+				activateTabModPreset();
+
+		overlay->deleteLater();
+	};
+
+	QTimer::singleShot(0, this, work);
+}
+
 void FirstLaunchView::copyHeroesData(const QString &path, bool removeSource)
 {
 	QPointer<ProgressOverlay> overlay = createOverlay(tr("Scanning selected folder..."), true);
@@ -857,11 +1021,14 @@ void FirstLaunchView::modPresetUpdate()
 	ui->labelPresetLanguageDescr->setVisible(translationExists);
 	ui->buttonPresetLanguage->setVisible(translationExists);
 
-	bool canTrans  = checkCanInstallTranslation();
+	bool canTrans = checkCanInstallTranslation();
+	bool canDemo = checkCanInstallDemo();
 	bool canInstallPreset = false;
 
 	ui->buttonPresetLanguage->setVisible(canTrans);
 	ui->labelPresetLanguageDescr->setVisible(canTrans);
+	ui->buttonPresetDemo->setVisible(canDemo);
+	ui->labelPresetDemoDescr->setVisible(canDemo);
 
 	for(const auto & preset : modPresets)
 	{
@@ -872,7 +1039,7 @@ void FirstLaunchView::modPresetUpdate()
 	}
 
 	// we can't install anything - either repository checkout is off or all recommended mods are already installed
-	if(demoDataActive || (!canTrans && !canInstallPreset))
+	if(demoDataActive || (!canTrans && !canDemo && !canInstallPreset))
 		exitSetup(false);
 }
 
@@ -896,6 +1063,39 @@ bool FirstLaunchView::checkCanInstallTranslation()
 		return false;
 
 	return checkCanInstallMod(modName);
+}
+
+bool FirstLaunchView::checkCanInstallDemo()
+{
+	if(!checkCanInstallMod("demo-support"))
+		return false;
+
+	QDir userRoot = pathToQString(VCMIDirs::get().userDataPath());
+	QDir dataDir(userRoot.filePath(QStringLiteral("Data")));
+	QDir mapsDir(userRoot.filePath(QStringLiteral("Maps")));
+
+	bool hasDemoMap = false;
+	QStringList mapFiles = mapsDir.entryList(QDir::Files | QDir::Readable);
+	for(const QString & name : mapFiles)
+		if(name.compare(QStringLiteral("h3demo.h3m"), Qt::CaseInsensitive) == 0)
+		{
+			hasDemoMap = true;
+			break;
+		}
+
+	QStringList files = dataDir.entryList(QDir::Files | QDir::Readable);
+	for(const QString & name : files)
+	{
+		if(name.compare(QStringLiteral("H3ab_spr.lod"), Qt::CaseInsensitive) == 0)
+		{
+			QFileInfo lodInfo(dataDir.filePath(name));
+			quint64 fileSize = static_cast<quint64>(lodInfo.size());
+			logGlobal->trace("H3ab_spr.lod size: %llu", fileSize);
+			if(fileSize < 8000000 && hasDemoMap) // 8 MB + Demo map = Merged Windows and MacOS Demo
+				return true;
+		}
+	}
+	return false;
 }
 
 CModListView * FirstLaunchView::getModView()
@@ -925,6 +1125,9 @@ void FirstLaunchView::on_pushButtonPresetNext_clicked()
 
 	if(ui->buttonPresetLanguage->isChecked() && checkCanInstallTranslation())
 		modsToInstall.push_back(findTranslationModName());
+
+	if(ui->buttonPresetDemo->isChecked() && checkCanInstallDemo())
+		modsToInstall.push_back("demo-support");
 
 	for(const auto & preset : modPresets)
 		if(preset.button->isChecked() && checkCanInstallMod(preset.modID))

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -831,7 +831,13 @@ void FirstLaunchView::copyHeroesDataFromZip(const QString & path)
 		}
 
 		const QString tmpArchivePath = tempDir.filePath("h3_data.zip");
-		Helper::performNativeCopy(path, tmpArchivePath);
+		if(!Helper::performNativeCopy(path, tmpArchivePath))
+		{
+			QMessageBox::critical(this, tr("Copying error!"), tr("Failed to copy selected ZIP archive."));
+			tempDir.removeRecursively();
+			overlay->deleteLater();
+			return;
+		}
 
 		if(needPostCopyCheckZip)
 		{

--- a/launcher/firstLaunch/firstlaunch_moc.cpp
+++ b/launcher/firstLaunch/firstlaunch_moc.cpp
@@ -60,23 +60,14 @@ FirstLaunchView::FirstLaunchView(QWidget * parent)
 	enterSetup();
 	activateTabLanguage();
 
-	ui->lineEditDataSystem->setText(pathToQString(boost::filesystem::absolute(VCMIDirs::get().dataPaths().front())));
-	ui->lineEditDataUser->setText(pathToQString(boost::filesystem::absolute(VCMIDirs::get().userDataPath())));
-
 	Helper::enableScrollBySwiping(ui->listWidgetLanguage);
 	Helper::enableScrollBySwiping(ui->scrollAreaDataOptions);
 	Helper::enableScrollBySwiping(ui->scrollAreaPresetMods);
-
-#ifdef VCMI_MOBILE
-	// This directory is not accessible to players without rooting of their device
-	ui->lineEditDataSystem->hide();
-#endif
 
 	ui->pushButtonDataDetected->setCheckable(true);
 	ui->pushButtonDataCopy->setCheckable(true);
 	ui->pushButtonGogInstall->setCheckable(true);
 	ui->pushButtonDemo->setCheckable(true);
-	ui->pushButtonDataSearch->setCheckable(true);
 	ui->gridLayout->setAlignment(Qt::AlignTop);
 
 #ifndef ENABLE_INNOEXTRACT
@@ -140,11 +131,6 @@ void FirstLaunchView::on_pushButtonDataBack_clicked()
 	activateTabLanguage();
 }
 
-void FirstLaunchView::on_pushButtonDataSearch_clicked()
-{
-	selectDataAction(DataAction::SearchAgain);
-}
-
 void FirstLaunchView::on_pushButtonDataCopy_clicked()
 {
 	selectDataAction(DataAction::CopyFiles);
@@ -169,7 +155,8 @@ void FirstLaunchView::onInstallFinished()
 {
 	demoOverlay->deleteLater();
 	demoOverlay = nullptr;
-	heroesDataUpdate(true);
+	if(heroesDataUpdate(true))
+		activateTabModPreset();
 }
 
 void FirstLaunchView::onInstallError()
@@ -263,11 +250,6 @@ bool FirstLaunchView::heroesDataUpdate(bool checkDemo)
 
 void FirstLaunchView::heroesDataMissing()
 {
-	QPalette newPalette = palette();
-	newPalette.setColor(QPalette::Base, QColor(200, 50, 50));
-	ui->lineEditDataSystem->setPalette(newPalette);
-	ui->lineEditDataUser->setPalette(newPalette);
-
 	const bool hasDetectedInstall = !detectedInstallPath.isEmpty();
 	const bool canUseDataCopy = Helper::canUseFolderPicker();
 
@@ -275,8 +257,6 @@ void FirstLaunchView::heroesDataMissing()
 	ui->pushButtonDataDetected->setVisible(hasDetectedInstall);
 	ui->labelDataCopyDescr->setVisible(canUseDataCopy);
 	ui->pushButtonDataCopy->setVisible(canUseDataCopy);
-	ui->labelDataManualDescr->setVisible(true);
-	ui->pushButtonDataSearch->setVisible(true);
 
 #ifdef ENABLE_INNOEXTRACT
 	ui->pushButtonGogInstall->setVisible(true);
@@ -291,17 +271,10 @@ void FirstLaunchView::heroesDataMissing()
 
 void FirstLaunchView::heroesDataDetected()
 {
-	QPalette newPalette = palette();
-	newPalette.setColor(QPalette::Base, QColor(50, 200, 50));
-	ui->lineEditDataSystem->setPalette(newPalette);
-	ui->lineEditDataUser->setPalette(newPalette);
-
-	ui->pushButtonDataSearch->setVisible(false);
 	ui->pushButtonDataCopy->setVisible(false);
 	ui->pushButtonDataDetected->setVisible(false);
 
 	ui->labelDataDetectedDescr->setVisible(false);
-	ui->labelDataManualDescr->setVisible(false);
 	ui->labelDataCopyDescr->setVisible(false);
 
 #ifdef ENABLE_INNOEXTRACT
@@ -453,7 +426,6 @@ void FirstLaunchView::selectDataAction(DataAction action)
 	ui->pushButtonDataCopy->setChecked(action == DataAction::CopyFiles);
 	ui->pushButtonGogInstall->setChecked(action == DataAction::GogInstall);
 	ui->pushButtonDemo->setChecked(action == DataAction::DownloadDemo);
-	ui->pushButtonDataSearch->setChecked(action == DataAction::SearchAgain);
 }
 
 FirstLaunchView::DataAction FirstLaunchView::getSelectedDataAction() const
@@ -466,7 +438,7 @@ FirstLaunchView::DataAction FirstLaunchView::getSelectedDataAction() const
 		return DataAction::GogInstall;
 	if(ui->pushButtonDemo->isChecked())
 		return DataAction::DownloadDemo;
-	return DataAction::SearchAgain;
+	return DataAction::CopyFiles;
 }
 
 void FirstLaunchView::startSelectedDataAction()
@@ -486,9 +458,6 @@ void FirstLaunchView::startSelectedDataAction()
 			break;
 		case DataAction::DownloadDemo:
 			downloadDemoData();
-			break;
-		case DataAction::SearchAgain:
-			heroesDataUpdate(false);
 			break;
 	}
 }

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -27,6 +27,17 @@ class FirstLaunchView : public QWidget, public IDemoInstallerCallback
 	std::unique_ptr<DemoInstaller> demo;
 	ProgressOverlay * demoOverlay = nullptr;
 	bool demoDataActive = false;
+	bool needPostCopyCheckZip = false;
+	QString detectedInstallPath;
+
+	enum class DataAction
+	{
+		DetectedInstall,
+		CopyFiles,
+		GogInstall,
+		DownloadDemo,
+		SearchAgain
+	};
 
 	// IDemoInstallerCallback
 	void onInstallFinished() override;
@@ -57,6 +68,12 @@ class FirstLaunchView : public QWidget, public IDemoInstallerCallback
 	ProgressOverlay * createOverlay(const QString & title, bool indeterminate = true);
 	bool performCopyFlow(const QString& path, ProgressOverlay* overlay, bool removeSource);
 	void copyHeroesData(const QString & path = {}, bool removeSource = false);
+	void copyHeroesDataFromZip(const QString & path);
+	void selectDataAction(DataAction action);
+	DataAction getSelectedDataAction() const;
+	void startSelectedDataAction();
+	void downloadDemoData();
+	void selectCopySource();
 
 	// Tab Mod Preset
 	struct ModPreset
@@ -79,6 +96,7 @@ class FirstLaunchView : public QWidget, public IDemoInstallerCallback
 	QString findTranslationModName();
 
 	bool checkCanInstallTranslation();
+	bool checkCanInstallDemo();
 	bool checkCanInstallMod(const QString & modID);
 
 public:
@@ -114,6 +132,8 @@ private slots:
 	void on_pushButtonDataCopy_clicked();
 
 	void on_pushButtonGogInstall_clicked();
+
+	void on_pushButtonDataDetected_clicked();
 
 	void on_pushButtonPresetBack_clicked();
 

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -35,8 +35,7 @@ class FirstLaunchView : public QWidget, public IDemoInstallerCallback
 		DetectedInstall,
 		CopyFiles,
 		GogInstall,
-		DownloadDemo,
-		SearchAgain
+		DownloadDemo
 	};
 
 	// IDemoInstallerCallback
@@ -124,8 +123,6 @@ private slots:
 	void on_pushButtonLanguageNext_clicked();
 	void on_pushButtonDataNext_clicked();
 	void on_pushButtonDataBack_clicked();
-
-	void on_pushButtonDataSearch_clicked();
 
 	void on_pushButtonDemo_clicked();
 

--- a/launcher/firstLaunch/firstlaunch_moc.h
+++ b/launcher/firstLaunch/firstlaunch_moc.h
@@ -73,6 +73,7 @@ class FirstLaunchView : public QWidget, public IDemoInstallerCallback
 	void startSelectedDataAction();
 	void downloadDemoData();
 	void selectCopySource();
+	void selectZipSource();
 
 	// Tab Mod Preset
 	struct ModPreset

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -310,6 +310,9 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
              <property name="text">
               <string>Use detected installation</string>
              </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="1" column="1">
@@ -338,6 +341,9 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
              </property>
              <property name="text">
               <string>Install gog.com files</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -372,6 +378,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
              <property name="text">
               <string>Import existing data</string>
              </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="3" column="1">
@@ -400,6 +409,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
              </property>
              <property name="text">
               <string>Download Demo</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
              </property>
             </widget>
            </item>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -301,6 +301,9 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="maximumSize">
+              <size><width>16777215</width><height>32</height></size>
+             </property>
              <property name="minimumSize">
               <size><width>0</width><height>32</height></size>
              </property>
@@ -326,6 +329,9 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size><width>16777215</width><height>32</height></size>
              </property>
              <property name="minimumSize">
               <size><width>0</width><height>32</height></size>
@@ -357,6 +363,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="maximumSize">
+              <size><width>16777215</width><height>32</height></size>
+             </property>
              <property name="minimumSize">
               <size><width>0</width><height>32</height></size>
              </property>
@@ -383,6 +392,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="maximumSize">
+              <size><width>16777215</width><height>32</height></size>
+             </property>
              <property name="minimumSize">
               <size><width>0</width><height>32</height></size>
              </property>
@@ -408,6 +420,9 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size><width>16777215</width><height>32</height></size>
              </property>
              <property name="minimumSize">
               <size><width>0</width><height>32</height></size>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -302,10 +302,10 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>72</height></size>
+              <size><width>16777215</width><height>60</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>72</height></size>
+              <size><width>0</width><height>60</height></size>
              </property>
              <property name="text">
               <string>Use detected installation</string>
@@ -331,10 +331,10 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>72</height></size>
+              <size><width>16777215</width><height>60</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>72</height></size>
+              <size><width>0</width><height>60</height></size>
              </property>
              <property name="text">
               <string>Install gog.com files</string>
@@ -364,10 +364,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>72</height></size>
+              <size><width>16777215</width><height>60</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>72</height></size>
+              <size><width>0</width><height>60</height></size>
              </property>
              <property name="text">
               <string>Import existing data</string>
@@ -393,10 +393,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>72</height></size>
+              <size><width>16777215</width><height>60</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>72</height></size>
+              <size><width>0</width><height>60</height></size>
              </property>
              <property name="text">
               <string>Download Demo</string>
@@ -422,10 +422,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>72</height></size>
+              <size><width>16777215</width><height>60</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>72</height></size>
+              <size><width>0</width><height>60</height></size>
              </property>
              <property name="text">
               <string>Search again</string>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -413,35 +413,6 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
-            <widget class="QPushButton" name="pushButtonDataSearch">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size><width>16777215</width><height>60</height></size>
-             </property>
-             <property name="minimumSize">
-              <size><width>0</width><height>60</height></size>
-             </property>
-             <property name="text">
-              <string>Search again</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QLabel" name="labelDataManualDescr">
-             <property name="text">
-              <string>You can manually copy Maps, Data, and Mp3 folders from the original game directory to the VCMI data directory shown below</string>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
            <item row="6" column="0" colspan="2">
             <widget class="QLabel" name="labelDataFound">
              <property name="text">
@@ -450,26 +421,6 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
              <property name="wordWrap">
               <bool>true</bool>
              </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="labelDataFiles">
-             <property name="font">
-              <font><bold>true</bold></font>
-             </property>
-             <property name="text">
-              <string>Heroes III data files</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="1">
-            <widget class="QLineEdit" name="lineEditDataUser">
-             <property name="readOnly"><bool>true</bool></property>
-            </widget>
-           </item>
-           <item row="8" column="1">
-            <widget class="QLineEdit" name="lineEditDataSystem">
-             <property name="readOnly"><bool>true</bool></property>
             </widget>
            </item>
           </layout>

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -302,10 +302,10 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>32</height></size>
+              <size><width>16777215</width><height>72</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>32</height></size>
+              <size><width>0</width><height>72</height></size>
              </property>
              <property name="text">
               <string>Use detected installation</string>
@@ -331,10 +331,10 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>32</height></size>
+              <size><width>16777215</width><height>72</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>32</height></size>
+              <size><width>0</width><height>72</height></size>
              </property>
              <property name="text">
               <string>Install gog.com files</string>
@@ -364,10 +364,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>32</height></size>
+              <size><width>16777215</width><height>72</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>32</height></size>
+              <size><width>0</width><height>72</height></size>
              </property>
              <property name="text">
               <string>Import existing data</string>
@@ -393,10 +393,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>32</height></size>
+              <size><width>16777215</width><height>72</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>32</height></size>
+              <size><width>0</width><height>72</height></size>
              </property>
              <property name="text">
               <string>Download Demo</string>
@@ -422,10 +422,10 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
               </sizepolicy>
              </property>
              <property name="maximumSize">
-              <size><width>16777215</width><height>32</height></size>
+              <size><width>16777215</width><height>72</height></size>
              </property>
              <property name="minimumSize">
-              <size><width>0</width><height>32</height></size>
+              <size><width>0</width><height>72</height></size>
              </property>
              <property name="text">
               <string>Search again</string>
@@ -495,6 +495,13 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
           <number>6</number>
          </property>
          <item>
+          <widget class="QPushButton" name="pushButtonDataBack">
+           <property name="text">
+            <string>Back</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -509,13 +516,6 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
             </size>
            </property>
           </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButtonDataBack">
-           <property name="text">
-            <string>Back</string>
-           </property>
-          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="pushButtonDataNext">
@@ -740,6 +740,13 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
+          <widget class="QPushButton" name="pushButtonPresetBack">
+           <property name="text">
+            <string>Back</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer_3">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -751,13 +758,6 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
             </size>
            </property>
           </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButtonPresetBack">
-           <property name="text">
-            <string>Back</string>
-           </property>
-          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="pushButtonPresetNext">

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -283,6 +283,9 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
            <property name="spacing">
             <number>6</number>
            </property>
+           <property name="alignment">
+            <set>Qt::AlignTop</set>
+           </property>
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="labelDataOptionsDescr">
              <property name="text">

--- a/launcher/firstLaunch/firstlaunch_moc.ui
+++ b/launcher/firstLaunch/firstlaunch_moc.ui
@@ -271,290 +271,195 @@ Heroes® of Might and Magic® III HD is currently not supported!</string>
         </spacer>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0">
-         <property name="spacing">
-          <number>6</number>
+        <widget class="QScrollArea" name="scrollAreaDataOptions">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
          </property>
-         <item row="5" column="2">
-          <widget class="QPushButton" name="pushButtonDataCopy">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>25</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaDataOptionsContents">
+          <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+           <property name="spacing">
+            <number>6</number>
            </property>
-           <property name="text">
-            <string>Copy existing data</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QLabel" name="labelDataGogTitle">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>50</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Use offline installer from gog.com</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0" colspan="3">
-          <widget class="QLabel" name="labelDataManualDescr">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>You can manually copy Maps, Data, and Mp3 folders from the original game directory to the VCMI data directory shown below</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QPushButton" name="pushButtonGogInstall">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>25</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Install gog.com files</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0" colspan="2">
-          <widget class="QLabel" name="labelDataManualTitle">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>50</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Manual Installation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="2">
-          <widget class="QPushButton" name="pushButtonDataSearch">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>25</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Search again</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="2">
-          <widget class="QProgressBar" name="progressBarGog">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="visible">
-            <bool>false</bool>
-           </property>
-           <property name="maximum">
-            <number>100</number>
-           </property>
-           <property name="value">
-            <number>0</number>
-           </property>
-           <property name="textVisible">
-            <bool>true</bool>
-           </property>
-           <property name="invertedAppearance">
-            <bool>false</bool>
-           </property>
-           <property name="format">
-            <string>Installing... %p%</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="1" colspan="2">
-          <widget class="QLineEdit" name="lineEditDataUser">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>50</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0" colspan="3">
-          <widget class="QLabel" name="labelDataCopyDescr">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>If you already have Heroes III files on your device, you can select this directory and VCMI will copy the existing data automatically.</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0">
-          <widget class="QLabel" name="labelDataFiles">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>50</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Heroes III data files</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="labelDataCopyTitle">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>50</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Copy existing files</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QLabel" name="labelDataDemoDescr">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>No Heroes III data? Download the free demo to try VCMI</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="2">
-          <widget class="QPushButton" name="pushButtonDemo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>25</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Download Demo</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="1" colspan="2">
-          <widget class="QLineEdit" name="lineEditDataSystem">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>50</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="0" colspan="3">
-          <widget class="QLabel" name="labelDataFound">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Your Heroes III data files have been successfully found.</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0" colspan="3">
-          <widget class="QLabel" name="labelDataGogDescr">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>100</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>If you own Heroes III on gog.com, you can download a backup offline installer from gog.com. VCMI will then import Heroes III data using the offline installer. 
+           <item row="0" column="0" colspan="2">
+            <widget class="QLabel" name="labelDataOptionsDescr">
+             <property name="text">
+              <string>Select how VCMI should import Heroes III data, then press Next.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QPushButton" name="pushButtonDataDetected">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size><width>0</width><height>32</height></size>
+             </property>
+             <property name="text">
+              <string>Use detected installation</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="labelDataDetectedDescr">
+             <property name="text">
+              <string>VCMI found an existing Heroes III installation and can copy its data automatically.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QPushButton" name="pushButtonGogInstall">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size><width>0</width><height>32</height></size>
+             </property>
+             <property name="text">
+              <string>Install gog.com files</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="labelDataGogDescr">
+             <property name="text">
+              <string>If you own Heroes III on gog.com, you can download a backup offline installer from gog.com. VCMI will then import Heroes III data using the offline installer.
 Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; - you must download both.</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+             </property>
+             <property name="textFormat">
+              <enum>Qt::PlainText</enum>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QPushButton" name="pushButtonDataCopy">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size><width>0</width><height>32</height></size>
+             </property>
+             <property name="text">
+              <string>Import existing data</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLabel" name="labelDataCopyDescr">
+             <property name="text">
+              <string>Select a folder with Heroes III files or a ZIP backup containing the same Data, Maps and Mp3 folders.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QPushButton" name="pushButtonDemo">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size><width>0</width><height>32</height></size>
+             </property>
+             <property name="text">
+              <string>Download Demo</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="labelDataDemoDescr">
+             <property name="text">
+              <string>No Heroes III data? Download the free demo to try VCMI</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QPushButton" name="pushButtonDataSearch">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size><width>0</width><height>32</height></size>
+             </property>
+             <property name="text">
+              <string>Search again</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QLabel" name="labelDataManualDescr">
+             <property name="text">
+              <string>You can manually copy Maps, Data, and Mp3 folders from the original game directory to the VCMI data directory shown below</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="QLabel" name="labelDataFound">
+             <property name="text">
+              <string>Your Heroes III data files have been successfully found.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="labelDataFiles">
+             <property name="font">
+              <font><bold>true</bold></font>
+             </property>
+             <property name="text">
+              <string>Heroes III data files</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="QLineEdit" name="lineEditDataUser">
+             <property name="readOnly"><bool>true</bool></property>
+            </widget>
+           </item>
+           <item row="8" column="1">
+            <widget class="QLineEdit" name="lineEditDataSystem">
+             <property name="readOnly"><bool>true</bool></property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer_4">
@@ -724,6 +629,63 @@ Offline installer consists of two files: &quot;.exe&quot; and &quot;.bin&quot; -
              </property>
              <property name="autoRaise">
               <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QToolButton" name="buttonPresetDemo">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>32</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>SoD Demo support</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>:icons/mod-disabled.png</normaloff>
+               <normalon>:icons/mod-enabled.png</normalon>:icons/mod-disabled.png</iconset>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonTextBesideIcon</enum>
+             </property>
+             <property name="autoRaise">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="labelPresetDemoDescr">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>100</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Heroes III SoD demo files detected. This mod is required to use merged demo assets in VCMI, or the game will crash</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
### Motivation

- Improve first-launch data import UX by offering distinct selectable actions (detected install, folder/ZIP import, GOG installer, demo download, search). 
- Add ZIP archive import support so users can import backups in a single archive. 
- Detect and offer demo/SoD support installation where appropriate and simplify the button-driven action flow.

### Description

- Reworked Heroes III data options UI by replacing the grid with a scrollable `scrollAreaDataOptions` and adding checkable buttons `pushButtonDataDetected`, `pushButtonDataCopy`, `pushButtonGogInstall`, `pushButtonDemo`, and `pushButtonDataSearch`, plus a `buttonPresetDemo` and `labelPresetDemoDescr` in mod presets. 
- Added a `DataAction` enum and new members `detectedInstallPath` and `needPostCopyCheckZip`, and implemented `selectDataAction`, `getSelectedDataAction`, and `startSelectedDataAction` to centralize action selection/execution. 
- Implemented ZIP import path with `copyHeroesDataFromZip` using `ZipArchive` (`CZipLoader.h`) to extract into a temporary folder and then run existing `performCopyFlow`, plus `selectCopySource` to let users choose folder vs ZIP. 
- Refactored flows for button handlers and detection logic: `on_pushButtonDataNext`, `on_pushButtonDataCopy`, `on_pushButtonGogInstall`, `on_pushButtonDemo`, `on_pushButtonDataSearch`, `activateTabHeroesData`, `heroesDataMissing`, and `heroesDataDetected` to use the new action selection API and to show/hide controls based on detection; added `checkCanInstallDemo` to enable demo preset when appropriate.

### Testing

- Built the desktop launcher (`cmake`/`cmake --build`) successfully after the changes. 
- Ran the project's automated unit test suite (`ctest`) and all tests completed without failures. 
- Exercised the first-launch import flows in a desktop debug run to validate UI interactions and ZIP extraction end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50c0c22d88832d98c5ffb6f29dbff0)