### PR TITLE
Expand lobby town selection grid dynamically

### DIFF
--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -451,15 +451,31 @@ OptionsTab::SelectionWindow::SelectionWindow(const PlayerColor & color, SelType 
 	recreate(sliderPos);
 }
 
+int OptionsTab::SelectionWindow::getMaxElementsPerLine(int itemCount) const
+{
+	if(type == SelType::TOWN)
+	{
+		if(itemCount > MIN_ELEM_PER_LINE * MIN_LINES)
+			return std::min(MAX_ELEM_PER_LINE, std::min(MAX_LINES, static_cast<int>(std::ceil(std::sqrt(itemCount)))));
+	}
+
+	return MIN_ELEM_PER_LINE;
+}
+
 std::tuple<int, int> OptionsTab::SelectionWindow::calcLines(FactionID faction)
 {
 	int additionalItems = 1; // random
 
 	if(!faction.isValid())
+	{
+		int itemCount = static_cast<int>(allowedFactions.size()) + additionalItems;
+		int maxElementsPerLine = getMaxElementsPerLine(itemCount);
+
 		return std::make_tuple(
-			std::ceil(((double)allowedFactions.size() + additionalItems) / MAX_ELEM_PER_LINES),
-			(allowedFactions.size() + additionalItems) % MAX_ELEM_PER_LINES
+			std::ceil(static_cast<double>(itemCount) / maxElementsPerLine),
+			itemCount % maxElementsPerLine
 		);
+	}
 
 	int count = 0;
 	for(auto & elemh : allowedHeroes)
@@ -471,9 +487,12 @@ std::tuple<int, int> OptionsTab::SelectionWindow::calcLines(FactionID faction)
 		count++;
 	}
 
+	int itemCount = count + additionalItems;
+	int maxElementsPerLine = getMaxElementsPerLine(itemCount);
+
 	return std::make_tuple(
-		std::ceil(((double)count + additionalItems) / MAX_ELEM_PER_LINES),
-		(count + additionalItems) % MAX_ELEM_PER_LINES
+		std::ceil(static_cast<double>(itemCount) / maxElementsPerLine),
+		itemCount % maxElementsPerLine
 	);
 }
 
@@ -524,14 +543,21 @@ void OptionsTab::SelectionWindow::recreate(int sliderPos)
 	else
 	{
 		std::tie(amountLines, elementsPerLine) = calcLines((type > SelType::TOWN) ? selectedFaction : FactionID::RANDOM);
-		if(amountLines > 1 || elementsPerLine == 0)
-			elementsPerLine = MAX_ELEM_PER_LINES;
+		if(type == SelType::TOWN)
+			elementsPerLine = getMaxElementsPerLine(static_cast<int>(allowedFactions.size()) + 1);
+		else if(amountLines > 1 || elementsPerLine == 0)
+			elementsPerLine = getMaxElementsPerLine(amountLines * MIN_ELEM_PER_LINE);
 	}
 
+	int visibleLines = amountLines;
+	if(type == SelType::TOWN)
+		visibleLines = getMaxElementsPerLine(static_cast<int>(allowedFactions.size()) + 1);
+	else if(type == SelType::HERO)
+		visibleLines = std::min(amountLines, MIN_LINES);
 	int x = (elementsPerLine) * (ICON_BIG_WIDTH-1);
-	int y = (std::min(amountLines, MAX_LINES)) * (ICON_BIG_HEIGHT-1);
+	int y = visibleLines * (ICON_BIG_HEIGHT-1);
 
-	int sliderWidth = ((amountLines > MAX_LINES) ? 16 : 0);
+	int sliderWidth = ((amountLines > visibleLines) ? 16 : 0);
 
 	pos = Rect(pos.x, pos.y, x + sliderWidth, y);
 	backgroundTexture = std::make_shared<FilledTexturePlayerColored>(Rect(0, 0, pos.w - sliderWidth, pos.h));
@@ -544,11 +570,11 @@ void OptionsTab::SelectionWindow::recreate(int sliderPos)
 		genContentHeroes();
 	if(type == SelType::BONUS)
 		genContentBonus();
-	genContentGrid(std::min(amountLines, MAX_LINES));
+	genContentGrid(visibleLines);
 
-	if(!slider && amountLines > MAX_LINES)
+	if(!slider && amountLines > visibleLines)
 	{
-		slider = std::make_shared<CSlider>(Point(x, 0), y, std::bind(&OptionsTab::SelectionWindow::sliderMove, this, _1), MAX_LINES, amountLines, 0, Orientation::VERTICAL, CSlider::BLUE);
+		slider = std::make_shared<CSlider>(Point(x, 0), y, std::bind(&OptionsTab::SelectionWindow::sliderMove, this, _1), visibleLines, amountLines, 0, Orientation::VERTICAL, CSlider::BLUE);
 		slider->setPanningStep(ICON_BIG_HEIGHT);
 		slider->setScrollBounds(Rect(-pos.w + slider->pos.w, 0, x + slider->pos.w, y));
 		slider->scrollTo(sliderPos);
@@ -604,7 +630,7 @@ void OptionsTab::SelectionWindow::genContentFactions()
 		factions.push_back(elem);
 		i++;
 
-		if(y < 0 || y > MAX_LINES - 1)
+		if(y < 0 || y > (pos.h / (ICON_BIG_HEIGHT-1)) - 1)
 			continue;
 			
 		components.push_back(std::make_shared<CAnimImage>(helper.getImageName(true), helper.getImageIndex(true), 0, x * (ICON_BIG_WIDTH-1), y * (ICON_BIG_HEIGHT-1)));
@@ -645,7 +671,7 @@ void OptionsTab::SelectionWindow::genContentHeroes()
 		heroes.push_back(elem);
 		i++;
 
-		if(y < 0 || y > MAX_LINES - 1)
+		if(y < 0 || y > (pos.h / (ICON_BIG_HEIGHT-1)) - 1)
 			continue;
 
 		components.push_back(std::make_shared<CAnimImage>(helper.getImageName(true), helper.getImageIndex(true), 0, x * (ICON_BIG_WIDTH-1), y * (ICON_BIG_HEIGHT-1)));

--- a/client/lobby/OptionsTab.cpp
+++ b/client/lobby/OptionsTab.cpp
@@ -551,7 +551,7 @@ void OptionsTab::SelectionWindow::recreate(int sliderPos)
 
 	int visibleLines = amountLines;
 	if(type == SelType::TOWN)
-		visibleLines = getMaxElementsPerLine(static_cast<int>(allowedFactions.size()) + 1);
+		visibleLines = std::min(amountLines, MAX_LINES);
 	else if(type == SelType::HERO)
 		visibleLines = std::min(amountLines, MIN_LINES);
 	int x = (elementsPerLine) * (ICON_BIG_WIDTH-1);

--- a/client/lobby/OptionsTab.h
+++ b/client/lobby/OptionsTab.h
@@ -122,8 +122,10 @@ private:
 		const int TEXT_POS_X = 29;
 		const int TEXT_POS_Y = 56;
 
-		const int MAX_LINES = 5;
-		const int MAX_ELEM_PER_LINES = 5;
+		const int MIN_LINES = 5;
+		const int MIN_ELEM_PER_LINE = 5;
+		const int MAX_LINES = 7;
+		const int MAX_ELEM_PER_LINE = 7;
 
 		int elementsPerLine;
 
@@ -156,6 +158,7 @@ private:
 		void genContentBonus();
 
 		void drawOutlinedText(int x, int y, ColorRGBA color, std::string text);
+		int getMaxElementsPerLine(int itemCount) const;
 		std::tuple<int, int> calcLines(FactionID faction);
 		void apply();
 		void recreate(int sliderPos = 0);


### PR DESCRIPTION
### Motivation
- Replace the fixed 5x5 town selection grid that immediately shows a scrollbar when more than 25 towns are present with a dynamic layout that can grow to better fit items and delay the scrollbar until necessary.
- Keep minimum layout density and avoid changing hero/bonus selection behaviour while improving UX for town/faction selection in the lobby.

### Description
- Replace the fixed constants with `MIN_LINES`, `MIN_ELEM_PER_LINE`, `MAX_LINES` and `MAX_ELEM_PER_LINE` and add `getMaxElementsPerLine(int)` to compute a dynamic elements-per-line value for town lists based on `itemCount`.
- Update `calcLines` to compute `amountLines` and element counts using the dynamic `getMaxElementsPerLine` instead of the old `MAX_ELEM_PER_LINES` logic.
- Change `recreate` to choose `elementsPerLine` and `visibleLines` dynamically for `SelType::TOWN`, compute window `pos` height from `visibleLines`, and create the `CSlider` only when `amountLines` exceeds the dynamic visible capacity.
- Update `genContentFactions` and `genContentHeroes` clipping to use the actual window height (`pos.h`) for visibility checks instead of the fixed `MAX_LINES` magic number.

### Testing
- Ran `git diff --check` to verify no whitespace or trivial diff problems; the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a582028cb40832da7ff80eb6d9a1904)